### PR TITLE
Support runs nested under sub-folders of runs/

### DIFF
--- a/build_indexes.py
+++ b/build_indexes.py
@@ -45,12 +45,9 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    rebuilt = []
-    if args.runs_dir.is_dir():
-        for run_dir in sorted(p for p in args.runs_dir.iterdir() if p.is_dir()):
-            if (run_dir / "all-matches.html").exists():
-                htmlreport.build_run_index(run_dir)
-                rebuilt.append(run_dir)
+    rebuilt = htmlreport.find_run_dirs(args.runs_dir)
+    for run_dir in rebuilt:
+        htmlreport.build_run_index(run_dir)
 
     htmlreport.write_runs_index(args.runs_dir, args.root_index)
 

--- a/build_indexes_test.py
+++ b/build_indexes_test.py
@@ -55,6 +55,29 @@ class TestBuildIndexes(unittest.TestCase):
         self.assertTrue(self.root_index.exists())
         self.assertIn("2025-26-season", self.root_index.read_text())
 
+    def test_rebuilds_nested_run(self):
+        """A run doesn't need to sit directly under runs_dir -- e.g. several drafts
+        of a season grouped under a season folder -- and should still get its own
+        index.html rebuilt and be linked from the root index."""
+        run_dir = self.runs_dir / "2026-27" / "draft1"
+        run_dir.mkdir(parents=True)
+        (run_dir / "all-matches.html").write_text("<title>All matches</title>")
+
+        with patch(
+            "sys.argv",
+            [
+                "build_indexes.py",
+                "--runs-dir",
+                str(self.runs_dir),
+                "--root-index",
+                str(self.root_index),
+            ],
+        ):
+            build_indexes.main()
+
+        self.assertTrue((run_dir / "index.html").exists())
+        self.assertIn("runs/2026-27/draft1/index.html", self.root_index.read_text())
+
     def test_no_runs_dir(self):
         with patch(
             "sys.argv",

--- a/htmlreport.py
+++ b/htmlreport.py
@@ -23,6 +23,7 @@ third-party dependency.
 
 from __future__ import annotations
 
+import dataclasses
 import html
 import re
 from collections import defaultdict
@@ -52,6 +53,7 @@ _STYLE = """
     a { color: #0645ad; }
     nav ul { list-style: none; padding: 0; }
     nav li { margin-bottom: 0.3rem; }
+    nav ul ul { padding-left: 1.2rem; margin-top: 0.3rem; }
     .venue { margin-top: -0.5rem; margin-bottom: 1.5rem; color: #333; }
     ul.venues { padding-left: 1.2rem; }
     ul.venues li { margin-bottom: 0.3rem; }
@@ -531,25 +533,70 @@ def build_run_index(run_dir: Path) -> Path:
     return index_path
 
 
-def write_runs_index(runs_dir: Path, index_path: Path) -> Path:
-    """(Re)write the top-level index page listing every run under runs_dir that has a report."""
-    run_names = []
-    if runs_dir.is_dir():
-        run_names = sorted(
-            (
-                p.name
-                for p in runs_dir.iterdir()
-                if p.is_dir() and (p / "all-matches.html").exists()
-            ),
-            reverse=True,
-        )
+def find_run_dirs(runs_dir: Path) -> list[Path]:
+    """Every directory anywhere under runs_dir that has its own report (i.e. has an
+    all-matches.html), at any depth -- a run need not sit directly under runs_dir.
+    """
+    if not runs_dir.is_dir():
+        return []
+    return sorted(p.parent for p in runs_dir.rglob("all-matches.html"))
 
-    if run_names:
+
+@dataclasses.dataclass
+class _RunTreeNode:
+    """One level of the folder hierarchy under runs_dir: is_run if this exact path
+    is itself a run (has its own report), plus any child folders (further runs
+    and/or grouping folders) keyed by name."""
+
+    is_run: bool = False
+    children: dict[str, _RunTreeNode] = dataclasses.field(default_factory=dict)
+
+
+def _build_run_tree(run_paths: Collection[Path]) -> _RunTreeNode:
+    root = _RunTreeNode()
+    for run_path in run_paths:
+        node = root
+        for part in run_path.parts:
+            node = node.children.setdefault(part, _RunTreeNode())
+        node.is_run = True
+    return root
+
+
+def _render_run_tree(
+    node: _RunTreeNode, path_parts: tuple[str, ...], rel_runs_dir: Path
+) -> str:
+    """Render node's children as a nested <ul>, most recent (reverse alphabetical)
+    first at each level; a name with no report of its own (just a grouping folder
+    for further runs, e.g. a season with several draft sub-folders) is rendered as
+    a plain label rather than a link."""
+    items = []
+    for name in sorted(node.children, reverse=True):
+        child = node.children[name]
+        child_parts = (*path_parts, name)
+        label = html.escape(name)
+        if child.is_run:
+            href = f"{rel_runs_dir}/{'/'.join(child_parts)}/index.html"
+            label = f'<a href="{href}">{label}</a>'
+        if child.children:
+            label += _render_run_tree(child, child_parts, rel_runs_dir)
+        items.append(f"<li>{label}</li>\n")
+    return f"<ul>\n{''.join(items)}</ul>\n"
+
+
+def write_runs_index(runs_dir: Path, index_path: Path) -> Path:
+    """(Re)write the top-level index page listing every run under runs_dir that has
+    a report, at any depth -- nested to reflect runs_dir's own folder structure
+    (e.g. runs/2026-27/draft1 is listed under a "2026-27" heading)."""
+    run_dirs = find_run_dirs(runs_dir)
+
+    if run_dirs:
         try:
             rel_runs_dir = runs_dir.relative_to(index_path.parent)
         except ValueError:
             rel_runs_dir = runs_dir
-        body = _nav([(f"{rel_runs_dir}/{name}/index.html", name) for name in run_names])
+        run_paths = [d.relative_to(runs_dir) for d in run_dirs]
+        tree = _build_run_tree(run_paths)
+        body = f"<nav>{_render_run_tree(tree, (), rel_runs_dir)}</nav>\n"
     else:
         body = "<p>No runs yet.</p>\n"
 

--- a/htmlreport_test.py
+++ b/htmlreport_test.py
@@ -457,6 +457,61 @@ class TestWriteRunsIndex(unittest.TestCase):
             content.index("2025-26-season"), content.index("2024-25-season")
         )
 
+    def test_nested_run(self):
+        """A run need not sit directly under runs_dir -- e.g. several drafts of the
+        same season grouped under a season folder -- and should still be found and
+        linked correctly, nested under a heading for the grouping folder(s)."""
+        run_dir = self.runs_dir / "2026-27" / "draft1"
+        run_dir.mkdir(parents=True)
+        (run_dir / "all-matches.html").write_text("<html></html>")
+
+        htmlreport.write_runs_index(self.runs_dir, self.index_path)
+        content = self.index_path.read_text()
+
+        self.assertIn("runs/2026-27/draft1/index.html", content)
+        # The grouping folder itself has no report, so isn't a link.
+        self.assertNotIn('<a href="runs/2026-27/index.html"', content)
+        self.assertIn("2026-27", content)
+
+    def test_nested_and_flat_runs_combined(self):
+        (self.runs_dir / "example").mkdir(parents=True)
+        (self.runs_dir / "example" / "all-matches.html").write_text("<html></html>")
+        nested_run_dir = self.runs_dir / "2026-27" / "draft1"
+        nested_run_dir.mkdir(parents=True)
+        (nested_run_dir / "all-matches.html").write_text("<html></html>")
+
+        htmlreport.write_runs_index(self.runs_dir, self.index_path)
+        content = self.index_path.read_text()
+
+        self.assertIn("runs/example/index.html", content)
+        self.assertIn("runs/2026-27/draft1/index.html", content)
+
+
+class TestFindRunDirs(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.runs_dir = Path(self._tmpdir.name) / "runs"
+
+    def test_missing_runs_dir(self):
+        self.assertEqual(htmlreport.find_run_dirs(self.runs_dir), [])
+
+    def test_finds_runs_at_any_depth(self):
+        flat_run = self.runs_dir / "example"
+        flat_run.mkdir(parents=True)
+        (flat_run / "all-matches.html").write_text("<html></html>")
+
+        nested_run = self.runs_dir / "2026-27" / "draft1"
+        nested_run.mkdir(parents=True)
+        (nested_run / "all-matches.html").write_text("<html></html>")
+
+        (self.runs_dir / "incomplete-run").mkdir()
+
+        self.assertCountEqual(
+            htmlreport.find_run_dirs(self.runs_dir), [flat_run, nested_run]
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
A run's spec/solution/report no longer needs to sit directly under runs/ -- e.g. runs/2026-27/draft1/ is now discovered and rebuilt correctly, and the top-level index nests grouping folders (like "2026-27") rather than requiring every run one level deep.

htmlreport.find_run_dirs() replaces the old one-level iterdir() scan with a recursive search for any directory containing all-matches.html, used by both build_indexes.py (to rebuild every run's own index.html) and write_runs_index() (to render the top-level index as a nested list matching runs/'s own folder structure).