### PR TITLE
Support max_concurrent_home_matches: null (unlimited)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,13 @@ club must have its own `max_concurrent_home_matches` entry — there's no
 built-in fallback value. `home_dates` and `unavailable_away_dates` default to
 empty if a club's entry omits them (or the club has no entry at all).
 
+A `max_concurrent_home_matches` value (the plain integer, the `default`, or
+any individual `overrides` entry) can be `null` instead of an integer, to mean
+no limit is imposed by this mechanism on that club/date — e.g. for a club
+whose concurrency is already bounded by another constraint, such as a full
+set of `avoid_coscheduling_teams` pairings across its teams, where restating
+that bound as a number here would be redundant and easy to leave stale.
+
 A club's optional `teams` entry holds per-team overrides/additions to that
 club's own `home_dates`/`unavailable_away_dates`, for clubs whose teams
 don't all share the same availability (e.g. different squads of players) —

--- a/fixturespec.py
+++ b/fixturespec.py
@@ -95,6 +95,12 @@ def _require_bool(value: Any, context: str) -> bool:
     return value
 
 
+def _require_int_or_none(value: Any, context: str) -> int | None:
+    if value is None:
+        return None
+    return _require_int(value, context)
+
+
 def _parse_date(value: Any, context: str) -> date:
     """Coerce a YAML scalar into a date.
 
@@ -248,7 +254,12 @@ def _parse_divisions(
 def _parse_max_concurrent_home_matches_value(
     value: Any, context: str
 ) -> fmodel.MaxConcurrentHomeMatches:
-    if isinstance(value, int) and not isinstance(value, bool):
+    """A club's max_concurrent_home_matches value: either a plain integer, null (no
+    limit from this mechanism -- see fmodel.MaxConcurrentHomeMatches), or a mapping
+    with 'default' (an integer or null) and optionally 'overrides' (a date-keyed
+    mapping of integer-or-null overrides of that default).
+    """
+    if value is None or (isinstance(value, int) and not isinstance(value, bool)):
         return fmodel.MaxConcurrentHomeMatches(default=value)
     if isinstance(value, dict):
         unsupported = value.keys() - {"default", "overrides"}
@@ -256,22 +267,22 @@ def _parse_max_concurrent_home_matches_value(
             raise SpecError(f"{context}: unsupported field(s) {sorted(unsupported)}")
         if "default" not in value:
             raise SpecError(f"{context} missing required field 'default'")
-        default = _require_int(value["default"], f"{context}.default")
+        default = _require_int_or_none(value["default"], f"{context}.default")
 
         overrides_spec = value.get("overrides")
-        overrides: dict[date, int] = {}
+        overrides: dict[date, int | None] = {}
         if overrides_spec is not None:
             if not isinstance(overrides_spec, dict):
                 raise SpecError(f"{context}.overrides must be a mapping")
             for date_key, count in overrides_spec.items():
                 override_date = _parse_date(date_key, f"{context}.overrides")
-                overrides[override_date] = _require_int(
+                overrides[override_date] = _require_int_or_none(
                     count, f"{context}.overrides[{date_key!r}]"
                 )
         return fmodel.MaxConcurrentHomeMatches(default=default, overrides=overrides)
     raise SpecError(
-        f"{context}: expected an integer, or a mapping with 'default' and optionally "
-        f"'overrides', got {value!r}"
+        f"{context}: expected an integer, null (unlimited), or a mapping with "
+        f"'default' and optionally 'overrides', got {value!r}"
     )
 
 

--- a/fixturespec_test.py
+++ b/fixturespec_test.py
@@ -328,6 +328,39 @@ class TestLoadSpec(unittest.TestCase):
             fmodel.MaxConcurrentHomeMatches(default=2, overrides={date(2025, 9, 1): 3}),
         )
 
+    def test_max_concurrent_home_matches_null_shorthand(self):
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    max_concurrent_home_matches: null\n"
+            "  hackney:\n"
+            "    max_concurrent_home_matches: 1\n"
+        )
+        spec = fixturespec.load_spec(path)
+        self.assertEqual(
+            spec.parameters.max_concurrent_home_matches["albany"],
+            fmodel.MaxConcurrentHomeMatches(default=None),
+        )
+
+    def test_max_concurrent_home_matches_null_default_with_override(self):
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    max_concurrent_home_matches:\n"
+            "      default: null\n"
+            "      overrides:\n"
+            "        2025-09-01: 3\n"
+            "  hackney:\n"
+            "    max_concurrent_home_matches: 1\n"
+        )
+        spec = fixturespec.load_spec(path)
+        self.assertEqual(
+            spec.parameters.max_concurrent_home_matches["albany"],
+            fmodel.MaxConcurrentHomeMatches(
+                default=None, overrides={date(2025, 9, 1): 3}
+            ),
+        )
+
     def test_max_concurrent_home_matches_missing_default(self):
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"

--- a/fmodel.py
+++ b/fmodel.py
@@ -71,12 +71,18 @@ class Club:
 
 @dataclasses.dataclass(frozen=True)
 class MaxConcurrentHomeMatches:
-    """A club's home-match concurrency limit: a default, overridable for specific dates."""
+    """A club's home-match concurrency limit: a default, overridable for specific
+    dates. A value of None (for the default or an override) means no limit is
+    imposed by this mechanism -- e.g. for a club whose concurrency is already
+    bounded by another constraint (such as avoid_coscheduling_teams), where adding
+    an explicit number here would just be a redundant, easy-to-forget-to-update
+    restatement of that bound.
+    """
 
-    default: int
-    overrides: Mapping[date, int] = dataclasses.field(default_factory=dict)
+    default: int | None
+    overrides: Mapping[date, int | None] = dataclasses.field(default_factory=dict)
 
-    def for_date(self, d: date) -> int:
+    def for_date(self, d: date) -> int | None:
         return self.overrides.get(d, self.default)
 
 
@@ -142,8 +148,8 @@ class Parameters:
         _check_no_duplicate_home_dates(self.home_dates)
         _check_no_duplicate_home_dates(self.team_home_dates)
 
-    def max_concurrent_home_matches_for(self, club: ClubT, d: date) -> int:
-        """The most home matches `club` may host on date `d`."""
+    def max_concurrent_home_matches_for(self, club: ClubT, d: date) -> int | None:
+        """The most home matches `club` may host on date `d`, or None if unlimited."""
         return self.max_concurrent_home_matches[club].for_date(d)
 
     def home_dates_for(self, team: Team) -> list[date]:
@@ -321,8 +327,10 @@ def solve(params: Parameters) -> Collection[ScheduledFixture]:
 
     for (club, match_date), club_home_date_vars in vars_by_club_home_date.items():
         # Each club can host at most max_concurrent_home_matches matches per date
+        # (None means unlimited: no constraint to add).
         max_matches = params.max_concurrent_home_matches_for(club, match_date)
-        model.add(cp_model.LinearExpr.Sum(club_home_date_vars) <= max_matches)
+        if max_matches is not None:
+            model.add(cp_model.LinearExpr.Sum(club_home_date_vars) <= max_matches)
 
     _add_max_home_dates_used_constraints(
         model, params.max_home_dates_used, vars_by_club_home_date

--- a/model_test.py
+++ b/model_test.py
@@ -804,6 +804,91 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
         )
 
 
+class TestMaxConcurrentHomeMatchesUnlimited(unittest.TestCase):
+    """Test cases for MaxConcurrentHomeMatches(default=None) / overrides=None: no
+    limit imposed by this mechanism, as opposed to a finite one.
+    """
+
+    def test_finite_default_makes_it_infeasible(self):
+        """A has two teams (different divisions, so no direct fixture forces them
+        apart) but only one home date; with a limit of 1, both teams needing to host
+        on that one date is infeasible."""
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        a2 = fmodel.Team(division=2, club="A", index=2)
+        x1 = fmodel.Team(division=1, club="X", index=1)
+        x2 = fmodel.Team(division=2, club="X", index=2)
+        params = fmodel.Parameters(
+            teams=[a1, a2, x1, x2],
+            home_dates={
+                "A": [date(2025, 1, 1)],
+                "X": [date(2025, 3, 1), date(2025, 3, 8)],
+            },
+            unavailable_away_dates={"A": [], "X": []},
+            max_concurrent_home_matches={
+                "A": fmodel.MaxConcurrentHomeMatches(default=1),
+                "X": fmodel.MaxConcurrentHomeMatches(default=2),
+            },
+            min_gap_days=7,
+        )
+        with self.assertRaises(ValueError):
+            fmodel.solve(params)
+
+    def test_none_default_lifts_the_limit(self):
+        """Same setup, but A's default is None -- both A1 and A2 can now host on
+        their one shared date."""
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        a2 = fmodel.Team(division=2, club="A", index=2)
+        x1 = fmodel.Team(division=1, club="X", index=1)
+        x2 = fmodel.Team(division=2, club="X", index=2)
+        params = fmodel.Parameters(
+            teams=[a1, a2, x1, x2],
+            home_dates={
+                "A": [date(2025, 1, 1)],
+                "X": [date(2025, 3, 1), date(2025, 3, 8)],
+            },
+            unavailable_away_dates={"A": [], "X": []},
+            max_concurrent_home_matches={
+                "A": fmodel.MaxConcurrentHomeMatches(default=None),
+                "X": fmodel.MaxConcurrentHomeMatches(default=2),
+            },
+            min_gap_days=7,
+        )
+        fixtures = list(fmodel.solve(params))
+        a1_home_date = next(sf.date for sf in fixtures if sf.fixture.home_team == a1)
+        a2_home_date = next(sf.date for sf in fixtures if sf.fixture.home_team == a2)
+        self.assertEqual(a1_home_date, date(2025, 1, 1))
+        self.assertEqual(a2_home_date, date(2025, 1, 1))
+
+    def test_none_override_lifts_the_limit_for_one_date_only(self):
+        """A's default limit of 1 applies generally, but is overridden to None (no
+        limit) specifically on 2025-01-01 -- so both A1 and A2 can host there, even
+        though a finite default of 1 would otherwise forbid it."""
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        a2 = fmodel.Team(division=2, club="A", index=2)
+        x1 = fmodel.Team(division=1, club="X", index=1)
+        x2 = fmodel.Team(division=2, club="X", index=2)
+        params = fmodel.Parameters(
+            teams=[a1, a2, x1, x2],
+            home_dates={
+                "A": [date(2025, 1, 1)],
+                "X": [date(2025, 3, 1), date(2025, 3, 8)],
+            },
+            unavailable_away_dates={"A": [], "X": []},
+            max_concurrent_home_matches={
+                "A": fmodel.MaxConcurrentHomeMatches(
+                    default=1, overrides={date(2025, 1, 1): None}
+                ),
+                "X": fmodel.MaxConcurrentHomeMatches(default=2),
+            },
+            min_gap_days=7,
+        )
+        fixtures = list(fmodel.solve(params))
+        a1_home_date = next(sf.date for sf in fixtures if sf.fixture.home_team == a1)
+        a2_home_date = next(sf.date for sf in fixtures if sf.fixture.home_team == a2)
+        self.assertEqual(a1_home_date, date(2025, 1, 1))
+        self.assertEqual(a2_home_date, date(2025, 1, 1))
+
+
 class TestDuplicateRejection(unittest.TestCase):
     """Parameters construction relies on each (Fixture, date) pair mapping to at most
     one solver variable; these are the two ways it could otherwise be violated."""


### PR DESCRIPTION
A club's real home-match concurrency limit is sometimes already implied by another constraint (e.g. a full set of avoid_coscheduling_teams pairings across its teams). Forcing max_concurrent_home_matches to some finite number in that case is redundant and easy to leave stale (e.g. if the team count changes). null now means no limit from this mechanism, for the plain shorthand value, a mapping's 'default', or an individual 'overrides' entry.