### PR TITLE
Fix off-by-one in min_gap_days enforcement

### DIFF
--- a/fmodel.py
+++ b/fmodel.py
@@ -323,8 +323,11 @@ def solve(params: Parameters) -> Collection[ScheduledFixture]:
         model.add(cp_model.LinearExpr.Sum(fixture_vars) == 1)
 
     for team_vars_by_date in vars_by_team_date.values():
-        # Each team can play at most one match in each window
-        for window in date_windows(team_vars_by_date.keys(), params.min_gap_days):
+        # Each team can play at most one match in each window. date_windows groups
+        # dates up to and including window_days apart, so pass min_gap_days - 1: a
+        # gap of exactly min_gap_days (e.g. two matches a week apart when
+        # min_gap_days=7) must be allowed, not treated as a violation.
+        for window in date_windows(team_vars_by_date.keys(), params.min_gap_days - 1):
             window_vars = [v for d in window for v in team_vars_by_date[d]]
             model.add(cp_model.LinearExpr.Sum(window_vars) <= 1)
 

--- a/model_test.py
+++ b/model_test.py
@@ -393,6 +393,62 @@ class TestFixedFixtures(unittest.TestCase):
         )
         self.assertNotEqual(reverse.date, date(2025, 1, 1))
 
+    def test_reverse_fixture_exactly_min_gap_days_apart_is_allowed(self):
+        """Regression test: a gap of exactly min_gap_days satisfies a *minimum*
+        gap of min_gap_days, so two fixed fixtures for the same pair of teams
+        that many days apart must be schedulable, not rejected as too close."""
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        a2 = fmodel.Team(division=1, club="A", index=2)
+        fixed = [
+            fmodel.ScheduledFixture(
+                fixture=fmodel.Fixture(home_team=a1, away_team=a2),
+                date=date(2025, 1, 1),
+            ),
+            fmodel.ScheduledFixture(
+                fixture=fmodel.Fixture(home_team=a2, away_team=a1),
+                date=date(2025, 1, 8),
+            ),
+        ]
+        params = fmodel.Parameters(
+            teams=[a1, a2],
+            home_dates={"A": [date(2025, 1, 1), date(2025, 1, 8)]},
+            unavailable_away_dates={"A": []},
+            max_concurrent_home_matches={
+                "A": fmodel.MaxConcurrentHomeMatches(default=None)
+            },
+            min_gap_days=7,
+            fixed_fixtures=fixed,
+        )
+        fixtures = list(fmodel.solve(params))
+        self.assertCountEqual(fixtures, fixed)
+
+    def test_reverse_fixture_one_day_inside_min_gap_days_is_rejected(self):
+        """A gap one day short of min_gap_days must still be rejected."""
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        a2 = fmodel.Team(division=1, club="A", index=2)
+        fixed = [
+            fmodel.ScheduledFixture(
+                fixture=fmodel.Fixture(home_team=a1, away_team=a2),
+                date=date(2025, 1, 1),
+            ),
+            fmodel.ScheduledFixture(
+                fixture=fmodel.Fixture(home_team=a2, away_team=a1),
+                date=date(2025, 1, 7),
+            ),
+        ]
+        params = fmodel.Parameters(
+            teams=[a1, a2],
+            home_dates={"A": [date(2025, 1, 1), date(2025, 1, 7)]},
+            unavailable_away_dates={"A": []},
+            max_concurrent_home_matches={
+                "A": fmodel.MaxConcurrentHomeMatches(default=None)
+            },
+            min_gap_days=7,
+            fixed_fixtures=fixed,
+        )
+        with self.assertRaises(ValueError):
+            fmodel.solve(params)
+
 
 class TestLatestInternalMatchDate(unittest.TestCase):
     """Test cases for the latest_internal_match_date constraint."""


### PR DESCRIPTION
date_windows() groups dates up to and including window_days apart, so passing min_gap_days directly meant a gap of exactly min_gap_days was treated as a violation -- the true enforced minimum was min_gap_days + 1. Pass min_gap_days - 1 instead, so a gap of exactly min_gap_days (e.g. two fixed fixtures a week apart under the default min_gap_days=7) is allowed.