### PR TITLE
Add self-linking anchors to team headings in club reports (closes #29)

### DIFF
--- a/htmlreport.py
+++ b/htmlreport.py
@@ -57,6 +57,9 @@ _STYLE = """
     .venue { margin-top: -0.5rem; margin-bottom: 1.5rem; color: #333; }
     ul.venues { padding-left: 1.2rem; }
     ul.venues li { margin-bottom: 0.3rem; }
+    .anchor-link { margin-left: 0.4rem; font-size: 0.8em; text-decoration: none;
+                    color: #888; }
+    .anchor-link:hover { color: #0645ad; }
 
     @media (max-width: 40rem) {
         body { margin: 1rem; }
@@ -327,6 +330,17 @@ def _excluded_team_rows(
     return rows
 
 
+def _anchored_heading(level: int, text: str, anchor_id: str) -> str:
+    """An <hN> heading with a stable id, plus a small self-link icon next to it so
+    the anchor is discoverable and its URL easy to grab (e.g. to copy or bookmark)."""
+    escaped = html.escape(text)
+    return (
+        f'<h{level} id="{anchor_id}">{escaped} '
+        f'<a class="anchor-link" href="#{anchor_id}" aria-label="Link to {escaped}">'
+        f"\U0001f517</a></h{level}>\n"
+    )
+
+
 def _venue_header(club: fmodel.Club) -> str:
     return (
         f'<p class="venue"><strong>{html.escape(club.home_venue_name)}</strong><br>\n'
@@ -490,7 +504,8 @@ def generate_report(
                 for f in excluded_fixtures
                 if f.home_team == team or f.away_team == team
             ]
-            body += f"<h2>{html.escape(_team_name(team, clubs))}</h2>\n"
+            team_name = _team_name(team, clubs)
+            body += _anchored_heading(2, team_name, slugify(team_name))
             body += f"<h3>Division {team.division}</h3>\n"
             body += _table(
                 _TEAM_MATCH_HEADERS,

--- a/htmlreport_test.py
+++ b/htmlreport_test.py
@@ -185,13 +185,28 @@ class TestGenerateReport(unittest.TestCase):
         harrow_page = (self.output_dir / "club-harrow.html").read_text()
         # 3 distinct fixtures touch Harrow (incl. the Harrow 1 v Harrow 2 derby); the
         # consolidated table must list each exactly once, not twice for the derby.
-        consolidated_table = harrow_page.split("<h2>")[0]
+        consolidated_table = harrow_page.split("<h2")[0]
         self.assertEqual(consolidated_table.count("<tr>"), 4)  # header + 3 fixtures
-        self.assertIn("<h2>Harrow 1</h2>", harrow_page)
-        self.assertIn("<h2>Harrow 2</h2>", harrow_page)
+        self.assertIn('<h2 id="harrow-1">Harrow 1', harrow_page)
+        self.assertIn('<h2 id="harrow-2">Harrow 2', harrow_page)
         # Harrow 1's own table should list all 3 of its fixtures (2 external + the derby)
-        harrow1_section = harrow_page.split("<h2>Harrow 1</h2>")[1].split("<h2>")[0]
+        harrow1_section = harrow_page.split('<h2 id="harrow-1">')[1].split("<h2")[0]
         self.assertEqual(harrow1_section.count("<tr>"), 4)  # header + 3 fixtures
+
+    def test_team_heading_has_stable_anchor_id(self):
+        harrow_page = (self.output_dir / "club-harrow.html").read_text()
+        self.assertIn('<h2 id="harrow-1">', harrow_page)
+        self.assertIn('<h2 id="harrow-2">', harrow_page)
+        willesden_page = (self.output_dir / "club-willesden-brent.html").read_text()
+        # A name_override should be slugified for the anchor, same as everywhere else.
+        self.assertIn('<h2 id="willesden-warriors">', willesden_page)
+
+    def test_team_heading_has_self_link_icon_pointing_at_its_own_anchor(self):
+        harrow_page = (self.output_dir / "club-harrow.html").read_text()
+        self.assertIn(
+            '<a class="anchor-link" href="#harrow-1" aria-label="Link to Harrow 1">',
+            harrow_page,
+        )
 
     def test_club_page_header_shows_venue_name_and_address(self):
         harrow_page = (self.output_dir / "club-harrow.html").read_text()
@@ -375,15 +390,15 @@ class TestExcludedFixturesInReport(unittest.TestCase):
 
     def test_club_page_consolidated_shows_excluded_fixture(self):
         harrow_page = (self.output_dir / "club-harrow.html").read_text()
-        consolidated_table = harrow_page.split("<h2>")[0]
+        consolidated_table = harrow_page.split("<h2")[0]
         self.assertIn("TBC", consolidated_table)
         ealing_page = (self.output_dir / "club-ealing.html").read_text()
-        consolidated_table = ealing_page.split("<h2>")[0]
+        consolidated_table = ealing_page.split("<h2")[0]
         self.assertIn("TBC", consolidated_table)
 
     def test_team_page_shows_excluded_fixture_with_blank_days_since(self):
         harrow_page = (self.output_dir / "club-harrow.html").read_text()
-        harrow2_section = harrow_page.split("<h2>Harrow 2</h2>")[1].split("<h2>")[0]
+        harrow2_section = harrow_page.split('<h2 id="harrow-2">')[1].split("<h2")[0]
         expected_row = (
             "<tr><td><strong>TBC</strong></td><td>Ealing 1</td><td>Home</td>"
             "<td>Harrow Leisure Centre</td><td>19:30</td><td>75+15</td><td></td></tr>"
@@ -392,7 +407,7 @@ class TestExcludedFixturesInReport(unittest.TestCase):
 
     def test_team_not_involved_in_excluded_fixture_unaffected(self):
         harrow_page = (self.output_dir / "club-harrow.html").read_text()
-        harrow1_section = harrow_page.split("<h2>Harrow 1</h2>")[1].split("<h2>")[0]
+        harrow1_section = harrow_page.split('<h2 id="harrow-1">')[1].split("<h2")[0]
         self.assertNotIn("TBC", harrow1_section)
 
     def test_no_excluded_fixtures_by_default(self):

--- a/runs/example/all-matches.html
+++ b/runs/example/all-matches.html
@@ -22,9 +22,13 @@
     a { color: #0645ad; }
     nav ul { list-style: none; padding: 0; }
     nav li { margin-bottom: 0.3rem; }
+    nav ul ul { padding-left: 1.2rem; margin-top: 0.3rem; }
     .venue { margin-top: -0.5rem; margin-bottom: 1.5rem; color: #333; }
     ul.venues { padding-left: 1.2rem; }
     ul.venues li { margin-bottom: 0.3rem; }
+    .anchor-link { margin-left: 0.4rem; font-size: 0.8em; text-decoration: none;
+                    color: #888; }
+    .anchor-link:hover { color: #0645ad; }
 
     @media (max-width: 40rem) {
         body { margin: 1rem; }

--- a/runs/example/club-albany.html
+++ b/runs/example/club-albany.html
@@ -22,9 +22,13 @@
     a { color: #0645ad; }
     nav ul { list-style: none; padding: 0; }
     nav li { margin-bottom: 0.3rem; }
+    nav ul ul { padding-left: 1.2rem; margin-top: 0.3rem; }
     .venue { margin-top: -0.5rem; margin-bottom: 1.5rem; color: #333; }
     ul.venues { padding-left: 1.2rem; }
     ul.venues li { margin-bottom: 0.3rem; }
+    .anchor-link { margin-left: 0.4rem; font-size: 0.8em; text-decoration: none;
+                    color: #888; }
+    .anchor-link:hover { color: #0645ad; }
 
     @media (max-width: 40rem) {
         body { margin: 1rem; }
@@ -58,7 +62,7 @@
 </tbody>
 </table>
 </div>
-<h2>Albany 1</h2>
+<h2 id="albany-1">Albany 1 <a class="anchor-link" href="#albany-1" aria-label="Link to Albany 1">🔗</a></h2>
 <h3>Division 1</h3>
 <div class="table-scroll">
 <table>

--- a/runs/example/club-ealing.html
+++ b/runs/example/club-ealing.html
@@ -22,9 +22,13 @@
     a { color: #0645ad; }
     nav ul { list-style: none; padding: 0; }
     nav li { margin-bottom: 0.3rem; }
+    nav ul ul { padding-left: 1.2rem; margin-top: 0.3rem; }
     .venue { margin-top: -0.5rem; margin-bottom: 1.5rem; color: #333; }
     ul.venues { padding-left: 1.2rem; }
     ul.venues li { margin-bottom: 0.3rem; }
+    .anchor-link { margin-left: 0.4rem; font-size: 0.8em; text-decoration: none;
+                    color: #888; }
+    .anchor-link:hover { color: #0645ad; }
 
     @media (max-width: 40rem) {
         body { margin: 1rem; }
@@ -74,7 +78,7 @@
 </tbody>
 </table>
 </div>
-<h2>Ealing 1</h2>
+<h2 id="ealing-1">Ealing 1 <a class="anchor-link" href="#ealing-1" aria-label="Link to Ealing 1">🔗</a></h2>
 <h3>Division 2</h3>
 <div class="table-scroll">
 <table>
@@ -99,7 +103,7 @@
 </tbody>
 </table>
 </div>
-<h2>Ealing 2</h2>
+<h2 id="ealing-2">Ealing 2 <a class="anchor-link" href="#ealing-2" aria-label="Link to Ealing 2">🔗</a></h2>
 <h3>Division 3</h3>
 <div class="table-scroll">
 <table>

--- a/runs/example/club-hackney.html
+++ b/runs/example/club-hackney.html
@@ -22,9 +22,13 @@
     a { color: #0645ad; }
     nav ul { list-style: none; padding: 0; }
     nav li { margin-bottom: 0.3rem; }
+    nav ul ul { padding-left: 1.2rem; margin-top: 0.3rem; }
     .venue { margin-top: -0.5rem; margin-bottom: 1.5rem; color: #333; }
     ul.venues { padding-left: 1.2rem; }
     ul.venues li { margin-bottom: 0.3rem; }
+    .anchor-link { margin-left: 0.4rem; font-size: 0.8em; text-decoration: none;
+                    color: #888; }
+    .anchor-link:hover { color: #0645ad; }
 
     @media (max-width: 40rem) {
         body { margin: 1rem; }
@@ -72,7 +76,7 @@
 </tbody>
 </table>
 </div>
-<h2>Hackney 1</h2>
+<h2 id="hackney-1">Hackney 1 <a class="anchor-link" href="#hackney-1" aria-label="Link to Hackney 1">🔗</a></h2>
 <h3>Division 1</h3>
 <div class="table-scroll">
 <table>
@@ -95,7 +99,7 @@
 </tbody>
 </table>
 </div>
-<h2>Hackney 2</h2>
+<h2 id="hackney-2">Hackney 2 <a class="anchor-link" href="#hackney-2" aria-label="Link to Hackney 2">🔗</a></h2>
 <h3>Division 3</h3>
 <div class="table-scroll">
 <table>

--- a/runs/example/club-hammersmith.html
+++ b/runs/example/club-hammersmith.html
@@ -22,9 +22,13 @@
     a { color: #0645ad; }
     nav ul { list-style: none; padding: 0; }
     nav li { margin-bottom: 0.3rem; }
+    nav ul ul { padding-left: 1.2rem; margin-top: 0.3rem; }
     .venue { margin-top: -0.5rem; margin-bottom: 1.5rem; color: #333; }
     ul.venues { padding-left: 1.2rem; }
     ul.venues li { margin-bottom: 0.3rem; }
+    .anchor-link { margin-left: 0.4rem; font-size: 0.8em; text-decoration: none;
+                    color: #888; }
+    .anchor-link:hover { color: #0645ad; }
 
     @media (max-width: 40rem) {
         body { margin: 1rem; }
@@ -100,7 +104,7 @@
 </tbody>
 </table>
 </div>
-<h2>Hammersmith 1</h2>
+<h2 id="hammersmith-1">Hammersmith 1 <a class="anchor-link" href="#hammersmith-1" aria-label="Link to Hammersmith 1">🔗</a></h2>
 <h3>Division 1</h3>
 <div class="table-scroll">
 <table>
@@ -123,7 +127,7 @@
 </tbody>
 </table>
 </div>
-<h2>Hammersmith 2</h2>
+<h2 id="hammersmith-2">Hammersmith 2 <a class="anchor-link" href="#hammersmith-2" aria-label="Link to Hammersmith 2">🔗</a></h2>
 <h3>Division 2</h3>
 <div class="table-scroll">
 <table>
@@ -148,7 +152,7 @@
 </tbody>
 </table>
 </div>
-<h2>Hammersmith 3</h2>
+<h2 id="hammersmith-3">Hammersmith 3 <a class="anchor-link" href="#hammersmith-3" aria-label="Link to Hammersmith 3">🔗</a></h2>
 <h3>Division 3</h3>
 <div class="table-scroll">
 <table>
@@ -171,7 +175,7 @@
 </tbody>
 </table>
 </div>
-<h2>Hammersmith 4</h2>
+<h2 id="hammersmith-4">Hammersmith 4 <a class="anchor-link" href="#hammersmith-4" aria-label="Link to Hammersmith 4">🔗</a></h2>
 <h3>Division 3</h3>
 <div class="table-scroll">
 <table>

--- a/runs/example/club-harrow.html
+++ b/runs/example/club-harrow.html
@@ -22,9 +22,13 @@
     a { color: #0645ad; }
     nav ul { list-style: none; padding: 0; }
     nav li { margin-bottom: 0.3rem; }
+    nav ul ul { padding-left: 1.2rem; margin-top: 0.3rem; }
     .venue { margin-top: -0.5rem; margin-bottom: 1.5rem; color: #333; }
     ul.venues { padding-left: 1.2rem; }
     ul.venues li { margin-bottom: 0.3rem; }
+    .anchor-link { margin-left: 0.4rem; font-size: 0.8em; text-decoration: none;
+                    color: #888; }
+    .anchor-link:hover { color: #0645ad; }
 
     @media (max-width: 40rem) {
         body { margin: 1rem; }
@@ -74,7 +78,7 @@
 </tbody>
 </table>
 </div>
-<h2>Harrow 1</h2>
+<h2 id="harrow-1">Harrow 1 <a class="anchor-link" href="#harrow-1" aria-label="Link to Harrow 1">🔗</a></h2>
 <h3>Division 2</h3>
 <div class="table-scroll">
 <table>
@@ -99,7 +103,7 @@
 </tbody>
 </table>
 </div>
-<h2>Harrow 2</h2>
+<h2 id="harrow-2">Harrow 2 <a class="anchor-link" href="#harrow-2" aria-label="Link to Harrow 2">🔗</a></h2>
 <h3>Division 2</h3>
 <div class="table-scroll">
 <table>

--- a/runs/example/club-hendon.html
+++ b/runs/example/club-hendon.html
@@ -22,9 +22,13 @@
     a { color: #0645ad; }
     nav ul { list-style: none; padding: 0; }
     nav li { margin-bottom: 0.3rem; }
+    nav ul ul { padding-left: 1.2rem; margin-top: 0.3rem; }
     .venue { margin-top: -0.5rem; margin-bottom: 1.5rem; color: #333; }
     ul.venues { padding-left: 1.2rem; }
     ul.venues li { margin-bottom: 0.3rem; }
+    .anchor-link { margin-left: 0.4rem; font-size: 0.8em; text-decoration: none;
+                    color: #888; }
+    .anchor-link:hover { color: #0645ad; }
 
     @media (max-width: 40rem) {
         body { margin: 1rem; }
@@ -114,7 +118,7 @@
 </tbody>
 </table>
 </div>
-<h2>Hendon 1</h2>
+<h2 id="hendon-1">Hendon 1 <a class="anchor-link" href="#hendon-1" aria-label="Link to Hendon 1">🔗</a></h2>
 <h3>Division 1</h3>
 <div class="table-scroll">
 <table>
@@ -137,7 +141,7 @@
 </tbody>
 </table>
 </div>
-<h2>Hendon 2</h2>
+<h2 id="hendon-2">Hendon 2 <a class="anchor-link" href="#hendon-2" aria-label="Link to Hendon 2">🔗</a></h2>
 <h3>Division 2</h3>
 <div class="table-scroll">
 <table>
@@ -162,7 +166,7 @@
 </tbody>
 </table>
 </div>
-<h2>Hendon 3</h2>
+<h2 id="hendon-3">Hendon 3 <a class="anchor-link" href="#hendon-3" aria-label="Link to Hendon 3">🔗</a></h2>
 <h3>Division 2</h3>
 <div class="table-scroll">
 <table>
@@ -187,7 +191,7 @@
 </tbody>
 </table>
 </div>
-<h2>Hendon 4</h2>
+<h2 id="hendon-4">Hendon 4 <a class="anchor-link" href="#hendon-4" aria-label="Link to Hendon 4">🔗</a></h2>
 <h3>Division 3</h3>
 <div class="table-scroll">
 <table>
@@ -210,7 +214,7 @@
 </tbody>
 </table>
 </div>
-<h2>Hendon 5</h2>
+<h2 id="hendon-5">Hendon 5 <a class="anchor-link" href="#hendon-5" aria-label="Link to Hendon 5">🔗</a></h2>
 <h3>Division 3</h3>
 <div class="table-scroll">
 <table>

--- a/runs/example/club-kings-head.html
+++ b/runs/example/club-kings-head.html
@@ -22,9 +22,13 @@
     a { color: #0645ad; }
     nav ul { list-style: none; padding: 0; }
     nav li { margin-bottom: 0.3rem; }
+    nav ul ul { padding-left: 1.2rem; margin-top: 0.3rem; }
     .venue { margin-top: -0.5rem; margin-bottom: 1.5rem; color: #333; }
     ul.venues { padding-left: 1.2rem; }
     ul.venues li { margin-bottom: 0.3rem; }
+    .anchor-link { margin-left: 0.4rem; font-size: 0.8em; text-decoration: none;
+                    color: #888; }
+    .anchor-link:hover { color: #0645ad; }
 
     @media (max-width: 40rem) {
         body { margin: 1rem; }
@@ -88,7 +92,7 @@
 </tbody>
 </table>
 </div>
-<h2>Kings Head 1</h2>
+<h2 id="kings-head-1">Kings Head 1 <a class="anchor-link" href="#kings-head-1" aria-label="Link to Kings Head 1">🔗</a></h2>
 <h3>Division 1</h3>
 <div class="table-scroll">
 <table>
@@ -111,7 +115,7 @@
 </tbody>
 </table>
 </div>
-<h2>Kings Head 2</h2>
+<h2 id="kings-head-2">Kings Head 2 <a class="anchor-link" href="#kings-head-2" aria-label="Link to Kings Head 2">🔗</a></h2>
 <h3>Division 2</h3>
 <div class="table-scroll">
 <table>
@@ -136,7 +140,7 @@
 </tbody>
 </table>
 </div>
-<h2>Kings Head 3</h2>
+<h2 id="kings-head-3">Kings Head 3 <a class="anchor-link" href="#kings-head-3" aria-label="Link to Kings Head 3">🔗</a></h2>
 <h3>Division 3</h3>
 <div class="table-scroll">
 <table>

--- a/runs/example/club-metropolitan.html
+++ b/runs/example/club-metropolitan.html
@@ -22,9 +22,13 @@
     a { color: #0645ad; }
     nav ul { list-style: none; padding: 0; }
     nav li { margin-bottom: 0.3rem; }
+    nav ul ul { padding-left: 1.2rem; margin-top: 0.3rem; }
     .venue { margin-top: -0.5rem; margin-bottom: 1.5rem; color: #333; }
     ul.venues { padding-left: 1.2rem; }
     ul.venues li { margin-bottom: 0.3rem; }
+    .anchor-link { margin-left: 0.4rem; font-size: 0.8em; text-decoration: none;
+                    color: #888; }
+    .anchor-link:hover { color: #0645ad; }
 
     @media (max-width: 40rem) {
         body { margin: 1rem; }
@@ -58,7 +62,7 @@
 </tbody>
 </table>
 </div>
-<h2>Metropolitan 1</h2>
+<h2 id="metropolitan-1">Metropolitan 1 <a class="anchor-link" href="#metropolitan-1" aria-label="Link to Metropolitan 1">🔗</a></h2>
 <h3>Division 1</h3>
 <div class="table-scroll">
 <table>

--- a/runs/example/club-muswell-hill.html
+++ b/runs/example/club-muswell-hill.html
@@ -22,9 +22,13 @@
     a { color: #0645ad; }
     nav ul { list-style: none; padding: 0; }
     nav li { margin-bottom: 0.3rem; }
+    nav ul ul { padding-left: 1.2rem; margin-top: 0.3rem; }
     .venue { margin-top: -0.5rem; margin-bottom: 1.5rem; color: #333; }
     ul.venues { padding-left: 1.2rem; }
     ul.venues li { margin-bottom: 0.3rem; }
+    .anchor-link { margin-left: 0.4rem; font-size: 0.8em; text-decoration: none;
+                    color: #888; }
+    .anchor-link:hover { color: #0645ad; }
 
     @media (max-width: 40rem) {
         body { margin: 1rem; }
@@ -74,7 +78,7 @@
 </tbody>
 </table>
 </div>
-<h2>Muswell Hill 1</h2>
+<h2 id="muswell-hill-1">Muswell Hill 1 <a class="anchor-link" href="#muswell-hill-1" aria-label="Link to Muswell Hill 1">🔗</a></h2>
 <h3>Division 1</h3>
 <div class="table-scroll">
 <table>
@@ -97,7 +101,7 @@
 </tbody>
 </table>
 </div>
-<h2>Muswell Hill 2</h2>
+<h2 id="muswell-hill-2">Muswell Hill 2 <a class="anchor-link" href="#muswell-hill-2" aria-label="Link to Muswell Hill 2">🔗</a></h2>
 <h3>Division 2</h3>
 <div class="table-scroll">
 <table>

--- a/runs/example/club-potters-bar.html
+++ b/runs/example/club-potters-bar.html
@@ -22,9 +22,13 @@
     a { color: #0645ad; }
     nav ul { list-style: none; padding: 0; }
     nav li { margin-bottom: 0.3rem; }
+    nav ul ul { padding-left: 1.2rem; margin-top: 0.3rem; }
     .venue { margin-top: -0.5rem; margin-bottom: 1.5rem; color: #333; }
     ul.venues { padding-left: 1.2rem; }
     ul.venues li { margin-bottom: 0.3rem; }
+    .anchor-link { margin-left: 0.4rem; font-size: 0.8em; text-decoration: none;
+                    color: #888; }
+    .anchor-link:hover { color: #0645ad; }
 
     @media (max-width: 40rem) {
         body { margin: 1rem; }
@@ -58,7 +62,7 @@
 </tbody>
 </table>
 </div>
-<h2>Potters Bar 1</h2>
+<h2 id="potters-bar-1">Potters Bar 1 <a class="anchor-link" href="#potters-bar-1" aria-label="Link to Potters Bar 1">🔗</a></h2>
 <h3>Division 3</h3>
 <div class="table-scroll">
 <table>

--- a/runs/example/club-west-london.html
+++ b/runs/example/club-west-london.html
@@ -22,9 +22,13 @@
     a { color: #0645ad; }
     nav ul { list-style: none; padding: 0; }
     nav li { margin-bottom: 0.3rem; }
+    nav ul ul { padding-left: 1.2rem; margin-top: 0.3rem; }
     .venue { margin-top: -0.5rem; margin-bottom: 1.5rem; color: #333; }
     ul.venues { padding-left: 1.2rem; }
     ul.venues li { margin-bottom: 0.3rem; }
+    .anchor-link { margin-left: 0.4rem; font-size: 0.8em; text-decoration: none;
+                    color: #888; }
+    .anchor-link:hover { color: #0645ad; }
 
     @media (max-width: 40rem) {
         body { margin: 1rem; }
@@ -58,7 +62,7 @@
 </tbody>
 </table>
 </div>
-<h2>West London 1</h2>
+<h2 id="west-london-1">West London 1 <a class="anchor-link" href="#west-london-1" aria-label="Link to West London 1">🔗</a></h2>
 <h3>Division 1</h3>
 <div class="table-scroll">
 <table>

--- a/runs/example/club-willesden-brent.html
+++ b/runs/example/club-willesden-brent.html
@@ -22,9 +22,13 @@
     a { color: #0645ad; }
     nav ul { list-style: none; padding: 0; }
     nav li { margin-bottom: 0.3rem; }
+    nav ul ul { padding-left: 1.2rem; margin-top: 0.3rem; }
     .venue { margin-top: -0.5rem; margin-bottom: 1.5rem; color: #333; }
     ul.venues { padding-left: 1.2rem; }
     ul.venues li { margin-bottom: 0.3rem; }
+    .anchor-link { margin-left: 0.4rem; font-size: 0.8em; text-decoration: none;
+                    color: #888; }
+    .anchor-link:hover { color: #0645ad; }
 
     @media (max-width: 40rem) {
         body { margin: 1rem; }
@@ -60,7 +64,7 @@
 </tbody>
 </table>
 </div>
-<h2>Willesden &amp; Brent 1</h2>
+<h2 id="willesden-brent-1">Willesden &amp; Brent 1 <a class="anchor-link" href="#willesden-brent-1" aria-label="Link to Willesden &amp; Brent 1">🔗</a></h2>
 <h3>Division 2</h3>
 <div class="table-scroll">
 <table>

--- a/runs/example/division-1.html
+++ b/runs/example/division-1.html
@@ -22,9 +22,13 @@
     a { color: #0645ad; }
     nav ul { list-style: none; padding: 0; }
     nav li { margin-bottom: 0.3rem; }
+    nav ul ul { padding-left: 1.2rem; margin-top: 0.3rem; }
     .venue { margin-top: -0.5rem; margin-bottom: 1.5rem; color: #333; }
     ul.venues { padding-left: 1.2rem; }
     ul.venues li { margin-bottom: 0.3rem; }
+    .anchor-link { margin-left: 0.4rem; font-size: 0.8em; text-decoration: none;
+                    color: #888; }
+    .anchor-link:hover { color: #0645ad; }
 
     @media (max-width: 40rem) {
         body { margin: 1rem; }

--- a/runs/example/division-2.html
+++ b/runs/example/division-2.html
@@ -22,9 +22,13 @@
     a { color: #0645ad; }
     nav ul { list-style: none; padding: 0; }
     nav li { margin-bottom: 0.3rem; }
+    nav ul ul { padding-left: 1.2rem; margin-top: 0.3rem; }
     .venue { margin-top: -0.5rem; margin-bottom: 1.5rem; color: #333; }
     ul.venues { padding-left: 1.2rem; }
     ul.venues li { margin-bottom: 0.3rem; }
+    .anchor-link { margin-left: 0.4rem; font-size: 0.8em; text-decoration: none;
+                    color: #888; }
+    .anchor-link:hover { color: #0645ad; }
 
     @media (max-width: 40rem) {
         body { margin: 1rem; }

--- a/runs/example/division-3.html
+++ b/runs/example/division-3.html
@@ -22,9 +22,13 @@
     a { color: #0645ad; }
     nav ul { list-style: none; padding: 0; }
     nav li { margin-bottom: 0.3rem; }
+    nav ul ul { padding-left: 1.2rem; margin-top: 0.3rem; }
     .venue { margin-top: -0.5rem; margin-bottom: 1.5rem; color: #333; }
     ul.venues { padding-left: 1.2rem; }
     ul.venues li { margin-bottom: 0.3rem; }
+    .anchor-link { margin-left: 0.4rem; font-size: 0.8em; text-decoration: none;
+                    color: #888; }
+    .anchor-link:hover { color: #0645ad; }
 
     @media (max-width: 40rem) {
         body { margin: 1rem; }


### PR DESCRIPTION
Each team heading in a per-club report now carries a stable id (from its slugified display name) plus a small link icon so the anchor is discoverable and its URL is easy to copy, e.g. club-hendon.html#hendon-2. Regenerated the checked-in runs/example report to reflect this.