### PR TITLE
Generate schema reference docs into a schema-docs/ folder

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           mkdir -p _site
           cp index.html _site/index.html
-          cp spec-schema.html schema_doc.css schema_doc.min.js _site/
+          cp -r schema-docs _site/schema-docs
           if [ -d runs ]; then cp -r runs _site/runs; fi
 
       - name: Upload pages artifact

--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,8 @@ __pycache__/
 /index.html
 runs/*/index.html
 
-# The schema reference page (and its support CSS/JS, copied alongside it by
-# json-schema-for-humans) is fully derived from spec-schema.json and is
-# rebuilt on demand (build_schema_docs.py) and at Pages deploy time, so none
-# of it needs to be committed.
-/spec-schema.html
-/schema_doc.css
-/schema_doc.min.js
+# The schema reference page (and whatever support files json-schema-for-humans
+# copies alongside it) is fully derived from spec-schema.json and is rebuilt
+# on demand (build_schema_docs.py) and at Pages deploy time, so none of it
+# needs to be committed.
+/schema-docs/

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ fixtures, and more. For the full field-by-field reference, see:
 
 - **[spec-schema.json](spec-schema.json)**, the JSON Schema every field is
   defined in (rendered to a browsable reference page at
-  <https://amdw.github.io/fixtures/spec-schema.html>, published alongside
-  every other run's report by the same GitHub Pages build -- see
+  <https://amdw.github.io/fixtures/schema-docs/spec-schema.html>, published
+  alongside every other run's report by the same GitHub Pages build -- see
   "Publishing via GitHub Pages" below). Adding a
   `# yaml-language-server: $schema=<path-to-spec-schema.json>` comment atop a
   spec file also gets you inline validation and autocomplete while editing it,
@@ -186,9 +186,9 @@ python genfixtures.py
 
 ### Publishing via GitHub Pages
 
-The root `index.html`, `spec-schema.html` (plus its `schema_doc.css` and
-`schema_doc.min.js` support files) and everything under `runs/` are plain
-static HTML, published from the `main` branch at
+The root `index.html`, `schema-docs/spec-schema.html` (plus whatever support
+files `json-schema-for-humans` copies alongside it) and everything under
+`runs/` are plain static HTML, published from the `main` branch at
 <https://amdw.github.io/fixtures/> by `.github/workflows/pages.yml`. All of
 these are build artifacts, not source -- gitignored, and regenerated before
 every deploy from whatever `runs/*/` folders and `spec-schema.json` are
@@ -213,7 +213,8 @@ and serve that instead:
 
 ```bash
 mkdir -p _site
-cp index.html spec-schema.html schema_doc.css schema_doc.min.js _site/
+cp index.html _site/index.html
+cp -r schema-docs _site/schema-docs
 cp -r runs _site/runs
 python -m http.server --directory _site
 ```

--- a/build_schema_docs.py
+++ b/build_schema_docs.py
@@ -42,10 +42,12 @@ def main() -> None:
     parser.add_argument(
         "--out",
         type=Path,
-        default=Path("spec-schema.html"),
-        help="Path of the HTML page to (re)generate (default: spec-schema.html)",
+        default=Path("schema-docs/spec-schema.html"),
+        help="Path of the HTML page to (re)generate (default: schema-docs/spec-schema.html)",
     )
     args = parser.parse_args()
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
 
     config = GenerationConfiguration(show_breadcrumbs=False, with_footer=False)
     generate_from_filename(args.schema, str(args.out), config=config)


### PR DESCRIPTION
Gitignoring a single generated folder (both locally and in the deployed _site) is more robust against future json-schema-for-humans versions changing what support files it emits alongside spec-schema.html, versus listing each filename explicitly. This also avoids the generated files colliding with anything else at the site root.