### PR TITLE
Add uv init's default Python .gitignore patterns (closes #39)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,11 @@ __pycache__/
 .hypothesis/
 .mypy_cache/
 .ruff_cache/
-*.pyc
+*.py[oc]
+build/
+dist/
+wheels/
+*.egg-info
 
 # Index pages are fully derived from the report files under runs/ and are
 # rebuilt on demand (run.py / build_indexes.py) and at Pages deploy time, so


### PR DESCRIPTION
We switched from Pipenv to uv without ever running uv init, so we were missing build/, dist/, wheels/, and *.egg-info; also widen *.pyc to *.py[oc] to match uv's default.