### PR TITLE
Sort more columns in HTML tables (closes #37)

### DIFF
--- a/htmlreport.py
+++ b/htmlreport.py
@@ -179,19 +179,52 @@ def _team_name(team: fmodel.Team, clubs: Mapping[str, fmodel.Club]) -> str:
     return f"{clubs[team.club].name} {team.index}"
 
 
-def _by_date(
-    fixtures: Collection[fmodel.ScheduledFixture], clubs: Mapping[str, fmodel.Club]
+def _team_sort_key(
+    team: fmodel.Team, clubs: Mapping[str, fmodel.Club]
+) -> tuple[str, int]:
+    """(club name, team index) of a team, used as a sort tie-break throughout."""
+    return (clubs[team.club].name, team.index)
+
+
+def _by_date_home_away(
+    fixtures: Collection[fmodel.ScheduledFixture],
+    clubs: Mapping[str, fmodel.Club],
+    with_division: bool,
 ) -> list[fmodel.ScheduledFixture]:
-    return sorted(
-        fixtures, key=lambda sf: (sf.date, _team_name(sf.fixture.home_team, clubs))
-    )
+    def key(sf: fmodel.ScheduledFixture) -> tuple:
+        home_team = sf.fixture.home_team
+        division_part = (home_team.division,) if with_division else ()
+        return (
+            sf.date,
+            *division_part,
+            *_team_sort_key(home_team, clubs),
+            *_team_sort_key(sf.fixture.away_team, clubs),
+        )
+
+    return sorted(fixtures, key=key)
+
+
+def _by_date_opponent(
+    team: fmodel.Team,
+    fixtures: Collection[fmodel.ScheduledFixture],
+    clubs: Mapping[str, fmodel.Club],
+) -> list[fmodel.ScheduledFixture]:
+    def key(sf: fmodel.ScheduledFixture) -> tuple:
+        opponent = (
+            sf.fixture.away_team
+            if sf.fixture.home_team == team
+            else sf.fixture.home_team
+        )
+        return (sf.date, *_team_sort_key(opponent, clubs))
+
+    return sorted(fixtures, key=key)
 
 
 def _rows_with_division(
     fixtures: Collection[fmodel.ScheduledFixture], clubs: Mapping[str, fmodel.Club]
 ) -> list[list[str]]:
     rows = []
-    for sf in _by_date(fixtures, clubs):
+    for sf in _by_date_home_away(fixtures, clubs, with_division=True):
         home_club = clubs[sf.fixture.home_team.club]
         rows.append(
             [
@@ -211,7 +244,7 @@ def _rows(
     fixtures: Collection[fmodel.ScheduledFixture], clubs: Mapping[str, fmodel.Club]
 ) -> list[list[str]]:
     rows = []
-    for sf in _by_date(fixtures, clubs):
+    for sf in _by_date_home_away(fixtures, clubs, with_division=False):
         home_club = clubs[sf.fixture.home_team.club]
         rows.append(
             [
@@ -237,7 +270,7 @@ def _team_rows(
 ) -> list[list[str]]:
     rows = []
     prev_date: date | None = None
-    for sf in _by_date(fixtures, clubs):
+    for sf in _by_date_opponent(team, fixtures, clubs):
         is_home = sf.fixture.home_team == team
         opponent = sf.fixture.away_team if is_home else sf.fixture.home_team
         home_club = clubs[sf.fixture.home_team.club]
@@ -256,17 +289,27 @@ def _team_rows(
     return rows
 
 
-def _by_home_team_name(
-    fixtures: Collection[fmodel.Fixture], clubs: Mapping[str, fmodel.Club]
+def _by_home_away(
+    fixtures: Collection[fmodel.Fixture],
+    clubs: Mapping[str, fmodel.Club],
+    with_division: bool,
 ) -> list[fmodel.Fixture]:
-    return sorted(fixtures, key=lambda f: _team_name(f.home_team, clubs))
+    def key(f: fmodel.Fixture) -> tuple:
+        division_part = (f.home_team.division,) if with_division else ()
+        return (
+            *division_part,
+            *_team_sort_key(f.home_team, clubs),
+            *_team_sort_key(f.away_team, clubs),
+        )
+
+    return sorted(fixtures, key=key)
 
 
 def _excluded_rows_with_division(
     fixtures: Collection[fmodel.Fixture], clubs: Mapping[str, fmodel.Club]
 ) -> list[list[str]]:
     rows = []
-    for f in _by_home_team_name(fixtures, clubs):
+    for f in _by_home_away(fixtures, clubs, with_division=True):
         home_club = clubs[f.home_team.club]
         rows.append(
             [
@@ -286,7 +329,7 @@ def _excluded_rows(
     fixtures: Collection[fmodel.Fixture], clubs: Mapping[str, fmodel.Club]
 ) -> list[list[str]]:
     rows = []
-    for f in _by_home_team_name(fixtures, clubs):
+    for f in _by_home_away(fixtures, clubs, with_division=False):
         home_club = clubs[f.home_team.club]
         rows.append(
             [
@@ -309,7 +352,7 @@ def _excluded_team_rows(
     rows = []
     for f in sorted(
         fixtures,
-        key=lambda f: _team_name(
+        key=lambda f: _team_sort_key(
             f.away_team if f.home_team == team else f.home_team, clubs
         ),
     ):

--- a/runs/example/all-matches.html
+++ b/runs/example/all-matches.html
@@ -44,20 +44,20 @@
 <thead><tr><th>Date</th><th>Div</th><th>Home</th><th>Away</th><th>Venue</th><th>Start</th><th>Time Limit</th></tr></thead>
 <tbody>
 <tr><td>Tue 02 Sep 2025</td><td>1</td><td>Muswell Hill 1</td><td>Albany 1</td><td>Muswell Hill Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Wed 03 Sep 2025</td><td>3</td><td>Hackney 2</td><td>Hammersmith 3</td><td>Hackney Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 03 Sep 2025</td><td>1</td><td>West London 1</td><td>Hammersmith 1</td><td>West London Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 03 Sep 2025</td><td>2</td><td>Willesden &amp; Brent 1</td><td>Harrow 1</td><td>Willesden &amp; Brent Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 04 Sep 2025</td><td>3</td><td>Hammersmith 4</td><td>Hendon 4</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Wed 03 Sep 2025</td><td>3</td><td>Hackney 2</td><td>Hammersmith 3</td><td>Hackney Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 04 Sep 2025</td><td>2</td><td>Kings Head 2</td><td>Muswell Hill 2</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 04 Sep 2025</td><td>3</td><td>Hammersmith 4</td><td>Hendon 4</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 10 Sep 2025</td><td>1</td><td>Hackney 1</td><td>Albany 1</td><td>Hackney Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 11 Sep 2025</td><td>1</td><td>Metropolitan 1</td><td>Hendon 1</td><td>Metropolitan Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 11 Sep 2025</td><td>2</td><td>Harrow 1</td><td>Harrow 2</td><td>Harrow Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 11 Sep 2025</td><td>2</td><td>Hendon 2</td><td>Hendon 3</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 11 Sep 2025</td><td>3</td><td>Kings Head 3</td><td>Hackney 2</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 11 Sep 2025</td><td>1</td><td>Metropolitan 1</td><td>Hendon 1</td><td>Metropolitan Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Mon 15 Sep 2025</td><td>3</td><td>Ealing 2</td><td>Hammersmith 4</td><td>Ealing Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 18 Sep 2025</td><td>3</td><td>Hendon 4</td><td>Hammersmith 3</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 18 Sep 2025</td><td>1</td><td>Kings Head 1</td><td>West London 1</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 18 Sep 2025</td><td>2</td><td>Kings Head 2</td><td>Willesden &amp; Brent 1</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 18 Sep 2025</td><td>3</td><td>Hendon 4</td><td>Hammersmith 3</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Mon 22 Sep 2025</td><td>1</td><td>Albany 1</td><td>Hammersmith 1</td><td>Albany Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Mon 22 Sep 2025</td><td>2</td><td>Ealing 1</td><td>Muswell Hill 2</td><td>Ealing Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 25 Sep 2025</td><td>2</td><td>Harrow 1</td><td>Hammersmith 2</td><td>Harrow Sports Hall</td><td>19:30</td><td>75+15</td></tr>
@@ -70,9 +70,9 @@
 <tr><td>Mon 06 Oct 2025</td><td>2</td><td>Ealing 1</td><td>Willesden &amp; Brent 1</td><td>Ealing Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Mon 06 Oct 2025</td><td>3</td><td>Ealing 2</td><td>Hackney 2</td><td>Ealing Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 08 Oct 2025</td><td>1</td><td>West London 1</td><td>Muswell Hill 1</td><td>West London Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 09 Oct 2025</td><td>1</td><td>Kings Head 1</td><td>Hackney 1</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 09 Oct 2025</td><td>3</td><td>Hammersmith 3</td><td>Kings Head 3</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 09 Oct 2025</td><td>3</td><td>Hammersmith 4</td><td>Hendon 5</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 09 Oct 2025</td><td>1</td><td>Kings Head 1</td><td>Hackney 1</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 15 Oct 2025</td><td>3</td><td>Hackney 2</td><td>Potters Bar 1</td><td>Hackney Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 16 Oct 2025</td><td>2</td><td>Harrow 2</td><td>Willesden &amp; Brent 1</td><td>Harrow Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 16 Oct 2025</td><td>2</td><td>Hendon 2</td><td>Muswell Hill 2</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
@@ -82,30 +82,30 @@
 <tr><td>Thu 23 Oct 2025</td><td>1</td><td>Hendon 1</td><td>Metropolitan 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 29 Oct 2025</td><td>2</td><td>Willesden &amp; Brent 1</td><td>Hendon 2</td><td>Willesden &amp; Brent Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 30 Oct 2025</td><td>2</td><td>Hammersmith 2</td><td>Kings Head 2</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 30 Oct 2025</td><td>3</td><td>Hammersmith 3</td><td>Hammersmith 4</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 30 Oct 2025</td><td>2</td><td>Harrow 2</td><td>Harrow 1</td><td>Harrow Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 30 Oct 2025</td><td>3</td><td>Hammersmith 3</td><td>Hammersmith 4</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 30 Oct 2025</td><td>3</td><td>Hendon 5</td><td>Hendon 4</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Mon 03 Nov 2025</td><td>3</td><td>Potters Bar 1</td><td>Kings Head 3</td><td>Potters Bar Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Tue 04 Nov 2025</td><td>2</td><td>Muswell Hill 2</td><td>Ealing 1</td><td>Muswell Hill Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 12 Nov 2025</td><td>1</td><td>Hackney 1</td><td>Hendon 1</td><td>Hackney Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 12 Nov 2025</td><td>3</td><td>Hackney 2</td><td>Hendon 5</td><td>Hackney Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 13 Nov 2025</td><td>1</td><td>Hammersmith 1</td><td>Albany 1</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 13 Nov 2025</td><td>1</td><td>Metropolitan 1</td><td>Kings Head 1</td><td>Metropolitan Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 13 Nov 2025</td><td>2</td><td>Hammersmith 2</td><td>Muswell Hill 2</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 13 Nov 2025</td><td>3</td><td>Hammersmith 4</td><td>Hammersmith 3</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 13 Nov 2025</td><td>2</td><td>Harrow 1</td><td>Kings Head 2</td><td>Harrow Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 13 Nov 2025</td><td>2</td><td>Hendon 3</td><td>Ealing 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 13 Nov 2025</td><td>3</td><td>Hammersmith 4</td><td>Hammersmith 3</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 13 Nov 2025</td><td>3</td><td>Hendon 4</td><td>Kings Head 3</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 13 Nov 2025</td><td>1</td><td>Metropolitan 1</td><td>Kings Head 1</td><td>Metropolitan Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 20 Nov 2025</td><td>2</td><td>Harrow 2</td><td>Hendon 2</td><td>Harrow Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Mon 24 Nov 2025</td><td>3</td><td>Potters Bar 1</td><td>Hendon 4</td><td>Potters Bar Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Tue 25 Nov 2025</td><td>2</td><td>Muswell Hill 2</td><td>Kings Head 2</td><td>Muswell Hill Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 27 Nov 2025</td><td>1</td><td>Hammersmith 1</td><td>Muswell Hill 1</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 27 Nov 2025</td><td>1</td><td>Hendon 1</td><td>Kings Head 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 27 Nov 2025</td><td>2</td><td>Hendon 3</td><td>Harrow 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 27 Nov 2025</td><td>1</td><td>Metropolitan 1</td><td>Hackney 1</td><td>Metropolitan Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 27 Nov 2025</td><td>2</td><td>Hendon 3</td><td>Harrow 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Mon 01 Dec 2025</td><td>2</td><td>Ealing 1</td><td>Hammersmith 2</td><td>Ealing Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 04 Dec 2025</td><td>3</td><td>Hammersmith 4</td><td>Ealing 2</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 04 Dec 2025</td><td>2</td><td>Kings Head 2</td><td>Harrow 2</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 04 Dec 2025</td><td>3</td><td>Hammersmith 4</td><td>Ealing 2</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 10 Dec 2025</td><td>1</td><td>Hackney 1</td><td>Muswell Hill 1</td><td>Hackney Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 10 Dec 2025</td><td>1</td><td>West London 1</td><td>Albany 1</td><td>West London Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 11 Dec 2025</td><td>2</td><td>Hendon 2</td><td>Harrow 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
@@ -113,14 +113,14 @@
 <tr><td>Thu 11 Dec 2025</td><td>3</td><td>Kings Head 3</td><td>Hammersmith 3</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Mon 15 Dec 2025</td><td>3</td><td>Potters Bar 1</td><td>Ealing 2</td><td>Potters Bar Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 18 Dec 2025</td><td>1</td><td>Hammersmith 1</td><td>West London 1</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 18 Dec 2025</td><td>1</td><td>Kings Head 1</td><td>Metropolitan 1</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 18 Dec 2025</td><td>2</td><td>Hammersmith 2</td><td>Willesden &amp; Brent 1</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 18 Dec 2025</td><td>2</td><td>Hendon 3</td><td>Harrow 2</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 18 Dec 2025</td><td>1</td><td>Kings Head 1</td><td>Metropolitan 1</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 18 Dec 2025</td><td>2</td><td>Kings Head 2</td><td>Ealing 1</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 25 Dec 2025</td><td>1</td><td>Hendon 1</td><td>Albany 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 25 Dec 2025</td><td>2</td><td>Harrow 1</td><td>Hendon 2</td><td>Harrow Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 25 Dec 2025</td><td>3</td><td>Hammersmith 3</td><td>Hendon 5</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 25 Dec 2025</td><td>3</td><td>Hammersmith 4</td><td>Kings Head 3</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 25 Dec 2025</td><td>2</td><td>Harrow 1</td><td>Hendon 2</td><td>Harrow Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 25 Dec 2025</td><td>1</td><td>Hendon 1</td><td>Albany 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Mon 29 Dec 2025</td><td>2</td><td>Ealing 1</td><td>Harrow 2</td><td>Ealing Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 31 Dec 2025</td><td>2</td><td>Willesden &amp; Brent 1</td><td>Kings Head 2</td><td>Willesden &amp; Brent Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 01 Jan 2026</td><td>1</td><td>Metropolitan 1</td><td>Muswell Hill 1</td><td>Metropolitan Sports Hall</td><td>19:30</td><td>75+15</td></tr>
@@ -131,8 +131,8 @@
 <tr><td>Thu 08 Jan 2026</td><td>2</td><td>Kings Head 2</td><td>Hendon 3</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Mon 12 Jan 2026</td><td>3</td><td>Ealing 2</td><td>Hendon 4</td><td>Ealing Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Tue 13 Jan 2026</td><td>2</td><td>Muswell Hill 2</td><td>Willesden &amp; Brent 1</td><td>Muswell Hill Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 15 Jan 2026</td><td>3</td><td>Hammersmith 4</td><td>Hackney 2</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 15 Jan 2026</td><td>1</td><td>Hendon 1</td><td>Hackney 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 15 Jan 2026</td><td>3</td><td>Hammersmith 4</td><td>Hackney 2</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 15 Jan 2026</td><td>3</td><td>Hendon 5</td><td>Kings Head 3</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Mon 19 Jan 2026</td><td>1</td><td>Albany 1</td><td>Metropolitan 1</td><td>Albany Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Tue 20 Jan 2026</td><td>1</td><td>Muswell Hill 1</td><td>Kings Head 1</td><td>Muswell Hill Sports Hall</td><td>19:30</td><td>75+15</td></tr>
@@ -141,8 +141,8 @@
 <tr><td>Mon 26 Jan 2026</td><td>3</td><td>Ealing 2</td><td>Hendon 5</td><td>Ealing Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 28 Jan 2026</td><td>1</td><td>Hackney 1</td><td>Metropolitan 1</td><td>Hackney Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 28 Jan 2026</td><td>2</td><td>Willesden &amp; Brent 1</td><td>Hammersmith 2</td><td>Willesden &amp; Brent Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 29 Jan 2026</td><td>3</td><td>Hendon 4</td><td>Potters Bar 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 29 Jan 2026</td><td>1</td><td>Kings Head 1</td><td>Muswell Hill 1</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 29 Jan 2026</td><td>3</td><td>Hendon 4</td><td>Potters Bar 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Mon 02 Feb 2026</td><td>1</td><td>Albany 1</td><td>West London 1</td><td>Albany Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Mon 02 Feb 2026</td><td>2</td><td>Ealing 1</td><td>Hendon 2</td><td>Ealing Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 04 Feb 2026</td><td>3</td><td>Hackney 2</td><td>Kings Head 3</td><td>Hackney Sports Hall</td><td>19:30</td><td>75+15</td></tr>
@@ -159,11 +159,11 @@
 <tr><td>Tue 17 Feb 2026</td><td>2</td><td>Muswell Hill 2</td><td>Hammersmith 2</td><td>Muswell Hill Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 19 Feb 2026</td><td>2</td><td>Harrow 1</td><td>Willesden &amp; Brent 1</td><td>Harrow Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 25 Feb 2026</td><td>1</td><td>Hackney 1</td><td>Hammersmith 1</td><td>Hackney Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Wed 25 Feb 2026</td><td>3</td><td>Hackney 2</td><td>Ealing 2</td><td>Hackney Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 25 Feb 2026</td><td>1</td><td>West London 1</td><td>Hendon 1</td><td>West London Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Wed 25 Feb 2026</td><td>3</td><td>Hackney 2</td><td>Ealing 2</td><td>Hackney Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 26 Feb 2026</td><td>2</td><td>Hendon 3</td><td>Muswell Hill 2</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 26 Feb 2026</td><td>3</td><td>Hendon 5</td><td>Potters Bar 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 26 Feb 2026</td><td>2</td><td>Kings Head 2</td><td>Hammersmith 2</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 26 Feb 2026</td><td>3</td><td>Hendon 5</td><td>Potters Bar 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 26 Feb 2026</td><td>3</td><td>Kings Head 3</td><td>Hammersmith 4</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Mon 02 Mar 2026</td><td>1</td><td>Albany 1</td><td>Muswell Hill 1</td><td>Albany Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 04 Mar 2026</td><td>2</td><td>Willesden &amp; Brent 1</td><td>Harrow 2</td><td>Willesden &amp; Brent Sports Hall</td><td>19:30</td><td>75+15</td></tr>
@@ -171,45 +171,45 @@
 <tr><td>Mon 09 Mar 2026</td><td>2</td><td>Ealing 1</td><td>Kings Head 2</td><td>Ealing Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Mon 09 Mar 2026</td><td>3</td><td>Ealing 2</td><td>Hammersmith 3</td><td>Ealing Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Tue 10 Mar 2026</td><td>2</td><td>Muswell Hill 2</td><td>Hendon 3</td><td>Muswell Hill Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 12 Mar 2026</td><td>2</td><td>Hendon 2</td><td>Willesden &amp; Brent 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 12 Mar 2026</td><td>1</td><td>Metropolitan 1</td><td>Albany 1</td><td>Metropolitan Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 12 Mar 2026</td><td>2</td><td>Hendon 2</td><td>Willesden &amp; Brent 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Mon 16 Mar 2026</td><td>3</td><td>Potters Bar 1</td><td>Hendon 5</td><td>Potters Bar Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 18 Mar 2026</td><td>3</td><td>Hackney 2</td><td>Hammersmith 4</td><td>Hackney Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 19 Mar 2026</td><td>2</td><td>Harrow 1</td><td>Ealing 1</td><td>Harrow Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 19 Mar 2026</td><td>2</td><td>Harrow 2</td><td>Hendon 3</td><td>Harrow Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 19 Mar 2026</td><td>1</td><td>Hendon 1</td><td>Muswell Hill 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 19 Mar 2026</td><td>1</td><td>Kings Head 1</td><td>Hammersmith 1</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 19 Mar 2026</td><td>2</td><td>Harrow 1</td><td>Ealing 1</td><td>Harrow Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 19 Mar 2026</td><td>2</td><td>Harrow 2</td><td>Hendon 3</td><td>Harrow Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 25 Mar 2026</td><td>2</td><td>Willesden &amp; Brent 1</td><td>Muswell Hill 2</td><td>Willesden &amp; Brent Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 26 Mar 2026</td><td>1</td><td>Metropolitan 1</td><td>West London 1</td><td>Metropolitan Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 26 Mar 2026</td><td>2</td><td>Kings Head 2</td><td>Hendon 2</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 26 Mar 2026</td><td>3</td><td>Hendon 4</td><td>Hammersmith 4</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 26 Mar 2026</td><td>3</td><td>Hendon 5</td><td>Hackney 2</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 26 Mar 2026</td><td>2</td><td>Kings Head 2</td><td>Hendon 2</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 26 Mar 2026</td><td>3</td><td>Kings Head 3</td><td>Potters Bar 1</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 26 Mar 2026</td><td>1</td><td>Metropolitan 1</td><td>West London 1</td><td>Metropolitan Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Mon 30 Mar 2026</td><td>1</td><td>Albany 1</td><td>Kings Head 1</td><td>Albany Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 02 Apr 2026</td><td>2</td><td>Hammersmith 2</td><td>Harrow 1</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 02 Apr 2026</td><td>3</td><td>Hammersmith 3</td><td>Ealing 2</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Wed 08 Apr 2026</td><td>3</td><td>Hackney 2</td><td>Hendon 4</td><td>Hackney Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 08 Apr 2026</td><td>1</td><td>West London 1</td><td>Metropolitan 1</td><td>West London Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Wed 08 Apr 2026</td><td>3</td><td>Hackney 2</td><td>Hendon 4</td><td>Hackney Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 09 Apr 2026</td><td>1</td><td>Hammersmith 1</td><td>Hackney 1</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 09 Apr 2026</td><td>3</td><td>Hammersmith 4</td><td>Potters Bar 1</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 09 Apr 2026</td><td>3</td><td>Kings Head 3</td><td>Hendon 5</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 15 Apr 2026</td><td>2</td><td>Willesden &amp; Brent 1</td><td>Ealing 1</td><td>Willesden &amp; Brent Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 16 Apr 2026</td><td>1</td><td>Hendon 1</td><td>West London 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 16 Apr 2026</td><td>2</td><td>Hammersmith 2</td><td>Hendon 2</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 16 Apr 2026</td><td>3</td><td>Hammersmith 3</td><td>Hendon 4</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 16 Apr 2026</td><td>2</td><td>Harrow 1</td><td>Muswell Hill 2</td><td>Harrow Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 16 Apr 2026</td><td>2</td><td>Harrow 2</td><td>Kings Head 2</td><td>Harrow Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 16 Apr 2026</td><td>1</td><td>Hendon 1</td><td>West London 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 16 Apr 2026</td><td>3</td><td>Hammersmith 3</td><td>Hendon 4</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Mon 20 Apr 2026</td><td>3</td><td>Potters Bar 1</td><td>Hackney 2</td><td>Potters Bar Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 23 Apr 2026</td><td>3</td><td>Kings Head 3</td><td>Ealing 2</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 23 Apr 2026</td><td>1</td><td>Metropolitan 1</td><td>Hammersmith 1</td><td>Metropolitan Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 23 Apr 2026</td><td>3</td><td>Kings Head 3</td><td>Ealing 2</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Tue 28 Apr 2026</td><td>1</td><td>Muswell Hill 1</td><td>Hendon 1</td><td>Muswell Hill Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Tue 28 Apr 2026</td><td>2</td><td>Muswell Hill 2</td><td>Harrow 1</td><td>Muswell Hill Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 29 Apr 2026</td><td>2</td><td>Willesden &amp; Brent 1</td><td>Hendon 3</td><td>Willesden &amp; Brent Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 30 Apr 2026</td><td>2</td><td>Hammersmith 2</td><td>Harrow 2</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 30 Apr 2026</td><td>3</td><td>Hammersmith 3</td><td>Potters Bar 1</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 30 Apr 2026</td><td>2</td><td>Hendon 2</td><td>Ealing 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 30 Apr 2026</td><td>3</td><td>Hendon 4</td><td>Hackney 2</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 30 Apr 2026</td><td>1</td><td>Kings Head 1</td><td>Albany 1</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 30 Apr 2026</td><td>2</td><td>Hammersmith 2</td><td>Harrow 2</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 30 Apr 2026</td><td>2</td><td>Hendon 2</td><td>Ealing 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 30 Apr 2026</td><td>3</td><td>Hammersmith 3</td><td>Potters Bar 1</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 30 Apr 2026</td><td>3</td><td>Hendon 4</td><td>Hackney 2</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Mon 04 May 2026</td><td>3</td><td>Ealing 2</td><td>Kings Head 3</td><td>Ealing Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 06 May 2026</td><td>1</td><td>West London 1</td><td>Hackney 1</td><td>West London Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Tue 12 May 2026</td><td>2</td><td>Muswell Hill 2</td><td>Hendon 2</td><td>Muswell Hill Sports Hall</td><td>19:30</td><td>75+15</td></tr>
@@ -221,11 +221,11 @@
 <tr><td>Thu 21 May 2026</td><td>3</td><td>Hendon 4</td><td>Ealing 2</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Mon 25 May 2026</td><td>3</td><td>Potters Bar 1</td><td>Hammersmith 4</td><td>Potters Bar Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 27 May 2026</td><td>1</td><td>Hackney 1</td><td>Kings Head 1</td><td>Hackney Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 28 May 2026</td><td>2</td><td>Hammersmith 2</td><td>Ealing 1</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 28 May 2026</td><td>3</td><td>Hammersmith 3</td><td>Hackney 2</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 28 May 2026</td><td>2</td><td>Harrow 2</td><td>Muswell Hill 2</td><td>Harrow Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 28 May 2026</td><td>1</td><td>Hendon 1</td><td>Hammersmith 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 28 May 2026</td><td>2</td><td>Hammersmith 2</td><td>Ealing 1</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 28 May 2026</td><td>2</td><td>Harrow 2</td><td>Muswell Hill 2</td><td>Harrow Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 28 May 2026</td><td>2</td><td>Hendon 3</td><td>Willesden &amp; Brent 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 28 May 2026</td><td>3</td><td>Hammersmith 3</td><td>Hackney 2</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td><strong>TBC</strong></td><td>1</td><td>Albany 1</td><td>Hackney 1</td><td>Albany Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 </tbody>
 </table>

--- a/runs/example/club-hackney.html
+++ b/runs/example/club-hackney.html
@@ -56,8 +56,8 @@
 <tr><td>Thu 27 Nov 2025</td><td>1</td><td>Metropolitan 1</td><td>Hackney 1</td><td>Metropolitan Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 10 Dec 2025</td><td>1</td><td>Hackney 1</td><td>Muswell Hill 1</td><td>Hackney Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 07 Jan 2026</td><td>1</td><td>Hackney 1</td><td>West London 1</td><td>Hackney Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 15 Jan 2026</td><td>3</td><td>Hammersmith 4</td><td>Hackney 2</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 15 Jan 2026</td><td>1</td><td>Hendon 1</td><td>Hackney 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 15 Jan 2026</td><td>3</td><td>Hammersmith 4</td><td>Hackney 2</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 28 Jan 2026</td><td>1</td><td>Hackney 1</td><td>Metropolitan 1</td><td>Hackney Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 04 Feb 2026</td><td>3</td><td>Hackney 2</td><td>Kings Head 3</td><td>Hackney Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Tue 10 Feb 2026</td><td>1</td><td>Muswell Hill 1</td><td>Hackney 1</td><td>Muswell Hill Sports Hall</td><td>19:30</td><td>75+15</td></tr>

--- a/runs/example/club-hammersmith.html
+++ b/runs/example/club-hammersmith.html
@@ -45,8 +45,8 @@
 <table>
 <thead><tr><th>Date</th><th>Div</th><th>Home</th><th>Away</th><th>Venue</th><th>Start</th><th>Time Limit</th></tr></thead>
 <tbody>
-<tr><td>Wed 03 Sep 2025</td><td>3</td><td>Hackney 2</td><td>Hammersmith 3</td><td>Hackney Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 03 Sep 2025</td><td>1</td><td>West London 1</td><td>Hammersmith 1</td><td>West London Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Wed 03 Sep 2025</td><td>3</td><td>Hackney 2</td><td>Hammersmith 3</td><td>Hackney Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 04 Sep 2025</td><td>3</td><td>Hammersmith 4</td><td>Hendon 4</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Mon 15 Sep 2025</td><td>3</td><td>Ealing 2</td><td>Hammersmith 4</td><td>Ealing Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 18 Sep 2025</td><td>3</td><td>Hendon 4</td><td>Hammersmith 3</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
@@ -98,9 +98,9 @@
 <tr><td>Thu 14 May 2026</td><td>3</td><td>Hendon 5</td><td>Hammersmith 4</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Tue 19 May 2026</td><td>1</td><td>Muswell Hill 1</td><td>Hammersmith 1</td><td>Muswell Hill Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Mon 25 May 2026</td><td>3</td><td>Potters Bar 1</td><td>Hammersmith 4</td><td>Potters Bar Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 28 May 2026</td><td>1</td><td>Hendon 1</td><td>Hammersmith 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 28 May 2026</td><td>2</td><td>Hammersmith 2</td><td>Ealing 1</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 28 May 2026</td><td>3</td><td>Hammersmith 3</td><td>Hackney 2</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 28 May 2026</td><td>1</td><td>Hendon 1</td><td>Hammersmith 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 </tbody>
 </table>
 </div>

--- a/runs/example/club-hendon.html
+++ b/runs/example/club-hendon.html
@@ -46,8 +46,8 @@
 <thead><tr><th>Date</th><th>Div</th><th>Home</th><th>Away</th><th>Venue</th><th>Start</th><th>Time Limit</th></tr></thead>
 <tbody>
 <tr><td>Thu 04 Sep 2025</td><td>3</td><td>Hammersmith 4</td><td>Hendon 4</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 11 Sep 2025</td><td>2</td><td>Hendon 2</td><td>Hendon 3</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 11 Sep 2025</td><td>1</td><td>Metropolitan 1</td><td>Hendon 1</td><td>Metropolitan Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 11 Sep 2025</td><td>2</td><td>Hendon 2</td><td>Hendon 3</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 18 Sep 2025</td><td>3</td><td>Hendon 4</td><td>Hammersmith 3</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 25 Sep 2025</td><td>2</td><td>Hendon 3</td><td>Hendon 2</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 25 Sep 2025</td><td>3</td><td>Hendon 5</td><td>Ealing 2</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
@@ -69,9 +69,9 @@
 <tr><td>Thu 11 Dec 2025</td><td>2</td><td>Hendon 2</td><td>Harrow 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 11 Dec 2025</td><td>3</td><td>Hendon 4</td><td>Hendon 5</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 18 Dec 2025</td><td>2</td><td>Hendon 3</td><td>Harrow 2</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 25 Dec 2025</td><td>3</td><td>Hammersmith 3</td><td>Hendon 5</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 25 Dec 2025</td><td>2</td><td>Harrow 1</td><td>Hendon 2</td><td>Harrow Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 25 Dec 2025</td><td>1</td><td>Hendon 1</td><td>Albany 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 25 Dec 2025</td><td>2</td><td>Harrow 1</td><td>Hendon 2</td><td>Harrow Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 25 Dec 2025</td><td>3</td><td>Hammersmith 3</td><td>Hendon 5</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 08 Jan 2026</td><td>2</td><td>Hendon 2</td><td>Hammersmith 2</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 08 Jan 2026</td><td>2</td><td>Kings Head 2</td><td>Hendon 3</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Mon 12 Jan 2026</td><td>3</td><td>Ealing 2</td><td>Hendon 4</td><td>Ealing Sports Hall</td><td>19:30</td><td>75+15</td></tr>
@@ -95,16 +95,16 @@
 <tr><td>Tue 10 Mar 2026</td><td>2</td><td>Muswell Hill 2</td><td>Hendon 3</td><td>Muswell Hill Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 12 Mar 2026</td><td>2</td><td>Hendon 2</td><td>Willesden &amp; Brent 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Mon 16 Mar 2026</td><td>3</td><td>Potters Bar 1</td><td>Hendon 5</td><td>Potters Bar Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 19 Mar 2026</td><td>2</td><td>Harrow 2</td><td>Hendon 3</td><td>Harrow Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 19 Mar 2026</td><td>1</td><td>Hendon 1</td><td>Muswell Hill 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 19 Mar 2026</td><td>2</td><td>Harrow 2</td><td>Hendon 3</td><td>Harrow Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 26 Mar 2026</td><td>2</td><td>Kings Head 2</td><td>Hendon 2</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 26 Mar 2026</td><td>3</td><td>Hendon 4</td><td>Hammersmith 4</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 26 Mar 2026</td><td>3</td><td>Hendon 5</td><td>Hackney 2</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 26 Mar 2026</td><td>2</td><td>Kings Head 2</td><td>Hendon 2</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 08 Apr 2026</td><td>3</td><td>Hackney 2</td><td>Hendon 4</td><td>Hackney Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 09 Apr 2026</td><td>3</td><td>Kings Head 3</td><td>Hendon 5</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 16 Apr 2026</td><td>1</td><td>Hendon 1</td><td>West London 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 16 Apr 2026</td><td>2</td><td>Hammersmith 2</td><td>Hendon 2</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 16 Apr 2026</td><td>3</td><td>Hammersmith 3</td><td>Hendon 4</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 16 Apr 2026</td><td>1</td><td>Hendon 1</td><td>West London 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Tue 28 Apr 2026</td><td>1</td><td>Muswell Hill 1</td><td>Hendon 1</td><td>Muswell Hill Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Wed 29 Apr 2026</td><td>2</td><td>Willesden &amp; Brent 1</td><td>Hendon 3</td><td>Willesden &amp; Brent Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 30 Apr 2026</td><td>2</td><td>Hendon 2</td><td>Ealing 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>

--- a/runs/example/club-kings-head.html
+++ b/runs/example/club-kings-head.html
@@ -49,14 +49,14 @@
 <tr><td>Thu 11 Sep 2025</td><td>3</td><td>Kings Head 3</td><td>Hackney 2</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 18 Sep 2025</td><td>1</td><td>Kings Head 1</td><td>West London 1</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 18 Sep 2025</td><td>2</td><td>Kings Head 2</td><td>Willesden &amp; Brent 1</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 09 Oct 2025</td><td>3</td><td>Hammersmith 3</td><td>Kings Head 3</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 09 Oct 2025</td><td>1</td><td>Kings Head 1</td><td>Hackney 1</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 09 Oct 2025</td><td>3</td><td>Hammersmith 3</td><td>Kings Head 3</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 16 Oct 2025</td><td>2</td><td>Kings Head 2</td><td>Harrow 1</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 30 Oct 2025</td><td>2</td><td>Hammersmith 2</td><td>Kings Head 2</td><td>Hammersmith Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Mon 03 Nov 2025</td><td>3</td><td>Potters Bar 1</td><td>Kings Head 3</td><td>Potters Bar Sports Hall</td><td>19:30</td><td>75+15</td></tr>
+<tr><td>Thu 13 Nov 2025</td><td>1</td><td>Metropolitan 1</td><td>Kings Head 1</td><td>Metropolitan Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 13 Nov 2025</td><td>2</td><td>Harrow 1</td><td>Kings Head 2</td><td>Harrow Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 13 Nov 2025</td><td>3</td><td>Hendon 4</td><td>Kings Head 3</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
-<tr><td>Thu 13 Nov 2025</td><td>1</td><td>Metropolitan 1</td><td>Kings Head 1</td><td>Metropolitan Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Tue 25 Nov 2025</td><td>2</td><td>Muswell Hill 2</td><td>Kings Head 2</td><td>Muswell Hill Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 27 Nov 2025</td><td>1</td><td>Hendon 1</td><td>Kings Head 1</td><td>Hendon Sports Hall</td><td>19:30</td><td>75+15</td></tr>
 <tr><td>Thu 04 Dec 2025</td><td>2</td><td>Kings Head 2</td><td>Harrow 2</td><td>Kings Head Sports Hall</td><td>19:30</td><td>75+15</td></tr>


### PR DESCRIPTION
After date and division, break ties using club and team index: home club/index then away club/index for tables listing both teams, or opponent club/index for per-team tables where the team itself is implicit. Also regenerate the example run's HTML to reflect the new ordering.