### PR TITLE
Allow unavailable_home_dates entries not yet in a club's home_dates

### DIFF
--- a/fixturespec.py
+++ b/fixturespec.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import collections
 import dataclasses
 import itertools
+import logging
 from collections.abc import Mapping
 from datetime import date, datetime
 from pathlib import Path
@@ -31,6 +32,8 @@ from typing import Any
 import yaml
 
 import fmodel
+
+logger = logging.getLogger(__name__)
 
 
 class SpecError(ValueError):
@@ -468,12 +471,16 @@ def _parse_club_team_constraints(
     Home dates are always specified at the club level; per-team variations are
     supported only via exclusions.
 
-    A team's unavailable_home_dates entry, if given, lists dates from the club's own
-    home_dates on which that team specifically can't host (e.g. its venue slot is
-    taken by another of the club's teams); the team's effective home dates are the
-    club's home_dates minus these, and every entry must be one of the club's
-    home_dates. A team's unavailable_away_dates entry, if given, is additional to its
-    club's unavailable_away_dates (not instead of it).
+    A team's unavailable_home_dates entry, if given, lists dates on which that team
+    specifically can't host (e.g. its venue slot is taken by another of the club's
+    teams); the team's effective home dates are the club's home_dates minus these.
+    An entry not currently in the club's home_dates (e.g. a date commented out and
+    held in reserve) has no effect yet but isn't an error -- this lets a team's
+    unavailability be recorded ahead of that date being added to (or uncommented
+    from) home_dates later, without needing to remember to add it then; a warning is
+    logged so the mismatch isn't silently missed. A team's unavailable_away_dates
+    entry, if given, is additional to its club's unavailable_away_dates (not instead
+    of it).
     """
     if not isinstance(teams_spec, dict):
         raise SpecError(f"{context} must be a mapping")
@@ -504,12 +511,15 @@ def _parse_club_team_constraints(
                 team_spec["unavailable_home_dates"],
                 f"{team_context}.unavailable_home_dates",
             )
-            invalid = [d for d in excluded if d not in club_home_dates]
-            if invalid:
-                raise SpecError(
-                    f"{team_context}.unavailable_home_dates: "
-                    f"{[d.isoformat() for d in invalid]} not in {club_id!r}'s "
-                    "home_dates"
+            not_yet_active = [d for d in excluded if d not in club_home_dates]
+            if not_yet_active:
+                logger.warning(
+                    "%s.unavailable_home_dates: %s not currently in %r's "
+                    "home_dates (ok if held in reserve there; has no effect "
+                    "until it is)",
+                    team_context,
+                    [d.isoformat() for d in not_yet_active],
+                    club_id,
                 )
             excluded_set = set(excluded)
             team_home_dates[team] = [

--- a/fixturespec_test.py
+++ b/fixturespec_test.py
@@ -834,7 +834,13 @@ club_constraints:
             spec.parameters.team_home_dates, {albany_1: [date(2025, 9, 1)]}
         )
 
-    def test_team_constraints_unavailable_home_dates_must_be_subset_of_clubs(self):
+    def test_team_constraints_unavailable_home_dates_not_yet_in_clubs_logs_warning(
+        self,
+    ):
+        """An unavailable_home_dates entry not currently in the club's home_dates
+        (e.g. a date held in reserve, commented out) is accepted rather than
+        rejected -- it just has no effect yet -- but logs a warning so the mismatch
+        isn't silently missed."""
         path = self._write(
             self._with_albany_teams(
                 "    teams:\n      albany-1:\n"
@@ -842,8 +848,18 @@ club_constraints:
                 "        unavailable_home_dates: [2025-09-16]\n"
             )
         )
-        with self.assertRaisesRegex(fixturespec.SpecError, "home_dates"):
-            fixturespec.load_spec(path)
+        with self.assertLogs("fixturespec", level="WARNING") as logs:
+            spec = fixturespec.load_spec(path)
+        self.assertIn("2025-09-16", logs.output[0])
+        self.assertIn("albany", logs.output[0])
+        albany_1 = next(t for t in spec.parameters.teams if t.club == "albany")
+        # The exclusion has no effect since 2025-09-16 isn't one of albany's
+        # home_dates in the first place: albany-1's effective home dates are just
+        # albany's full home_dates list, unchanged.
+        self.assertEqual(
+            spec.parameters.team_home_dates,
+            {albany_1: [date(2025, 9, 1), date(2025, 9, 29)]},
+        )
 
     def test_team_constraints_unavailable_away_dates_additive(self):
         path = self._write(

--- a/spec-schema.json
+++ b/spec-schema.json
@@ -235,7 +235,7 @@
       "properties": {
         "unavailable_home_dates": {
           "type": "array",
-          "description": "Excludes these dates from this club's own 'home_dates', for this team only. Each entry must be one of the club's own home_dates.",
+          "description": "Excludes these dates from this club's own 'home_dates', for this team only. An entry that isn't currently one of the club's own home_dates (e.g. a date held in reserve, commented out) is allowed -- it just has no effect until that date is added -- though fixturespec.py logs a warning for it.",
           "items": { "$ref": "#/$defs/date" },
           "uniqueItems": true
         },


### PR DESCRIPTION
Previously fixturespec.py rejected a team's unavailable_home_dates entry if it wasn't already one of the club's home_dates. This made it impossible to record a team's unavailability against a reserve date (kept commented out until needed) ahead of time -- the entry would have to be added later, when the reserve date itself is activated, with a risk of it being forgotten. Log a warning instead and treat the entry as a no-op until the date is actually added.