### PR TITLE
Add hyperlink to OR-Tools in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ## Introduction
 
-This repo generates Middlesex League fixture schedules using an OR-Tools
-constraint solver.
+This repo generates Middlesex League fixture schedules using an [OR-Tools
+constraint solver](https://developers.google.com/optimization/cp).
 
 ## Setup
 


### PR DESCRIPTION
Updated README to include a hyperlink for OR-Tools constraint solver.