### PR TITLE
Add applies_to scope to avoid_coscheduling_teams

### DIFF
--- a/fixturespec.py
+++ b/fixturespec.py
@@ -301,7 +301,7 @@ _CLUB_CONSTRAINT_FIELD_KEYS = {
 
 _TEAM_CONSTRAINT_FIELD_KEYS = {"unavailable_home_dates", "unavailable_away_dates"}
 
-_AVOID_COSCHEDULING_FIELD_KEYS = {"teams", "within_days"}
+_AVOID_COSCHEDULING_FIELD_KEYS = {"teams", "within_days", "applies_to"}
 
 # Constraint types with a notion of a default, overridable per club. Other constraint
 # types (home_dates, unavailable_away_dates, max_home_dates_used, teams,
@@ -544,10 +544,11 @@ def _parse_avoid_coscheduling_teams(
     """Parse a club_constraints entry's optional 'avoid_coscheduling_teams' list.
 
     Each entry names a group of that club's own teams (all of which must belong to
-    this club) and an optional 'within_days' window (default 0, i.e. the same date):
-    the solver then allows at most one match involving any of those teams within any
-    window of that many days -- e.g. two teams that share players shouldn't both be
-    fielded on the same date.
+    this club), an optional 'within_days' window (default 0, i.e. the same date), and
+    an optional 'applies_to' scope ('home', 'away' or the default 'both'): the solver
+    then allows at most one match involving any of those teams -- counting only the
+    matches of the kind named by 'applies_to' -- within any window of that many days,
+    e.g. two teams that share players shouldn't both be fielded on the same date.
     """
     if entries_spec is None:
         return []
@@ -598,9 +599,20 @@ def _parse_avoid_coscheduling_teams(
             if within_days < 0:
                 raise SpecError(f"{entry_context}.within_days must be >= 0")
 
+        applies_to = fmodel.CoschedulingScope.BOTH
+        if "applies_to" in entry:
+            try:
+                applies_to = fmodel.CoschedulingScope(entry["applies_to"])
+            except ValueError:
+                allowed = ", ".join(repr(s.value) for s in fmodel.CoschedulingScope)
+                raise SpecError(
+                    f"{entry_context}.applies_to must be one of {allowed}, got "
+                    f"{entry['applies_to']!r}"
+                ) from None
+
         constraints.append(
             fmodel.AvoidCoschedulingConstraint(
-                teams=entry_teams, within_days=within_days
+                teams=entry_teams, within_days=within_days, applies_to=applies_to
             )
         )
 

--- a/fixturespec_test.py
+++ b/fixturespec_test.py
@@ -989,6 +989,39 @@ club_constraints:
         constraints = list(spec.parameters.avoid_coscheduling_teams)
         self.assertEqual(constraints[0].within_days, 3)
 
+    def test_avoid_coscheduling_teams_applies_to_defaults_to_both(self):
+        path = self._write(
+            self._with_albany_avoid_coscheduling(
+                "    avoid_coscheduling_teams:\n      - teams: [albany-1, albany-2]\n"
+            )
+        )
+        spec = fixturespec.load_spec(path)
+        constraints = list(spec.parameters.avoid_coscheduling_teams)
+        self.assertEqual(constraints[0].applies_to, fmodel.CoschedulingScope.BOTH)
+
+    def test_avoid_coscheduling_teams_applies_to_parsed(self):
+        path = self._write(
+            self._with_albany_avoid_coscheduling(
+                "    avoid_coscheduling_teams:\n"
+                "      - teams: [albany-1, albany-2]\n"
+                "        applies_to: away\n"
+            )
+        )
+        spec = fixturespec.load_spec(path)
+        constraints = list(spec.parameters.avoid_coscheduling_teams)
+        self.assertEqual(constraints[0].applies_to, fmodel.CoschedulingScope.AWAY)
+
+    def test_avoid_coscheduling_teams_invalid_applies_to_rejected(self):
+        path = self._write(
+            self._with_albany_avoid_coscheduling(
+                "    avoid_coscheduling_teams:\n"
+                "      - teams: [albany-1, albany-2]\n"
+                "        applies_to: sometimes\n"
+            )
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "applies_to"):
+            fixturespec.load_spec(path)
+
     def test_avoid_coscheduling_teams_not_a_list(self):
         path = self._write(
             self._with_albany_avoid_coscheduling("    avoid_coscheduling_teams: {}\n")

--- a/fmodel.py
+++ b/fmodel.py
@@ -16,6 +16,7 @@
 
 import collections
 import dataclasses
+import enum
 import functools
 import itertools
 import logging
@@ -90,16 +91,32 @@ class MaxConcurrentHomeMatches:
         return self.overrides.get(d, self.default)
 
 
+class CoschedulingScope(enum.Enum):
+    """Which of an AvoidCoschedulingConstraint's teams' matches are counted towards
+    its limit: only their home matches, only their away matches, or both."""
+
+    HOME = "home"
+    AWAY = "away"
+    BOTH = "both"
+
+
 @dataclasses.dataclass(frozen=True)
 class AvoidCoschedulingConstraint:
     """At most one match involving any of `teams` may be scheduled within any window
     of `within_days` days -- e.g. within_days=0 (the default) means no two of them
     may share a date. Typically used for a club's own teams that draw from the same
     pool of players (e.g. adjacent-division teams), but not restricted to that.
+
+    `applies_to` narrows which of those teams' matches count: CoschedulingScope.HOME
+    only their home matches, CoschedulingScope.AWAY only their away matches,
+    CoschedulingScope.BOTH (the default) every match they play. So an AWAY constraint
+    keeps the teams' away fixtures on separate dates while still allowing one to play
+    away on a night another is hosting.
     """
 
     teams: Collection[Team]
     within_days: int = 0
+    applies_to: CoschedulingScope = CoschedulingScope.BOTH
 
 
 def _check_no_duplicate_teams(teams: Collection[Team]) -> None:
@@ -242,26 +259,36 @@ def _add_max_home_dates_used_constraints(
 def _add_avoid_coscheduling_constraints(
     model: cp_model.CpModel,
     constraints: Collection[AvoidCoschedulingConstraint],
-    vars_by_team_date: Mapping[Team, Mapping[date, list[cp_model.IntVar]]],
+    vars_by_fixture_date: Mapping[tuple[Fixture, date], cp_model.IntVar],
 ) -> None:
     """For each AvoidCoschedulingConstraint, ensure at most one match involving any
-    of its teams is scheduled within any window of within_days days.
+    of its teams is scheduled within any window of within_days days. The constraint's
+    `applies_to` scope limits which of those teams' matches are counted -- home only,
+    away only, or (by default) both.
     """
     for constraint in constraints:
-        # vars_by_team_date stores the same variable for both the home and away
-        # team of a fixture, so a match between two teams that are both in
-        # `constraint.teams` would be combined twice; key by id(var) per date to
-        # avoid double-counting it.
-        vars_by_date: MutableMapping[date, dict[int, cp_model.IntVar]] = (
-            collections.defaultdict(dict)
+        team_set = set(constraint.teams)
+        count_home = constraint.applies_to in (
+            CoschedulingScope.HOME,
+            CoschedulingScope.BOTH,
         )
-        for team in constraint.teams:
-            for d, team_vars in vars_by_team_date.get(team, {}).items():
-                for var in team_vars:
-                    vars_by_date[d][id(var)] = var
+        count_away = constraint.applies_to in (
+            CoschedulingScope.AWAY,
+            CoschedulingScope.BOTH,
+        )
+        # Each (fixture, date) maps to a single variable, visited once here, so a
+        # match between two teams both in `constraint.teams` is counted once.
+        vars_by_date: MutableMapping[date, list[cp_model.IntVar]] = (
+            collections.defaultdict(list)
+        )
+        for (fixture, d), var in vars_by_fixture_date.items():
+            if (count_home and fixture.home_team in team_set) or (
+                count_away and fixture.away_team in team_set
+            ):
+                vars_by_date[d].append(var)
 
         for window in date_windows(vars_by_date.keys(), constraint.within_days):
-            window_vars = [v for d in window for v in vars_by_date[d].values()]
+            window_vars = [v for d in window for v in vars_by_date[d]]
             if len(window_vars) > 1:
                 model.add(cp_model.LinearExpr.Sum(window_vars) <= 1)
 
@@ -370,7 +397,7 @@ def solve(params: Parameters) -> Collection[ScheduledFixture]:
         model, params.max_home_dates_used, vars_by_club_home_date
     )
     _add_avoid_coscheduling_constraints(
-        model, params.avoid_coscheduling_teams, vars_by_team_date
+        model, params.avoid_coscheduling_teams, vars_by_fixture_date
     )
     _add_fixed_fixtures_constraints(model, params.fixed_fixtures, vars_by_fixture_date)
 

--- a/model_test.py
+++ b/model_test.py
@@ -841,6 +841,14 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
             fmodel.AvoidCoschedulingConstraint(teams=[a1, a2]).within_days, 0
         )
 
+    def test_applies_to_defaults_to_both(self):
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        a2 = fmodel.Team(division=2, club="A", index=2)
+        self.assertEqual(
+            fmodel.AvoidCoschedulingConstraint(teams=[a1, a2]).applies_to,
+            fmodel.CoschedulingScope.BOTH,
+        )
+
     def test_forces_different_dates_for_constrained_teams(self):
         """A1 and A2 are in different divisions (so have no fixture between them
         directly forcing a gap) and could otherwise both be scheduled at home on the
@@ -992,6 +1000,125 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
                 )
             ],
         )
+
+    def test_applies_to_away_allows_shared_home_date(self):
+        """With applies_to=AWAY the constraint ignores home matches: A1 and A2 may
+        both host on A's single home date (which BOTH would forbid -- cf
+        test_infeasible_when_only_one_shared_date_available), while X's two dates keep
+        their away legs apart."""
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        a2 = fmodel.Team(division=2, club="A", index=2)
+        x1 = fmodel.Team(division=1, club="X", index=1)
+        x2 = fmodel.Team(division=2, club="X", index=2)
+        params = fmodel.Parameters(
+            teams=[a1, a2, x1, x2],
+            home_dates={
+                "A": [date(2025, 1, 1)],
+                "X": [date(2025, 3, 1), date(2025, 3, 8)],
+            },
+            unavailable_away_dates={"A": [], "X": []},
+            max_concurrent_home_matches={
+                "A": fmodel.MaxConcurrentHomeMatches(default=2),
+                "X": fmodel.MaxConcurrentHomeMatches(default=2),
+            },
+            min_gap_days=7,
+            avoid_coscheduling_teams=[
+                fmodel.AvoidCoschedulingConstraint(
+                    teams=[a1, a2], applies_to=fmodel.CoschedulingScope.AWAY
+                )
+            ],
+        )
+        fixtures = list(fmodel.solve(params))
+        a1_home_date = next(sf.date for sf in fixtures if sf.fixture.home_team == a1)
+        a2_home_date = next(sf.date for sf in fixtures if sf.fixture.home_team == a2)
+        self.assertEqual(a1_home_date, a2_home_date)
+
+    def test_applies_to_away_still_separates_away_legs(self):
+        """applies_to=AWAY still constrains away matches: with only one X home date,
+        A1 and A2 can't both play their away leg there."""
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        a2 = fmodel.Team(division=2, club="A", index=2)
+        x1 = fmodel.Team(division=1, club="X", index=1)
+        x2 = fmodel.Team(division=2, club="X", index=2)
+        params = fmodel.Parameters(
+            teams=[a1, a2, x1, x2],
+            home_dates={
+                "A": [date(2025, 1, 1), date(2025, 1, 8)],
+                "X": [date(2025, 3, 1)],
+            },
+            unavailable_away_dates={"A": [], "X": []},
+            max_concurrent_home_matches={
+                "A": fmodel.MaxConcurrentHomeMatches(default=2),
+                "X": fmodel.MaxConcurrentHomeMatches(default=2),
+            },
+            min_gap_days=7,
+            avoid_coscheduling_teams=[
+                fmodel.AvoidCoschedulingConstraint(
+                    teams=[a1, a2], applies_to=fmodel.CoschedulingScope.AWAY
+                )
+            ],
+        )
+        with self.assertRaises(ValueError):
+            fmodel.solve(params)
+
+    def test_applies_to_home_ignores_away_collision(self):
+        """With applies_to=HOME the constraint ignores away matches: A1 and A2 may
+        both play their away leg on X's single home date, while A's two dates keep
+        their home legs apart."""
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        a2 = fmodel.Team(division=2, club="A", index=2)
+        x1 = fmodel.Team(division=1, club="X", index=1)
+        x2 = fmodel.Team(division=2, club="X", index=2)
+        params = fmodel.Parameters(
+            teams=[a1, a2, x1, x2],
+            home_dates={
+                "A": [date(2025, 1, 1), date(2025, 1, 8)],
+                "X": [date(2025, 3, 1)],
+            },
+            unavailable_away_dates={"A": [], "X": []},
+            max_concurrent_home_matches={
+                "A": fmodel.MaxConcurrentHomeMatches(default=2),
+                "X": fmodel.MaxConcurrentHomeMatches(default=2),
+            },
+            min_gap_days=7,
+            avoid_coscheduling_teams=[
+                fmodel.AvoidCoschedulingConstraint(
+                    teams=[a1, a2], applies_to=fmodel.CoschedulingScope.HOME
+                )
+            ],
+        )
+        fixtures = list(fmodel.solve(params))
+        a1_away_date = next(sf.date for sf in fixtures if sf.fixture.away_team == a1)
+        a2_away_date = next(sf.date for sf in fixtures if sf.fixture.away_team == a2)
+        self.assertEqual(a1_away_date, a2_away_date)
+
+    def test_applies_to_home_still_separates_home_legs(self):
+        """applies_to=HOME still constrains home matches: with only one A home date,
+        A1 and A2 can't both host there."""
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        a2 = fmodel.Team(division=2, club="A", index=2)
+        x1 = fmodel.Team(division=1, club="X", index=1)
+        x2 = fmodel.Team(division=2, club="X", index=2)
+        params = fmodel.Parameters(
+            teams=[a1, a2, x1, x2],
+            home_dates={
+                "A": [date(2025, 1, 1)],
+                "X": [date(2025, 3, 1), date(2025, 3, 8)],
+            },
+            unavailable_away_dates={"A": [], "X": []},
+            max_concurrent_home_matches={
+                "A": fmodel.MaxConcurrentHomeMatches(default=2),
+                "X": fmodel.MaxConcurrentHomeMatches(default=2),
+            },
+            min_gap_days=7,
+            avoid_coscheduling_teams=[
+                fmodel.AvoidCoschedulingConstraint(
+                    teams=[a1, a2], applies_to=fmodel.CoschedulingScope.HOME
+                )
+            ],
+        )
+        with self.assertRaises(ValueError):
+            fmodel.solve(params)
 
 
 class TestMaxConcurrentHomeMatchesUnlimited(unittest.TestCase):

--- a/spec-schema.json
+++ b/spec-schema.json
@@ -264,6 +264,12 @@
           "default": 0,
           "minimum": 0,
           "description": "The solver allows at most one match involving any of 'teams' -- home or away -- within any window of this many days. The default, 0, means no two of them may share a date at all; a higher value also keeps them some number of days apart."
+        },
+        "applies_to": {
+          "type": "string",
+          "enum": ["home", "away", "both"],
+          "default": "both",
+          "description": "Which of the listed teams' matches the limit counts: 'home' only their home matches, 'away' only their away matches, or 'both' (the default) every match they play. E.g. 'away' keeps these teams' away fixtures on separate dates while still allowing one to play away on a night another is hosting."
         }
       }
     },

--- a/spec_schema_test.py
+++ b/spec_schema_test.py
@@ -96,6 +96,7 @@ club_constraints:
     avoid_coscheduling_teams:
       - teams: [hackney-1, hackney-5]
         within_days: 0
+        applies_to: away
 
 fixed_fixtures:
   - home: albany-1


### PR DESCRIPTION
avoid_coscheduling_teams entries gain an optional applies_to field ("home", "away" or the default "both") controlling which of the listed teams' matches count towards the "at most one within within_days" limit. "away" keeps the teams' away fixtures on separate dates while still allowing one to play away on a night another is hosting; "home" is the mirror; "both" preserves the previous behaviour.

_add_avoid_coscheduling_constraints now works from vars_by_fixture_date so it can see each fixture's home/away roles and filter by scope; this also replaces the old id(var) de-duplication, since each (fixture, date) variable is now visited exactly once.


Claude-Session: https://claude.ai/code/session_019XwvHfg73kTk5vVrxhfR8f