### PR TITLE
Generate the whole site directly into _site/ (closes #51)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,18 +31,11 @@ jobs:
       - name: Install dependencies
         run: uv sync --dev --locked
 
-      - name: Rebuild all run HTML (report and index pages)
+      - name: Build run HTML into _site (report and index pages)
         run: uv run python3 build_html.py
 
-      - name: Rebuild schema reference page
+      - name: Build schema reference page into _site
         run: uv run python3 build_schema_docs.py
-
-      - name: Assemble site
-        run: |
-          mkdir -p _site
-          cp index.html _site/index.html
-          cp -r schema-docs _site/schema-docs
-          if [ -d runs ]; then cp -r runs _site/runs; fi
 
       - name: Upload pages artifact
         uses: actions/upload-pages-artifact@v5

--- a/.gitignore
+++ b/.gitignore
@@ -8,16 +8,10 @@ dist/
 wheels/
 *.egg-info
 
-# Every HTML page under runs/, and the top-level index.html, is fully derived
-# from the committed spec.yaml + solution.yaml of each run (the report pages via
-# report.py / build_reports.py, the index pages via build_indexes.py on top of
-# those), and is regenerated on demand and at Pages deploy time, so none of it
-# needs to be committed.
-/index.html
-runs/**/*.html
-
-# The schema reference page (and whatever support files json-schema-for-humans
-# copies alongside it) is fully derived from spec-schema.json and is rebuilt
-# on demand (build_schema_docs.py) and at Pages deploy time, so none of it
-# needs to be committed.
-/schema-docs/
+# The published site is assembled entirely under _site/ -- the run reports and
+# top-level index by build_html.py, the schema reference page by
+# build_schema_docs.py -- from the committed spec.yaml + solution.yaml of each
+# run under runs/ and from spec-schema.json. It's a build artifact, regenerated
+# on demand and at Pages deploy time (see .github/workflows/pages.yml), so none
+# of it needs to be committed.
+/_site/

--- a/README.md
+++ b/README.md
@@ -23,24 +23,23 @@ contexts, since the venv already exists once `uv sync --dev` has been run.
 ## New run setup
 
 Describe the clubs, teams, divisions and constraints in a YAML specification
-file named `spec.yaml`, placed inside the run folder you want its output
-written to (e.g. `runs/2025-26-season/spec.yaml`), then run the solver against
-it, followed by the report generator:
+file named `spec.yaml`, placed inside the run folder you want it published
+under (e.g. `runs/2025-26-season/spec.yaml`), then solve it:
 
 ```bash
 python solve.py runs/2025-26-season/spec.yaml
-python report.py runs/2025-26-season/spec.yaml runs/2025-26-season/solution.yaml runs/2025-26-season
 ```
 
-This solves the fixtures and writes the HTML report alongside the spec in
-`runs/2025-26-season/`. Re-running both overwrites the previous solution and
-report in place, so it's safe to rerun after editing the spec.
+This writes `solution.yaml` next to the spec. Re-running overwrites it in
+place, so it's safe to rerun after editing the spec.
 
-Only `spec.yaml` and `solution.yaml` need committing: the HTML report is a
-build artifact, regenerated from that pair on every GitHub Pages deploy (and
-gitignored) -- see "Publishing via GitHub Pages" below. The fixed `spec.yaml`
-name is what lets the deploy discover each run folder; running `report.py`
-by hand is only needed to preview report-formatting changes locally.
+Only `spec.yaml` and `solution.yaml` are committed: the HTML report is a build
+artifact, assembled from that pair under `_site/` on every GitHub Pages deploy
+(and gitignored) -- see "Publishing via GitHub Pages" below. The fixed
+`spec.yaml` name is what lets the deploy discover each run folder. To preview
+the report locally without deploying, run `build_html.py` (see that section);
+`report.py` renders a single run's pages into a directory you name, which is
+mainly useful when iterating on report formatting.
 
 `solve.py` runs the constraint solver and writes its result to a
 `solution.yaml` file (canonical, solver-independent) next to the spec,
@@ -50,7 +49,7 @@ original spec alongside it for club/venue/name and excluded-fixture details
 that aren't part of the solution itself. Keeping these as two separate steps
 (rather than one combined command) means the HTML report can be regenerated
 -- e.g. after a report formatting change -- without re-running the
-(comparatively slow) solver: just rerun `report.py` against the existing
+(comparatively slow) solver: just rerun the report build against the existing
 `solution.yaml`. It also keeps solve-only flags (e.g. `--earliest-match-date`,
 which excludes newly scheduled fixtures before a given date, defaulting to
 today) on `solve.py` alone, rather than needing to be added to a combined
@@ -115,8 +114,9 @@ fixtures, and more. For the full field-by-field reference, see:
   [`runs/example/spec.yaml`](runs/example/spec.yaml) for an example.
 - **[`runs/example/spec.yaml`](runs/example/spec.yaml)**, a full worked
   example; its `solution.yaml` sits alongside it in
-  [`runs/example/`](runs/example/), and its report renders into the same
-  folder (locally via `report.py`, and on every Pages deploy).
+  [`runs/example/`](runs/example/), and its report is built into
+  `_site/runs/example/` (locally via `build_html.py`, and on every Pages
+  deploy).
 
 New constraint types can be added to `fixturespec.py` and `fmodel.Parameters`
 as they're needed; `spec-schema.json` should be kept in step with them (a
@@ -136,11 +136,11 @@ fixtures:
     date: 2025-09-01
 ```
 
-It only makes sense alongside the spec it was solved from -- `report.py`
+It only makes sense alongside the spec it was solved from -- the report build
 resolves each entry's team IDs against that spec's `teams` to recover each
 team's division and display name.
 
-`report.py` then writes, into the run's folder:
+The report build writes, for each run, into `_site/runs/<run path>/`:
 
 - `all-matches.html` — every fixture (date, division, home, away, venue
   name, start time, time limit), followed by a list of the full venue
@@ -194,44 +194,34 @@ python genfixtures.py
 
 ### Publishing via GitHub Pages
 
-The root `index.html`, `schema-docs/spec-schema.html` (plus whatever support
-files `json-schema-for-humans` copies alongside it) and everything under
-`runs/` are plain static HTML, published from the `main` branch at
-<https://amdw.github.io/fixtures/> by `.github/workflows/pages.yml`. All of
-these are build artifacts, not source -- gitignored, and regenerated before
-every deploy from whatever `runs/*/` folders (each a committed `spec.yaml` +
-`solution.yaml` pair) and `spec-schema.json` are committed:
+The whole published site is assembled under `_site/` and published from the
+`main` branch at <https://amdw.github.io/fixtures/> by
+`.github/workflows/pages.yml`. Everything under `_site/` is a build artifact,
+not source -- gitignored, and regenerated before every deploy from whatever
+`runs/*/` folders (each a committed `spec.yaml` + `solution.yaml` pair) and
+`spec-schema.json` are committed:
 
-- `build_html.py` regenerates every HTML page under `runs/` -- the report
-  pages *and* the per-run and top-level index pages -- from each run folder's
-  `spec.yaml` + `solution.yaml`. It renders the report pages via `report.py`,
-  so it needs the same dependencies (`pyyaml`, and `ortools` via `fmodel`); it
-  does *not* re-run the (slow) solver.
-- `build_schema_docs.py` renders `spec-schema.json`; it needs
-  `json-schema-for-humans`.
+- `build_html.py` builds every run's report pages into
+  `_site/runs/<run path>/` -- the per-fixture pages *and* the per-run and
+  top-level index pages -- from each run folder's `spec.yaml` +
+  `solution.yaml`. It renders the report pages via `report.py`, so it needs the
+  same dependencies (`pyyaml`, and `ortools` via `fmodel`); it does *not*
+  re-run the (slow) solver.
+- `build_schema_docs.py` renders `spec-schema.json` into
+  `_site/schema-docs/`; it needs `json-schema-for-humans`.
 
-The workflow installs the dev dependencies first, so both can run. Run them
-locally any time you want to preview without a full deploy:
+Both write straight into `_site/`, so the workflow uploads that directory
+as-is -- there's no separate copy/assemble step. It installs the dev
+dependencies first, so both scripts can run. Run them locally any time you
+want a preview that exactly matches what gets deployed:
 
 ```bash
 uv run python3 build_html.py
 uv run python3 build_schema_docs.py
-python -m http.server
-```
-
-Open <http://localhost:8000/> — it's the same files the Pages workflow
-deploys (the rest of the repo is visible too, but harmless; the workflow just
-doesn't copy it into the deployed site). For a preview that's an exact match
-of what gets deployed, replicate the workflow's "Assemble site" step first
-and serve that instead:
-
-```bash
-mkdir -p _site
-cp index.html _site/index.html
-cp -r schema-docs _site/schema-docs
-cp -r runs _site/runs
 python -m http.server --directory _site
 ```
+
+Open <http://localhost:8000/>.
 
 ## License
 

--- a/build_html.py
+++ b/build_html.py
@@ -12,14 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Regenerate every HTML page under runs/ from the committed spec + solution.yaml.
+"""Assemble the published site under _site/ from each run's committed spec + solution.
 
 For each directory anywhere under runs/ that holds both a spec.yaml and a
-solution.yaml, this re-renders the report pages (all-matches.html,
-division-<n>.html, club-<id>.html and the run's index.html); it then rebuilds the
-top-level runs index.html. That's the complete set of HTML the Pages deploy
-serves from runs/ (plus the root index.html), so none of it needs to be
-committed. See .github/workflows/pages.yml, which runs this before every deploy.
+solution.yaml, this renders that run's report pages (all-matches.html,
+division-<n>.html, club-<id>.html and the run's index.html) into the matching
+path under _site/runs/; it then writes the top-level _site/index.html linking
+them all. Together with the schema reference page (build_schema_docs.py writes it
+into the same _site/), that's the entire site the Pages workflow deploys -- it
+just uploads _site/ as-is, with no copy step -- so nothing under _site/ needs to
+be committed. See .github/workflows/pages.yml, which runs this before every
+deploy.
 
 It renders the report pages from source via report.py, so it needs the same
 dependencies (pyyaml, and ortools via fmodel). It does *not* re-run the solver:
@@ -30,6 +33,7 @@ enough to run on every deploy.
 from __future__ import annotations
 
 import argparse
+import shutil
 from pathlib import Path
 
 import htmlreport
@@ -52,31 +56,45 @@ def find_run_specs(runs_dir: Path) -> list[Path]:
     )
 
 
+def build_site(runs_dir: Path, out_dir: Path) -> None:
+    """Render every run under runs_dir into out_dir/runs/, mirroring runs_dir's own
+    folder structure, then (re)write out_dir/index.html linking them all."""
+    out_runs_dir = out_dir / "runs"
+    # Rebuild the runs tree from scratch so a run removed from runs_dir doesn't
+    # linger in a local out_dir (CI always builds from a fresh checkout).
+    shutil.rmtree(out_runs_dir, ignore_errors=True)
+
+    run_dirs = find_run_specs(runs_dir)
+    for run_dir in run_dirs:
+        dest = out_runs_dir / run_dir.relative_to(runs_dir)
+        report.report(run_dir / SPEC_FILENAME, run_dir / SOLUTION_FILENAME, dest)
+        print(f"Rebuilt report for {run_dir} -> {dest}")
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    root_index = out_dir / "index.html"
+    htmlreport.write_runs_index(out_runs_dir, root_index)
+
+    print(f"Rebuilt {len(run_dirs)} run report(s) into {out_runs_dir}")
+    print(f"Rebuilt top-level index at {root_index}")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--runs-dir",
         type=Path,
         default=Path("runs"),
-        help="Directory containing one sub-folder per run (default: runs)",
+        help="Source directory containing one sub-folder per run (default: runs)",
     )
     parser.add_argument(
-        "--root-index",
+        "--out-dir",
         type=Path,
-        default=Path("index.html"),
-        help="Path of the top-level index.html to (re)generate (default: index.html)",
+        default=Path("_site"),
+        help="Directory to assemble the site into (default: _site)",
     )
     args = parser.parse_args()
 
-    run_dirs = find_run_specs(args.runs_dir)
-    for run_dir in run_dirs:
-        report.report(run_dir / SPEC_FILENAME, run_dir / SOLUTION_FILENAME, run_dir)
-        print(f"Rebuilt report for {run_dir}")
-
-    htmlreport.write_runs_index(args.runs_dir, args.root_index)
-
-    print(f"Rebuilt {len(run_dirs)} run report(s) under {args.runs_dir}")
-    print(f"Rebuilt top-level index at {args.root_index}")
+    build_site(args.runs_dir, args.out_dir)
 
 
 if __name__ == "__main__":

--- a/build_html_test.py
+++ b/build_html_test.py
@@ -14,6 +14,7 @@
 
 """Test cases for the HTML-rebuilding CLI used by the Pages workflow."""
 
+import shutil
 import tempfile
 import unittest
 from pathlib import Path
@@ -105,7 +106,8 @@ class TestBuildReports(unittest.TestCase):
         self.addCleanup(self._tmpdir.cleanup)
         self.root = Path(self._tmpdir.name)
         self.runs_dir = self.root / "runs"
-        self.root_index = self.root / "index.html"
+        self.out_dir = self.root / "_site"
+        self.root_index = self.out_dir / "index.html"
 
     def _run_cli(self) -> None:
         with patch(
@@ -114,8 +116,8 @@ class TestBuildReports(unittest.TestCase):
                 "build_html.py",
                 "--runs-dir",
                 str(self.runs_dir),
-                "--root-index",
-                str(self.root_index),
+                "--out-dir",
+                str(self.out_dir),
             ],
         ):
             build_html.main()
@@ -128,16 +130,44 @@ class TestBuildReports(unittest.TestCase):
 
         self._run_cli()
 
-        for run_dir in (flat, nested):
+        for rel in (Path("example"), Path("2026-27") / "draft1"):
+            out_run = self.out_dir / "runs" / rel
             for page in ("all-matches.html", "division-1.html", "index.html"):
                 self.assertTrue(
-                    (run_dir / page).exists(), f"{run_dir / page} not written"
+                    (out_run / page).exists(), f"{out_run / page} not written"
                 )
-        self.assertIn("Example Season", (flat / "all-matches.html").read_text())
+        self.assertIn(
+            "Example Season",
+            (self.out_dir / "runs" / "example" / "all-matches.html").read_text(),
+        )
 
         root = self.root_index.read_text()
         self.assertIn("runs/example/index.html", root)
         self.assertIn("runs/2026-27/draft1/index.html", root)
+
+    def test_writes_nothing_into_the_source_runs_dir(self):
+        _make_run(self.runs_dir / "example", "Example Season")
+
+        self._run_cli()
+
+        self.assertEqual(
+            list((self.runs_dir / "example").glob("*.html")),
+            [],
+            "build_html.py should not write HTML back into the source runs dir",
+        )
+
+    def test_drops_runs_removed_from_the_source(self):
+        _make_run(self.runs_dir / "keep", "Keep")
+        _make_run(self.runs_dir / "drop", "Drop")
+        self._run_cli()
+        self.assertTrue((self.out_dir / "runs" / "drop" / "index.html").exists())
+
+        shutil.rmtree(self.runs_dir / "drop")
+        self._run_cli()
+
+        self.assertFalse((self.out_dir / "runs" / "drop").exists())
+        self.assertTrue((self.out_dir / "runs" / "keep" / "index.html").exists())
+        self.assertNotIn("runs/drop/index.html", self.root_index.read_text())
 
     def test_does_not_re_solve(self):
         run_dir = self.runs_dir / "example"

--- a/build_schema_docs.py
+++ b/build_schema_docs.py
@@ -13,12 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Render spec-schema.json to a static HTML reference page.
+"""Render spec-schema.json to a static HTML reference page under _site/.
 
 This needs a third-party dependency (json-schema-for-humans), so
-.github/workflows/pages.yml installs the dev dependencies before running it. Run
-it locally with `uv run python3 build_schema_docs.py` any time you want to
-preview the reference page without going through a full Pages deploy.
+.github/workflows/pages.yml installs the dev dependencies before running it. It
+writes straight into _site/ (alongside the run reports built by build_html.py),
+which the Pages workflow uploads as-is. Run it locally with `uv run python3
+build_schema_docs.py` any time you want to preview the reference page without
+going through a full Pages deploy.
 """
 
 from __future__ import annotations
@@ -41,8 +43,8 @@ def main() -> None:
     parser.add_argument(
         "--out",
         type=Path,
-        default=Path("schema-docs/spec-schema.html"),
-        help="Path of the HTML page to (re)generate (default: schema-docs/spec-schema.html)",
+        default=Path("_site/schema-docs/spec-schema.html"),
+        help="Path of the HTML page to (re)generate (default: _site/schema-docs/spec-schema.html)",
     )
     args = parser.parse_args()
 

--- a/report.py
+++ b/report.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Render a solution.yaml (as written by solve.py), plus its original spec (for
-team/club/exclusion metadata), as a set of HTML report pages.
+team/club/exclusion metadata), as a set of HTML report pages for one run.
 
 Usage:
     python report.py <spec.yaml> <solution.yaml> <output_dir>
@@ -21,6 +21,9 @@ Usage:
 This can be re-run at any time to regenerate the HTML report -- e.g. after
 changing report formatting -- without re-solving, as long as solution.yaml
 still matches the teams described in spec.yaml.
+
+It renders a single run's pages only. To (re)build the whole published site --
+every run's report plus the top-level index -- into _site/, run build_html.py.
 """
 
 from __future__ import annotations
@@ -62,25 +65,11 @@ def main() -> None:
     parser.add_argument(
         "output_dir", type=Path, help="Directory to write this run's HTML report into"
     )
-    parser.add_argument(
-        "--runs-dir",
-        type=Path,
-        default=Path("runs"),
-        help="Directory scanned to rebuild the top-level runs index (default: runs)",
-    )
-    parser.add_argument(
-        "--root-index",
-        type=Path,
-        default=Path("index.html"),
-        help="Path of the top-level index.html to (re)generate (default: index.html)",
-    )
     args = parser.parse_args()
 
     run_index_path = report(args.spec, args.solution, args.output_dir)
-    root_index_path = htmlreport.write_runs_index(args.runs_dir, args.root_index)
 
     print(f"Wrote run report to {run_index_path}")
-    print(f"Updated top-level index at {root_index_path}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
build_html.py and build_schema_docs.py now write their output straight into _site/ instead of in place under runs/ (plus the repo root and schema-docs/), so the Pages workflow uploads _site/ as-is with no copy/assemble step.

- build_html.py: new --out-dir (default _site); renders each run into _site/runs/<run path>/ and writes _site/index.html, rebuilding the runs tree from scratch each time so a run deleted from the source doesn't linger locally.
- build_schema_docs.py: default output moved under _site/.
- report.py main() now renders a single run's pages only; the top-level index rebuild (and its --runs-dir/--root-index flags) is gone, since build_html.py owns that and it would otherwise write an un-gitignored index.html.
- .gitignore: three stanzas collapsed to a single /_site/ entry.
- README: publishing section trimmed to match.


Claude-Session: https://claude.ai/code/session_01Q63QHQzrJfkMEFPvhBb4AT