### PR TITLE
Add CSV exports of each run's schedule (closes #52)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Install dependencies
         run: uv sync --dev --locked
 
-      - name: Build run HTML into _site (report and index pages)
-        run: uv run python3 build_html.py
+      - name: Build run reports into _site (HTML pages, CSV exports, index)
+        run: uv run python3 build_site.py
 
       - name: Build schema reference page into _site
         run: uv run python3 build_schema_docs.py

--- a/README.md
+++ b/README.md
@@ -33,23 +33,23 @@ python solve.py runs/2025-26-season/spec.yaml
 This writes `solution.yaml` next to the spec. Re-running overwrites it in
 place, so it's safe to rerun after editing the spec.
 
-Only `spec.yaml` and `solution.yaml` are committed: the HTML report is a build
-artifact, assembled from that pair under `_site/` on every GitHub Pages deploy
-(and gitignored) -- see "Publishing via GitHub Pages" below. The fixed
-`spec.yaml` name is what lets the deploy discover each run folder. To preview
-the report locally without deploying, run `build_html.py` (see that section);
-`report.py` renders a single run's pages into a directory you name, which is
-mainly useful when iterating on report formatting.
+Only `spec.yaml` and `solution.yaml` are committed: the report (HTML pages plus
+CSV exports) is a build artifact, assembled from that pair under `_site/` on
+every GitHub Pages deploy (and gitignored) -- see "Publishing via GitHub Pages"
+below. The fixed `spec.yaml` name is what lets the deploy discover each run
+folder. To preview the report locally without deploying, run `build_site.py`
+(see that section); `report.py` renders a single run's files into a directory
+you name, which is mainly useful when iterating on report formatting.
 
 `solve.py` runs the constraint solver and writes its result to a
 `solution.yaml` file (canonical, solver-independent) next to the spec,
 defaulting the output directory to the spec file's own directory.
-`report.py` turns a `solution.yaml` back into the HTML report, reading the
-original spec alongside it for club/venue/name and excluded-fixture details
-that aren't part of the solution itself. Keeping these as two separate steps
-(rather than one combined command) means the HTML report can be regenerated
--- e.g. after a report formatting change -- without re-running the
-(comparatively slow) solver: just rerun the report build against the existing
+`report.py` turns a `solution.yaml` back into the report (HTML and CSV),
+reading the original spec alongside it for club/venue/name and excluded-fixture
+details that aren't part of the solution itself. Keeping these as two separate
+steps (rather than one combined command) means the report can be regenerated
+-- e.g. after a formatting change -- without re-running the (comparatively
+slow) solver: just rerun the report build against the existing
 `solution.yaml`. It also keeps solve-only flags (e.g. `--earliest-match-date`,
 which excludes newly scheduled fixtures before a given date, defaulting to
 today) on `solve.py` alone, rather than needing to be added to a combined
@@ -115,7 +115,7 @@ fixtures, and more. For the full field-by-field reference, see:
 - **[`runs/example/spec.yaml`](runs/example/spec.yaml)**, a full worked
   example; its `solution.yaml` sits alongside it in
   [`runs/example/`](runs/example/), and its report is built into
-  `_site/runs/example/` (locally via `build_html.py`, and on every Pages
+  `_site/runs/example/` (locally via `build_site.py`, and on every Pages
   deploy).
 
 New constraint types can be added to `fixturespec.py` and `fmodel.Parameters`
@@ -150,17 +150,33 @@ The report build writes, for each run, into `_site/runs/<run path>/`:
 - `club-<id>.html` — one page per club, headed by that club's full venue
   name and address, with a consolidated table of all the club's matches
   followed by one table per team
-- `index.html` — links to all of the above
+- `all-matches.csv` — one row per match, `home_team` vs `away_team`, with
+  `date` (ISO `yyyy-mm-dd`), `division`, and the home club's `venue`,
+  `venue_address`, `start_time` and `time_limit`
+- `all-matches-by-team.csv` — two rows per match, one from each team's point
+  of view (`team`, `opponent`, `home_or_away`), so a club can filter its own
+  team's fixtures straight into a calendar
 
-None of these HTML pages are committed: they're all build artifacts, derived
-from `spec.yaml` + `solution.yaml` (the report pages) and from each other (the
-index pages), and regenerated on every GitHub Pages deploy -- see "Publishing
-via GitHub Pages" below.
+Each team appears as its display name, its club's name (`*_club`) and its
+index within that club (`*_index`), so the club and team number are available
+directly even when the display name is a `name_override`.
+- `index.html` — links to all of the above (the two CSV files are linked from
+  its "All matches" section)
+
+Both CSV files cover every division, and list withheld matches (a spec's
+`exclude_fixtures`) with an empty `date`, mirroring the HTML report's "TBC"
+rows.
+
+None of these files are committed: they're all build artifacts, derived from
+`spec.yaml` + `solution.yaml` (the report pages and CSV) and from each other
+(the index pages), and regenerated on every GitHub Pages deploy -- see
+"Publishing via GitHub Pages" below.
 
 Venue name (not the address), start time and time limit on each match are
-always the *home* team's club's values. If the spec sets `name`, every page
-shows it in a banner above the page title; if `draft: true` is also set,
-that banner is made prominent and prefixed "DRAFT".
+always the *home* team's club's values. If the spec sets `name`, every HTML
+page shows it in a banner above the page title; if `draft: true` is also set,
+that banner is made prominent and prefixed "DRAFT". (The CSV files carry the
+fixture data only, with no such banner.)
 
 ## Development
 
@@ -201,12 +217,11 @@ not source -- gitignored, and regenerated before every deploy from whatever
 `runs/*/` folders (each a committed `spec.yaml` + `solution.yaml` pair) and
 `spec-schema.json` are committed:
 
-- `build_html.py` builds every run's report pages into
-  `_site/runs/<run path>/` -- the per-fixture pages *and* the per-run and
-  top-level index pages -- from each run folder's `spec.yaml` +
-  `solution.yaml`. It renders the report pages via `report.py`, so it needs the
-  same dependencies (`pyyaml`, and `ortools` via `fmodel`); it does *not*
-  re-run the (slow) solver.
+- `build_site.py` builds every run's report into `_site/runs/<run path>/` --
+  the per-fixture HTML pages, the per-run and top-level index pages, *and* the
+  CSV exports -- from each run folder's `spec.yaml` + `solution.yaml`. It runs
+  `report.py` per run, so it needs the same dependencies (`pyyaml`, and
+  `ortools` via `fmodel`); it does *not* re-run the (slow) solver.
 - `build_schema_docs.py` renders `spec-schema.json` into
   `_site/schema-docs/`; it needs `json-schema-for-humans`.
 
@@ -216,7 +231,7 @@ dependencies first, so both scripts can run. Run them locally any time you
 want a preview that exactly matches what gets deployed:
 
 ```bash
-uv run python3 build_html.py
+uv run python3 build_site.py
 uv run python3 build_schema_docs.py
 python -m http.server --directory _site
 ```

--- a/build_schema_docs.py
+++ b/build_schema_docs.py
@@ -17,7 +17,7 @@
 
 This needs a third-party dependency (json-schema-for-humans), so
 .github/workflows/pages.yml installs the dev dependencies before running it. It
-writes straight into _site/ (alongside the run reports built by build_html.py),
+writes straight into _site/ (alongside the run reports built by build_site.py),
 which the Pages workflow uploads as-is. Run it locally with `uv run python3
 build_schema_docs.py` any time you want to preview the reference page without
 going through a full Pages deploy.

--- a/build_site.py
+++ b/build_site.py
@@ -15,18 +15,18 @@
 """Assemble the published site under _site/ from each run's committed spec + solution.
 
 For each directory anywhere under runs/ that holds both a spec.yaml and a
-solution.yaml, this renders that run's report pages (all-matches.html,
-division-<n>.html, club-<id>.html and the run's index.html) into the matching
-path under _site/runs/; it then writes the top-level _site/index.html linking
-them all. Together with the schema reference page (build_schema_docs.py writes it
-into the same _site/), that's the entire site the Pages workflow deploys -- it
-just uploads _site/ as-is, with no copy step -- so nothing under _site/ needs to
-be committed. See .github/workflows/pages.yml, which runs this before every
-deploy.
+solution.yaml, this renders that run's report files (all-matches.html,
+division-<n>.html, club-<id>.html, the run's index.html, and the all-matches.csv
+/ all-matches-by-team.csv exports) into the matching path under _site/runs/; it
+then writes the top-level _site/index.html linking them all. Together with the
+schema reference page (build_schema_docs.py writes it into the same _site/),
+that's the entire site the Pages workflow deploys -- it just uploads _site/
+as-is, with no copy step -- so nothing under _site/ needs to be committed. See
+.github/workflows/pages.yml, which runs this before every deploy.
 
-It renders the report pages from source via report.py, so it needs the same
+It renders each run from source via report.py, so it needs the same
 dependencies (pyyaml, and ortools via fmodel). It does *not* re-run the solver:
-it only turns each committed solution.yaml back into HTML, so it stays fast
+it only turns each committed solution.yaml back into a report, so it stays fast
 enough to run on every deploy.
 """
 

--- a/build_site_test.py
+++ b/build_site_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test cases for the HTML-rebuilding CLI used by the Pages workflow."""
+"""Test cases for the site-assembly CLI used by the Pages workflow."""
 
 import shutil
 import tempfile
@@ -20,7 +20,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-import build_html
+import build_site
 import solve
 
 _SPEC = """
@@ -85,7 +85,7 @@ class TestFindRunSpecs(unittest.TestCase):
             (d / "spec.yaml").write_text("clubs: {}\n")
             (d / "solution.yaml").write_text("fixtures: []\n")
 
-        self.assertEqual(build_html.find_run_specs(self.runs_dir), [nested, flat])
+        self.assertEqual(build_site.find_run_specs(self.runs_dir), [nested, flat])
 
     def test_ignores_dirs_missing_spec_or_solution(self):
         (self.runs_dir / "spec-only").mkdir(parents=True)
@@ -93,10 +93,10 @@ class TestFindRunSpecs(unittest.TestCase):
         (self.runs_dir / "solution-only").mkdir(parents=True)
         (self.runs_dir / "solution-only" / "solution.yaml").write_text("fixtures: []\n")
 
-        self.assertEqual(build_html.find_run_specs(self.runs_dir), [])
+        self.assertEqual(build_site.find_run_specs(self.runs_dir), [])
 
     def test_missing_runs_dir(self):
-        self.assertEqual(build_html.find_run_specs(self.runs_dir), [])
+        self.assertEqual(build_site.find_run_specs(self.runs_dir), [])
 
 
 class TestBuildReports(unittest.TestCase):
@@ -113,14 +113,14 @@ class TestBuildReports(unittest.TestCase):
         with patch(
             "sys.argv",
             [
-                "build_html.py",
+                "build_site.py",
                 "--runs-dir",
                 str(self.runs_dir),
                 "--out-dir",
                 str(self.out_dir),
             ],
         ):
-            build_html.main()
+            build_site.main()
 
     def test_regenerates_report_and_index_pages_from_source(self):
         flat = self.runs_dir / "example"
@@ -132,7 +132,13 @@ class TestBuildReports(unittest.TestCase):
 
         for rel in (Path("example"), Path("2026-27") / "draft1"):
             out_run = self.out_dir / "runs" / rel
-            for page in ("all-matches.html", "division-1.html", "index.html"):
+            for page in (
+                "all-matches.html",
+                "division-1.html",
+                "index.html",
+                "all-matches.csv",
+                "all-matches-by-team.csv",
+            ):
                 self.assertTrue(
                     (out_run / page).exists(), f"{out_run / page} not written"
                 )
@@ -150,10 +156,13 @@ class TestBuildReports(unittest.TestCase):
 
         self._run_cli()
 
+        strays = sorted(
+            p.name
+            for p in (self.runs_dir / "example").iterdir()
+            if p.name not in ("spec.yaml", "solution.yaml")
+        )
         self.assertEqual(
-            list((self.runs_dir / "example").glob("*.html")),
-            [],
-            "build_html.py should not write HTML back into the source runs dir",
+            strays, [], f"build_site.py wrote {strays} back into the source runs dir"
         )
 
     def test_drops_runs_removed_from_the_source(self):

--- a/csvreport.py
+++ b/csvreport.py
@@ -1,0 +1,222 @@
+# Copyright 2026 Andrew Medworth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Render a solved fixture list as CSV, for importing into other tools.
+
+Two files are written, covering every division (there's a ``division`` column
+to filter on):
+
+* ``all-matches.csv`` -- one row per match, ``home_team`` vs ``away_team``.
+* ``all-matches-by-team.csv`` -- two rows per match, one from each team's point
+  of view (``team``, ``opponent``, ``home_or_away``), so a club can pull just
+  its own team's fixtures straight into a calendar.
+
+Each team is given as its display name, its club's name (``*_club``, e.g.
+``Albany``) and its index within that club (``*_index``, e.g. ``1``), so the
+club and team number are available directly even when the display name is a
+``name_override``.
+
+Both files list withheld matches (a spec's ``exclude_fixtures``) too, with an
+empty ``date``, mirroring the HTML report's "TBC" rows. Dates are ISO
+``yyyy-mm-dd``; venue, start time and time limit are always the home team's
+club's, as in the HTML report.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from collections.abc import Collection, Mapping
+from datetime import date
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import reportdata
+
+if TYPE_CHECKING:
+    import fmodel
+
+ALL_MATCHES_FILENAME = "all-matches.csv"
+BY_TEAM_FILENAME = "all-matches-by-team.csv"
+
+_ALL_MATCHES_HEADER = [
+    "date",
+    "division",
+    "home_team",
+    "home_team_club",
+    "home_team_index",
+    "away_team",
+    "away_team_club",
+    "away_team_index",
+    "venue",
+    "venue_address",
+    "start_time",
+    "time_limit",
+]
+_BY_TEAM_HEADER = [
+    "date",
+    "division",
+    "team",
+    "team_club",
+    "team_index",
+    "opponent",
+    "opponent_club",
+    "opponent_index",
+    "home_or_away",
+    "venue",
+    "venue_address",
+    "start_time",
+    "time_limit",
+]
+
+
+def _iso(d: date | None) -> str:
+    return d.isoformat() if d is not None else ""
+
+
+def _team_columns(team: fmodel.Team, clubs: Mapping[str, fmodel.Club]) -> list[str]:
+    """(display name, club name, team index) -- the three columns describing a team."""
+    return [
+        reportdata.team_name(team, clubs),
+        clubs[team.club].name,
+        str(team.index),
+    ]
+
+
+def _venue_columns(
+    fixture: fmodel.Fixture, clubs: Mapping[str, fmodel.Club]
+) -> list[str]:
+    home_club = clubs[fixture.home_team.club]
+    return [
+        home_club.home_venue_name,
+        home_club.home_venue_address,
+        home_club.home_start_time,
+        home_club.home_time_limit,
+    ]
+
+
+def _match_row(
+    fixture: fmodel.Fixture,
+    fixture_date: date | None,
+    clubs: Mapping[str, fmodel.Club],
+) -> list[str]:
+    return [
+        _iso(fixture_date),
+        str(fixture.home_team.division),
+        *_team_columns(fixture.home_team, clubs),
+        *_team_columns(fixture.away_team, clubs),
+        *_venue_columns(fixture, clubs),
+    ]
+
+
+def _team_row(
+    team: fmodel.Team,
+    fixture: fmodel.Fixture,
+    fixture_date: date | None,
+    clubs: Mapping[str, fmodel.Club],
+) -> list[str]:
+    is_home = fixture.home_team == team
+    opponent = fixture.away_team if is_home else fixture.home_team
+    return [
+        _iso(fixture_date),
+        str(team.division),
+        *_team_columns(team, clubs),
+        *_team_columns(opponent, clubs),
+        "home" if is_home else "away",
+        *_venue_columns(fixture, clubs),
+    ]
+
+
+def _all_matches_rows(
+    fixtures: Collection[fmodel.ScheduledFixture],
+    excluded_fixtures: Collection[fmodel.Fixture],
+    clubs: Mapping[str, fmodel.Club],
+) -> list[list[str]]:
+    rows = [
+        _match_row(sf.fixture, sf.date, clubs)
+        for sf in reportdata.by_date_home_away(fixtures, clubs, with_division=True)
+    ]
+    rows += [
+        _match_row(f, None, clubs)
+        for f in reportdata.by_home_away(excluded_fixtures, clubs, with_division=True)
+    ]
+    return rows
+
+
+def _by_team_rows(
+    teams: Collection[fmodel.Team],
+    fixtures: Collection[fmodel.ScheduledFixture],
+    excluded_fixtures: Collection[fmodel.Fixture],
+    clubs: Mapping[str, fmodel.Club],
+) -> list[list[str]]:
+    rows: list[list[str]] = []
+    for team in sorted(teams, key=lambda t: reportdata.team_sort_key(t, clubs)):
+        team_fixtures = [
+            sf
+            for sf in fixtures
+            if team in (sf.fixture.home_team, sf.fixture.away_team)
+        ]
+        for sf in reportdata.by_date_opponent(team, team_fixtures, clubs):
+            rows.append(_team_row(team, sf.fixture, sf.date, clubs))
+
+        team_excluded = [
+            f for f in excluded_fixtures if team in (f.home_team, f.away_team)
+        ]
+        for f in sorted(
+            team_excluded,
+            key=lambda f: reportdata.team_sort_key(
+                f.away_team if f.home_team == team else f.home_team, clubs
+            ),
+        ):
+            rows.append(_team_row(team, f, None, clubs))
+    return rows
+
+
+def _write_csv(path: Path, header: list[str], rows: list[list[str]]) -> None:
+    buffer = io.StringIO()
+    writer = csv.writer(buffer, lineterminator="\n")
+    writer.writerow(header)
+    writer.writerows(rows)
+    path.write_text(buffer.getvalue())
+
+
+def generate_csv(
+    fixtures: Collection[fmodel.ScheduledFixture],
+    teams: Collection[fmodel.Team],
+    clubs: Mapping[str, fmodel.Club],
+    output_dir: Path,
+    excluded_fixtures: Collection[fmodel.Fixture] = (),
+) -> list[Path]:
+    """Write the CSV exports of a solved fixture list into output_dir.
+
+    See the module docstring for the two files and their columns. Returns the
+    paths written, in the order (all-matches, all-matches-by-team).
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    all_matches_path = output_dir / ALL_MATCHES_FILENAME
+    _write_csv(
+        all_matches_path,
+        _ALL_MATCHES_HEADER,
+        _all_matches_rows(fixtures, excluded_fixtures, clubs),
+    )
+
+    by_team_path = output_dir / BY_TEAM_FILENAME
+    _write_csv(
+        by_team_path,
+        _BY_TEAM_HEADER,
+        _by_team_rows(teams, fixtures, excluded_fixtures, clubs),
+    )
+
+    return [all_matches_path, by_team_path]

--- a/csvreport_test.py
+++ b/csvreport_test.py
@@ -1,0 +1,255 @@
+# Copyright 2026 Andrew Medworth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for CSV report generation."""
+
+import csv
+import tempfile
+import unittest
+from datetime import date
+from pathlib import Path
+
+import csvreport
+import fmodel
+
+
+def _sf(home: fmodel.Team, away: fmodel.Team, d: date) -> fmodel.ScheduledFixture:
+    return fmodel.ScheduledFixture(
+        fixture=fmodel.Fixture(home_team=home, away_team=away), date=d
+    )
+
+
+def _club(name: str, venue: str, address: str, start: str, limit: str) -> fmodel.Club:
+    return fmodel.Club(
+        name=name,
+        home_venue_name=venue,
+        home_venue_address=address,
+        home_start_time=start,
+        home_time_limit=limit,
+    )
+
+
+class CsvReportTest(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.out = Path(self._tmpdir.name) / "out"
+
+        self.clubs = {
+            "harrow": _club(
+                "Harrow",
+                "Harrow Leisure Centre",
+                "1 Harrow Road, London",
+                "19:30",
+                "75+15",
+            ),
+            "ealing": _club(
+                "Ealing",
+                "Ealing Sports Hall",
+                "2 Ealing Road, London",
+                "19:00",
+                "60+15",
+            ),
+            "hendon": _club(
+                "Hendon", "Hendon Club", "3 Hendon Road, London", "20:00", "90+30"
+            ),
+        }
+        self.harrow1 = fmodel.Team(division=1, club="harrow", index=1)
+        self.harrow2 = fmodel.Team(division=1, club="harrow", index=2)
+        self.ealing1 = fmodel.Team(division=1, club="ealing", index=1)
+        self.hendon1 = fmodel.Team(division=2, club="hendon", index=1)
+        self.warriors = fmodel.Team(
+            division=2, club="hendon", index=2, name_override="Hendon Warriors"
+        )
+        self.teams = [
+            self.harrow1,
+            self.harrow2,
+            self.ealing1,
+            self.hendon1,
+            self.warriors,
+        ]
+        self.fixtures = [
+            _sf(self.ealing1, self.harrow1, date(2025, 9, 8)),
+            _sf(self.harrow1, self.ealing1, date(2025, 9, 1)),
+            _sf(self.hendon1, self.warriors, date(2025, 9, 3)),
+        ]
+
+    def _rows(self, name: str) -> list[dict[str, str]]:
+        with (self.out / name).open(newline="") as f:
+            return list(csv.DictReader(f))
+
+    def test_writes_both_files_and_returns_their_paths(self):
+        paths = csvreport.generate_csv(self.fixtures, self.teams, self.clubs, self.out)
+        self.assertEqual(
+            paths,
+            [
+                self.out / "all-matches.csv",
+                self.out / "all-matches-by-team.csv",
+            ],
+        )
+        for p in paths:
+            self.assertTrue(p.exists())
+
+    def test_header_columns(self):
+        csvreport.generate_csv(self.fixtures, self.teams, self.clubs, self.out)
+        with (self.out / "all-matches.csv").open(newline="") as f:
+            self.assertEqual(
+                next(csv.reader(f)),
+                [
+                    "date",
+                    "division",
+                    "home_team",
+                    "home_team_club",
+                    "home_team_index",
+                    "away_team",
+                    "away_team_club",
+                    "away_team_index",
+                    "venue",
+                    "venue_address",
+                    "start_time",
+                    "time_limit",
+                ],
+            )
+        with (self.out / "all-matches-by-team.csv").open(newline="") as f:
+            self.assertEqual(
+                next(csv.reader(f)),
+                [
+                    "date",
+                    "division",
+                    "team",
+                    "team_club",
+                    "team_index",
+                    "opponent",
+                    "opponent_club",
+                    "opponent_index",
+                    "home_or_away",
+                    "venue",
+                    "venue_address",
+                    "start_time",
+                    "time_limit",
+                ],
+            )
+
+    def test_all_matches_one_row_per_match_sorted_by_date(self):
+        csvreport.generate_csv(self.fixtures, self.teams, self.clubs, self.out)
+        rows = self._rows("all-matches.csv")
+
+        self.assertEqual(len(rows), 3)
+        self.assertEqual(
+            [r["date"] for r in rows], ["2025-09-01", "2025-09-03", "2025-09-08"]
+        )
+        first = rows[0]
+        self.assertEqual(first["division"], "1")
+        self.assertEqual(first["home_team"], "Harrow 1")
+        self.assertEqual(first["home_team_club"], "Harrow")
+        self.assertEqual(first["home_team_index"], "1")
+        self.assertEqual(first["away_team"], "Ealing 1")
+        self.assertEqual(first["away_team_club"], "Ealing")
+        self.assertEqual(first["away_team_index"], "1")
+        # Venue/start/limit are always the home team's club's.
+        self.assertEqual(first["venue"], "Harrow Leisure Centre")
+        self.assertEqual(first["venue_address"], "1 Harrow Road, London")
+        self.assertEqual(first["start_time"], "19:30")
+        self.assertEqual(first["time_limit"], "75+15")
+
+    def test_all_matches_gives_name_override_plus_club_and_index(self):
+        csvreport.generate_csv(self.fixtures, self.teams, self.clubs, self.out)
+        hendon_row = next(
+            r for r in self._rows("all-matches.csv") if r["date"] == "2025-09-03"
+        )
+        self.assertEqual(hendon_row["away_team"], "Hendon Warriors")
+        # club name / index still identify the team behind the override name.
+        self.assertEqual(hendon_row["away_team_club"], "Hendon")
+        self.assertEqual(hendon_row["away_team_index"], "2")
+
+    def test_by_team_has_two_rows_per_match_from_each_side(self):
+        csvreport.generate_csv(self.fixtures, self.teams, self.clubs, self.out)
+        rows = self._rows("all-matches-by-team.csv")
+
+        # 3 matches -> 6 rows.
+        self.assertEqual(len(rows), 6)
+
+        # The 2025-09-01 Harrow 1 v Ealing 1 match shows up once for each team.
+        sep1 = [r for r in rows if r["date"] == "2025-09-01"]
+        self.assertEqual(len(sep1), 2)
+        by_team = {r["team"]: r for r in sep1}
+        self.assertEqual(by_team["Harrow 1"]["opponent"], "Ealing 1")
+        self.assertEqual(by_team["Harrow 1"]["team_club"], "Harrow")
+        self.assertEqual(by_team["Harrow 1"]["team_index"], "1")
+        self.assertEqual(by_team["Harrow 1"]["opponent_club"], "Ealing")
+        self.assertEqual(by_team["Harrow 1"]["opponent_index"], "1")
+        self.assertEqual(by_team["Harrow 1"]["home_or_away"], "home")
+        self.assertEqual(by_team["Ealing 1"]["opponent"], "Harrow 1")
+        self.assertEqual(by_team["Ealing 1"]["home_or_away"], "away")
+        # Both carry the home team's (Harrow's) venue details.
+        for r in sep1:
+            self.assertEqual(r["venue"], "Harrow Leisure Centre")
+            self.assertEqual(r["start_time"], "19:30")
+
+    def test_by_team_grouped_by_team_then_ordered_by_date(self):
+        csvreport.generate_csv(self.fixtures, self.teams, self.clubs, self.out)
+        rows = self._rows("all-matches-by-team.csv")
+
+        # Each team's rows are contiguous, and teams come in (club, index) order.
+        teams_in_order: list[str] = []
+        for r in rows:
+            if not teams_in_order or teams_in_order[-1] != r["team"]:
+                teams_in_order.append(r["team"])
+        self.assertEqual(
+            teams_in_order,
+            ["Ealing 1", "Harrow 1", "Hendon 1", "Hendon Warriors"],
+        )
+
+        ealing_dates = [r["date"] for r in rows if r["team"] == "Ealing 1"]
+        self.assertEqual(ealing_dates, ["2025-09-01", "2025-09-08"])
+
+    def test_excluded_fixtures_listed_with_empty_date_at_the_end(self):
+        excluded = [fmodel.Fixture(home_team=self.harrow1, away_team=self.harrow2)]
+        csvreport.generate_csv(
+            self.fixtures,
+            self.teams,
+            self.clubs,
+            self.out,
+            excluded_fixtures=excluded,
+        )
+
+        all_rows = self._rows("all-matches.csv")
+        self.assertEqual(all_rows[-1]["date"], "")
+        self.assertEqual(all_rows[-1]["home_team"], "Harrow 1")
+        self.assertEqual(all_rows[-1]["away_team"], "Harrow 2")
+        # The scheduled rows still come first, all with real dates.
+        self.assertTrue(all(r["date"] for r in all_rows[:-1]))
+
+        team_rows = self._rows("all-matches-by-team.csv")
+        harrow1_rows = [r for r in team_rows if r["team"] == "Harrow 1"]
+        self.assertEqual(harrow1_rows[-1]["date"], "")
+        self.assertEqual(harrow1_rows[-1]["opponent"], "Harrow 2")
+
+    def test_empty_fixture_list_writes_header_only(self):
+        csvreport.generate_csv([], [], self.clubs, self.out)
+
+        for name in ("all-matches.csv", "all-matches-by-team.csv"):
+            text = (self.out / name).read_text()
+            self.assertEqual(text.splitlines()[1:], [], f"{name} has data rows")
+            self.assertTrue(text.endswith("\n"))
+
+    def test_uses_unix_line_endings(self):
+        csvreport.generate_csv(self.fixtures, self.teams, self.clubs, self.out)
+        raw = (self.out / "all-matches.csv").read_bytes()
+        self.assertNotIn(b"\r", raw)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/htmlreport.py
+++ b/htmlreport.py
@@ -17,7 +17,7 @@
 The index-building helpers here (build_run_index and write_runs_index) derive
 the per-run and top-level index.html pages purely from the report files present
 on disk, without needing the original fixtures/teams data or any third-party
-dependency. build_html.py calls them after re-rendering the report pages during
+dependency. build_site.py calls them after re-rendering the report pages during
 a GitHub Pages deploy.
 """
 
@@ -31,6 +31,8 @@ from collections.abc import Collection, Mapping
 from datetime import date
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+import reportdata
 
 if TYPE_CHECKING:
     import fmodel
@@ -173,65 +175,18 @@ def _table(headers: list[str], rows: list[list[str]]) -> str:
     )
 
 
-def _team_name(team: fmodel.Team, clubs: Mapping[str, fmodel.Club]) -> str:
-    if team.name_override:
-        return team.name_override
-    return f"{clubs[team.club].name} {team.index}"
-
-
-def _team_sort_key(
-    team: fmodel.Team, clubs: Mapping[str, fmodel.Club]
-) -> tuple[str, int]:
-    """(club name, team index) of a team, used as a sort tie-break throughout."""
-    return (clubs[team.club].name, team.index)
-
-
-def _by_date_home_away(
-    fixtures: Collection[fmodel.ScheduledFixture],
-    clubs: Mapping[str, fmodel.Club],
-    with_division: bool,
-) -> list[fmodel.ScheduledFixture]:
-    def key(sf: fmodel.ScheduledFixture) -> tuple:
-        home_team = sf.fixture.home_team
-        division_part = (home_team.division,) if with_division else ()
-        return (
-            sf.date,
-            *division_part,
-            *_team_sort_key(home_team, clubs),
-            *_team_sort_key(sf.fixture.away_team, clubs),
-        )
-
-    return sorted(fixtures, key=key)
-
-
-def _by_date_opponent(
-    team: fmodel.Team,
-    fixtures: Collection[fmodel.ScheduledFixture],
-    clubs: Mapping[str, fmodel.Club],
-) -> list[fmodel.ScheduledFixture]:
-    def key(sf: fmodel.ScheduledFixture) -> tuple:
-        opponent = (
-            sf.fixture.away_team
-            if sf.fixture.home_team == team
-            else sf.fixture.home_team
-        )
-        return (sf.date, *_team_sort_key(opponent, clubs))
-
-    return sorted(fixtures, key=key)
-
-
 def _rows_with_division(
     fixtures: Collection[fmodel.ScheduledFixture], clubs: Mapping[str, fmodel.Club]
 ) -> list[list[str]]:
     rows = []
-    for sf in _by_date_home_away(fixtures, clubs, with_division=True):
+    for sf in reportdata.by_date_home_away(fixtures, clubs, with_division=True):
         home_club = clubs[sf.fixture.home_team.club]
         rows.append(
             [
                 _fmt_date(sf.date),
                 str(sf.fixture.home_team.division),
-                _team_name(sf.fixture.home_team, clubs),
-                _team_name(sf.fixture.away_team, clubs),
+                reportdata.team_name(sf.fixture.home_team, clubs),
+                reportdata.team_name(sf.fixture.away_team, clubs),
                 home_club.home_venue_name,
                 home_club.home_start_time,
                 home_club.home_time_limit,
@@ -244,13 +199,13 @@ def _rows(
     fixtures: Collection[fmodel.ScheduledFixture], clubs: Mapping[str, fmodel.Club]
 ) -> list[list[str]]:
     rows = []
-    for sf in _by_date_home_away(fixtures, clubs, with_division=False):
+    for sf in reportdata.by_date_home_away(fixtures, clubs, with_division=False):
         home_club = clubs[sf.fixture.home_team.club]
         rows.append(
             [
                 _fmt_date(sf.date),
-                _team_name(sf.fixture.home_team, clubs),
-                _team_name(sf.fixture.away_team, clubs),
+                reportdata.team_name(sf.fixture.home_team, clubs),
+                reportdata.team_name(sf.fixture.away_team, clubs),
                 home_club.home_venue_name,
                 home_club.home_start_time,
                 home_club.home_time_limit,
@@ -270,14 +225,14 @@ def _team_rows(
 ) -> list[list[str]]:
     rows = []
     prev_date: date | None = None
-    for sf in _by_date_opponent(team, fixtures, clubs):
+    for sf in reportdata.by_date_opponent(team, fixtures, clubs):
         is_home = sf.fixture.home_team == team
         opponent = sf.fixture.away_team if is_home else sf.fixture.home_team
         home_club = clubs[sf.fixture.home_team.club]
         rows.append(
             [
                 _fmt_date(sf.date),
-                _team_name(opponent, clubs),
+                reportdata.team_name(opponent, clubs),
                 "Home" if is_home else "Away",
                 home_club.home_venue_name,
                 home_club.home_start_time,
@@ -289,34 +244,18 @@ def _team_rows(
     return rows
 
 
-def _by_home_away(
-    fixtures: Collection[fmodel.Fixture],
-    clubs: Mapping[str, fmodel.Club],
-    with_division: bool,
-) -> list[fmodel.Fixture]:
-    def key(f: fmodel.Fixture) -> tuple:
-        division_part = (f.home_team.division,) if with_division else ()
-        return (
-            *division_part,
-            *_team_sort_key(f.home_team, clubs),
-            *_team_sort_key(f.away_team, clubs),
-        )
-
-    return sorted(fixtures, key=key)
-
-
 def _excluded_rows_with_division(
     fixtures: Collection[fmodel.Fixture], clubs: Mapping[str, fmodel.Club]
 ) -> list[list[str]]:
     rows = []
-    for f in _by_home_away(fixtures, clubs, with_division=True):
+    for f in reportdata.by_home_away(fixtures, clubs, with_division=True):
         home_club = clubs[f.home_team.club]
         rows.append(
             [
                 "TBC",
                 str(f.home_team.division),
-                _team_name(f.home_team, clubs),
-                _team_name(f.away_team, clubs),
+                reportdata.team_name(f.home_team, clubs),
+                reportdata.team_name(f.away_team, clubs),
                 home_club.home_venue_name,
                 home_club.home_start_time,
                 home_club.home_time_limit,
@@ -329,13 +268,13 @@ def _excluded_rows(
     fixtures: Collection[fmodel.Fixture], clubs: Mapping[str, fmodel.Club]
 ) -> list[list[str]]:
     rows = []
-    for f in _by_home_away(fixtures, clubs, with_division=False):
+    for f in reportdata.by_home_away(fixtures, clubs, with_division=False):
         home_club = clubs[f.home_team.club]
         rows.append(
             [
                 "TBC",
-                _team_name(f.home_team, clubs),
-                _team_name(f.away_team, clubs),
+                reportdata.team_name(f.home_team, clubs),
+                reportdata.team_name(f.away_team, clubs),
                 home_club.home_venue_name,
                 home_club.home_start_time,
                 home_club.home_time_limit,
@@ -352,7 +291,7 @@ def _excluded_team_rows(
     rows = []
     for f in sorted(
         fixtures,
-        key=lambda f: _team_sort_key(
+        key=lambda f: reportdata.team_sort_key(
             f.away_team if f.home_team == team else f.home_team, clubs
         ),
     ):
@@ -362,7 +301,7 @@ def _excluded_team_rows(
         rows.append(
             [
                 "TBC",
-                _team_name(opponent, clubs),
+                reportdata.team_name(opponent, clubs),
                 "Home" if is_home else "Away",
                 home_club.home_venue_name,
                 home_club.home_start_time,
@@ -547,7 +486,7 @@ def generate_report(
                 for f in excluded_fixtures
                 if f.home_team == team or f.away_team == team
             ]
-            team_name = _team_name(team, clubs)
+            team_name = reportdata.team_name(team, clubs)
             body += _anchored_heading(2, team_name, slugify(team_name))
             body += f"<h3>Division {team.division}</h3>\n"
             body += _table(
@@ -569,8 +508,17 @@ def build_run_index(run_dir: Path) -> Path:
     club_paths = sorted(run_dir.glob("club-*.html"))
 
     body = "<h2>All matches</h2>\n"
+    all_matches_links: list[tuple[str, str]] = []
     if all_matches_path.exists():
-        body += _nav([("all-matches.html", _page_title(all_matches_path))])
+        all_matches_links.append(("all-matches.html", _page_title(all_matches_path)))
+    for csv_name, csv_label in (
+        ("all-matches.csv", "CSV: one row per match"),
+        ("all-matches-by-team.csv", "CSV: two rows per match, one per team"),
+    ):
+        if (run_dir / csv_name).exists():
+            all_matches_links.append((csv_name, csv_label))
+    if all_matches_links:
+        body += _nav(all_matches_links)
     body += "<h2>Divisions</h2>\n"
     body += _nav([(p.name, _page_title(p)) for p in division_paths])
     body += "<h2>Clubs</h2>\n"

--- a/htmlreport_test.py
+++ b/htmlreport_test.py
@@ -231,6 +231,23 @@ class TestGenerateReport(unittest.TestCase):
         self.assertIn(">Division 1<", content)
         self.assertIn(">Willesden &amp; Brent<", content)
 
+    def test_run_index_links_to_csv_exports_when_present(self):
+        for name in ("all-matches.csv", "all-matches-by-team.csv"):
+            (self.output_dir / name).write_text("date\n")
+
+        content = htmlreport.build_run_index(self.output_dir).read_text()
+
+        self.assertIn('href="all-matches.csv"', content)
+        self.assertIn('href="all-matches-by-team.csv"', content)
+        # Grouped under the "All matches" heading, ahead of the divisions list.
+        self.assertLess(
+            content.index("all-matches.csv"), content.index("<h2>Divisions</h2>")
+        )
+
+    def test_run_index_has_no_csv_links_when_exports_absent(self):
+        # setUp's generate_report() writes HTML pages only, no CSV files.
+        self.assertNotIn(".csv", self.index_path.read_text())
+
     def test_build_run_index_is_rebuildable_from_disk_alone(self):
         """Deleting index.html and rebuilding from the other report files must reproduce it."""
         self.index_path.unlink()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ known-first-party = ["fmodel", "genfixtures"]
 "genfixtures.py" = ["T201"]  # Allow print statements in fixtures generator
 "solve.py" = ["T201"]  # Allow print statements in solve CLI
 "report.py" = ["T201"]  # Allow print statements in report CLI
-"build_html.py" = ["T201"]  # Allow print statements in HTML-rebuild CLI
+"build_site.py" = ["T201"]  # Allow print statements in site-assembly CLI
 "build_schema_docs.py" = ["T201"]  # Allow print statements in schema-docs CLI
 
 [tool.mypy]

--- a/report.py
+++ b/report.py
@@ -13,17 +13,18 @@
 # limitations under the License.
 
 """Render a solution.yaml (as written by solve.py), plus its original spec (for
-team/club/exclusion metadata), as a set of HTML report pages for one run.
+team/club/exclusion metadata), as the HTML report pages and CSV exports for one
+run.
 
 Usage:
     python report.py <spec.yaml> <solution.yaml> <output_dir>
 
-This can be re-run at any time to regenerate the HTML report -- e.g. after
-changing report formatting -- without re-solving, as long as solution.yaml
-still matches the teams described in spec.yaml.
+This can be re-run at any time to regenerate the report -- e.g. after changing
+report formatting -- without re-solving, as long as solution.yaml still matches
+the teams described in spec.yaml.
 
-It renders a single run's pages only. To (re)build the whole published site --
-every run's report plus the top-level index -- into _site/, run build_html.py.
+It renders a single run's files only. To (re)build the whole published site --
+every run's report plus the top-level index -- into _site/, run build_site.py.
 """
 
 from __future__ import annotations
@@ -31,18 +32,27 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+import csvreport
 import fixturesolution
 import fixturespec
 import htmlreport
 
 
 def report(spec_path: Path, solution_path: Path, output_dir: Path) -> Path:
-    """Render solution_path (a solution.yaml solved from spec_path) into output_dir.
-    Returns the path to the run's index.html."""
+    """Render solution_path (a solution.yaml solved from spec_path) into output_dir,
+    as the HTML report pages and the CSV exports. Returns the path to the run's
+    index.html."""
     spec = fixturespec.load_spec(spec_path)
     team_ids = fixturespec.load_team_ids(spec_path)
     fixtures = fixturesolution.load_solution(
         solution_path, spec.parameters.teams, team_ids
+    )
+    csvreport.generate_csv(
+        fixtures,
+        spec.parameters.teams,
+        spec.clubs,
+        output_dir,
+        excluded_fixtures=spec.parameters.excluded_fixtures,
     )
     return htmlreport.generate_report(
         fixtures,
@@ -69,7 +79,7 @@ def main() -> None:
 
     run_index_path = report(args.spec, args.solution, args.output_dir)
 
-    print(f"Wrote run report to {run_index_path}")
+    print(f"Wrote run report (HTML and CSV) to {run_index_path.parent}")
 
 
 if __name__ == "__main__":

--- a/report_test.py
+++ b/report_test.py
@@ -77,6 +77,20 @@ class TestReport(unittest.TestCase):
         self.assertTrue((self.output_dir / "all-matches.html").exists())
         self.assertIn("Test Season", (self.output_dir / "all-matches.html").read_text())
 
+    def test_also_writes_csv_exports(self):
+        report.report(self.spec_path, self.solution_path, self.output_dir)
+
+        for name in ("all-matches.csv", "all-matches-by-team.csv"):
+            self.assertTrue((self.output_dir / name).exists(), f"{name} not written")
+        self.assertIn("Albany 1", (self.output_dir / "all-matches.csv").read_text())
+
+    def test_run_index_links_to_the_csv_exports(self):
+        report.report(self.spec_path, self.solution_path, self.output_dir)
+
+        index = (self.output_dir / "index.html").read_text()
+        self.assertIn('href="all-matches.csv"', index)
+        self.assertIn('href="all-matches-by-team.csv"', index)
+
     def test_does_not_require_resolving(self):
         """Deleting nothing but the intermediate solving step should still work:
         report.py only reads solution.yaml, never calls fmodel.solve()."""

--- a/reportdata.py
+++ b/reportdata.py
@@ -1,0 +1,92 @@
+# Copyright 2026 Andrew Medworth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Format-agnostic shaping of a solved fixture list.
+
+Team display-name resolution and the row orderings the reports use, factored
+out of htmlreport.py so the CSV export (csvreport.py) can order and name things
+identically without going through the HTML renderer. Nothing here does any I/O
+or produces any markup.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Collection, Mapping
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import fmodel
+
+
+def team_name(team: fmodel.Team, clubs: Mapping[str, fmodel.Club]) -> str:
+    if team.name_override:
+        return team.name_override
+    return f"{clubs[team.club].name} {team.index}"
+
+
+def team_sort_key(
+    team: fmodel.Team, clubs: Mapping[str, fmodel.Club]
+) -> tuple[str, int]:
+    """(club name, team index) of a team, used as a sort tie-break throughout."""
+    return (clubs[team.club].name, team.index)
+
+
+def by_date_home_away(
+    fixtures: Collection[fmodel.ScheduledFixture],
+    clubs: Mapping[str, fmodel.Club],
+    with_division: bool,
+) -> list[fmodel.ScheduledFixture]:
+    def key(sf: fmodel.ScheduledFixture) -> tuple:
+        home_team = sf.fixture.home_team
+        division_part = (home_team.division,) if with_division else ()
+        return (
+            sf.date,
+            *division_part,
+            *team_sort_key(home_team, clubs),
+            *team_sort_key(sf.fixture.away_team, clubs),
+        )
+
+    return sorted(fixtures, key=key)
+
+
+def by_date_opponent(
+    team: fmodel.Team,
+    fixtures: Collection[fmodel.ScheduledFixture],
+    clubs: Mapping[str, fmodel.Club],
+) -> list[fmodel.ScheduledFixture]:
+    def key(sf: fmodel.ScheduledFixture) -> tuple:
+        opponent = (
+            sf.fixture.away_team
+            if sf.fixture.home_team == team
+            else sf.fixture.home_team
+        )
+        return (sf.date, *team_sort_key(opponent, clubs))
+
+    return sorted(fixtures, key=key)
+
+
+def by_home_away(
+    fixtures: Collection[fmodel.Fixture],
+    clubs: Mapping[str, fmodel.Club],
+    with_division: bool,
+) -> list[fmodel.Fixture]:
+    def key(f: fmodel.Fixture) -> tuple:
+        division_part = (f.home_team.division,) if with_division else ()
+        return (
+            *division_part,
+            *team_sort_key(f.home_team, clubs),
+            *team_sort_key(f.away_team, clubs),
+        )
+
+    return sorted(fixtures, key=key)

--- a/reportdata_test.py
+++ b/reportdata_test.py
@@ -1,0 +1,102 @@
+# Copyright 2026 Andrew Medworth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for the format-agnostic fixture-shaping helpers."""
+
+import unittest
+from datetime import date
+
+import fmodel
+import reportdata
+
+
+def _sf(home: fmodel.Team, away: fmodel.Team, d: date) -> fmodel.ScheduledFixture:
+    return fmodel.ScheduledFixture(
+        fixture=fmodel.Fixture(home_team=home, away_team=away), date=d
+    )
+
+
+def _club(name: str) -> fmodel.Club:
+    return fmodel.Club(
+        name=name,
+        home_venue_name=f"{name} Hall",
+        home_venue_address=f"1 {name} Road",
+        home_start_time="19:30",
+        home_time_limit="75+15",
+    )
+
+
+class ReportDataTest(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        # Club id "z-club" deliberately sorts after "a-club" by id but its
+        # display name "Aardvark" sorts first, so tests can tell which key wins.
+        self.clubs = {
+            "a-club": _club("Barnet"),
+            "z-club": _club("Aardvark"),
+        }
+        self.barnet1 = fmodel.Team(division=1, club="a-club", index=1)
+        self.barnet2 = fmodel.Team(division=1, club="a-club", index=2)
+        self.aardvark1 = fmodel.Team(division=1, club="z-club", index=1)
+        self.nick = fmodel.Team(
+            division=1, club="z-club", index=2, name_override="Aardvark Nomads"
+        )
+
+    def test_team_name_falls_back_to_club_name_and_index(self):
+        self.assertEqual(reportdata.team_name(self.barnet1, self.clubs), "Barnet 1")
+
+    def test_team_name_prefers_override(self):
+        self.assertEqual(reportdata.team_name(self.nick, self.clubs), "Aardvark Nomads")
+
+    def test_team_sort_key_is_club_display_name_then_index(self):
+        self.assertEqual(
+            reportdata.team_sort_key(self.aardvark1, self.clubs), ("Aardvark", 1)
+        )
+        self.assertLess(
+            reportdata.team_sort_key(self.aardvark1, self.clubs),
+            reportdata.team_sort_key(self.barnet1, self.clubs),
+        )
+
+    def test_by_date_home_away_orders_by_date_then_home_then_away(self):
+        later = _sf(self.barnet1, self.aardvark1, date(2025, 10, 1))
+        early_b = _sf(self.barnet1, self.aardvark1, date(2025, 9, 1))
+        early_a = _sf(self.aardvark1, self.barnet1, date(2025, 9, 1))
+
+        ordered = reportdata.by_date_home_away(
+            [later, early_b, early_a], self.clubs, with_division=False
+        )
+        # Same date: home team "Aardvark 1" sorts before "Barnet 1"; later date last.
+        self.assertEqual(ordered, [early_a, early_b, later])
+
+    def test_by_date_opponent_orders_by_date_then_opponent(self):
+        vs_nick = _sf(self.aardvark1, self.nick, date(2025, 9, 1))
+        vs_barnet2 = _sf(self.barnet2, self.aardvark1, date(2025, 9, 1))
+        later = _sf(self.aardvark1, self.barnet1, date(2025, 9, 20))
+
+        ordered = reportdata.by_date_opponent(
+            self.aardvark1, [later, vs_barnet2, vs_nick], self.clubs
+        )
+        # Same date: opponent "Aardvark Nomads" before "Barnet 2"; later date last.
+        self.assertEqual(ordered, [vs_nick, vs_barnet2, later])
+
+    def test_by_home_away_orders_without_dates(self):
+        f1 = fmodel.Fixture(home_team=self.barnet1, away_team=self.aardvark1)
+        f2 = fmodel.Fixture(home_team=self.aardvark1, away_team=self.barnet1)
+
+        ordered = reportdata.by_home_away([f1, f2], self.clubs, with_division=False)
+        self.assertEqual(ordered, [f2, f1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Every run's report now includes two CSV files alongside the HTML pages, built into _site/runs/<run>/ by build_site.py (renamed from build_html.py, since it's no longer HTML-only) and by report.py locally:

- all-matches.csv -- one row per match (home vs away)
- all-matches-by-team.csv -- two rows per match, one from each team's point of view (team, opponent, home_or_away)

Both cover every division, carry ISO dates, and list withheld matches (a spec's exclude_fixtures) with an empty date, mirroring the HTML "TBC" rows. Each team is given as its display name plus its club's name and index within that club, so the club/number are available even for name_override teams. The per-run index.html links both files from its "All matches" section.

The fixture ordering and team-name resolution shared with the HTML report move to a new format-agnostic module, reportdata.py; htmlreport.py now calls that (behaviour unchanged, its tests pass untouched).


Claude-Session: https://claude.ai/code/session_01Q63QHQzrJfkMEFPvhBb4AT