### PR TITLE
Support per-division fixture schemes, including single round-robin

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ teams:
     index: 1
 
 divisions:                       # each team's division: the only place it's given
-  1: [albany-1, hackney-1]
+  1:
+    scheme: double_round         # or single_round (Berger table; teams list = draw order)
+    teams: [albany-1, hackney-1]
 
 club_constraints:
   albany:

--- a/berger.py
+++ b/berger.py
@@ -1,0 +1,89 @@
+# Copyright 2026 Andrew Medworth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Berger tables: the standard construction for single round-robin draws.
+
+Middlesex League Rules 7c: a division of more than eight teams plays each pair
+once only, "based on the draw for the appropriate Berger table". Given a draw
+(an ordering of the entrants, position 1 first), the Berger table fixes which
+side of every match is at home; the solver then only has to place each of those
+fixtures on a date.
+
+berger_pairings() returns the table for plain entrant numbers; single_round_pairings()
+maps those numbers onto caller-supplied entrants.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+
+def _rotate(slots: list[int], step: int, modulus: int, fixed: int) -> list[int]:
+    """Advance every slot value by `step` positions, wrapping within 1..modulus, and
+    leaving `fixed` (the entrant that stays put across all rounds) untouched."""
+    return [s if s == fixed else ((s - 1 + step) % modulus) + 1 for s in slots]
+
+
+def berger_pairings(n: int) -> list[tuple[int, int]]:
+    """The Berger table for `n` entrants numbered 1..n, as a flat list of
+    (home, away) number pairs -- one per unordered pair of entrants, so
+    n * (n - 1) // 2 pairs in all.
+
+    Pairs are listed round by round (rounds 1..n-1 for even n), in the order the
+    canonical FIDE/Schurig Berger tables print them. Entrant `n` alternates
+    sides each round; the rest follow the standard rotation. For odd `n` a
+    phantom entrant is added to even out the rounds and its games (the byes) are
+    dropped, so every real entrant still plays n-1 games.
+    """
+    if n < 2:
+        return []
+
+    # For odd n, add a phantom entrant (number `total`) so there's an even field;
+    # its games are byes and get filtered out below.
+    total = n if n % 2 == 0 else n + 1
+    half = total // 2
+
+    # `top[i]` plays `bottom[i]` each round. The phantom / pivot entrant `total`
+    # sits in bottom[0] and never rotates; everyone else advances by `half` each
+    # round, wrapping within 1..total-1.
+    top = list(range(1, half + 1))
+    bottom = list(range(total, half, -1))
+
+    pairings: list[tuple[int, int]] = []
+    for rnd in range(1, total):
+        for home, away in zip(top, bottom, strict=True):
+            # Entrant `total` takes each side on alternate rounds (it is White /
+            # at home on even rounds in the canonical tables).
+            if total in (home, away) and rnd % 2 == 0:
+                home, away = away, home
+            if home <= n and away <= n:
+                pairings.append((home, away))
+        top = _rotate(top, half, total - 1, total)
+        bottom = _rotate(bottom, half, total - 1, total)
+
+    return pairings
+
+
+def single_round_pairings[T](entrants: Sequence[T]) -> list[tuple[T, T]]:
+    """Return the (home, away) pairs for a single round-robin among `entrants`,
+    with the home/away side of each match taken from the Berger table for
+    len(entrants) entrants drawn in the given order: entrants[0] is table
+    position 1, entrants[1] position 2, and so on. Each unordered pair of
+    entrants appears exactly once.
+    """
+    ordered = list(entrants)
+    return [
+        (ordered[home - 1], ordered[away - 1])
+        for home, away in berger_pairings(len(ordered))
+    ]

--- a/berger_test.py
+++ b/berger_test.py
@@ -1,0 +1,110 @@
+# Copyright 2026 Andrew Medworth
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for berger.py."""
+
+import collections
+import itertools
+import unittest
+
+import berger
+
+# The canonical FIDE Berger table for 9 or 10 players (FIDE Handbook C.06,
+# "Berger Tables"), round by round, each entry "home-away" (White-Black).
+_FIDE_10 = [
+    [(1, 10), (2, 9), (3, 8), (4, 7), (5, 6)],
+    [(10, 6), (7, 5), (8, 4), (9, 3), (1, 2)],
+    [(2, 10), (3, 1), (4, 9), (5, 8), (6, 7)],
+    [(10, 7), (8, 6), (9, 5), (1, 4), (2, 3)],
+    [(3, 10), (4, 2), (5, 1), (6, 9), (7, 8)],
+    [(10, 8), (9, 7), (1, 6), (2, 5), (3, 4)],
+    [(4, 10), (5, 3), (6, 2), (7, 1), (8, 9)],
+    [(10, 9), (1, 8), (2, 7), (3, 6), (4, 5)],
+    [(5, 10), (6, 4), (7, 3), (8, 2), (9, 1)],
+]
+
+
+class BergerPairingsTest(unittest.TestCase):
+    def test_matches_canonical_fide_table_for_10(self):
+        expected = [pair for rnd in _FIDE_10 for pair in rnd]
+        self.assertEqual(expected, berger.berger_pairings(10))
+
+    def test_two_entrants(self):
+        self.assertEqual([(1, 2)], berger.berger_pairings(2))
+
+    def test_degenerate_sizes(self):
+        self.assertEqual([], berger.berger_pairings(0))
+        self.assertEqual([], berger.berger_pairings(1))
+
+    def _assert_valid_single_round(self, n: int) -> list[tuple[int, int]]:
+        pairings = berger.berger_pairings(n)
+        # Every unordered pair exactly once.
+        self.assertEqual(n * (n - 1) // 2, len(pairings))
+        unordered = collections.Counter(frozenset(p) for p in pairings)
+        self.assertEqual(
+            {frozenset(p): 1 for p in itertools.combinations(range(1, n + 1), 2)},
+            dict(unordered),
+        )
+        # Every entrant plays n-1 games.
+        appearances = collections.Counter(x for p in pairings for x in p)
+        self.assertEqual({x: n - 1 for x in range(1, n + 1)}, dict(appearances))
+        return pairings
+
+    def test_valid_single_round_for_even_and_odd_sizes(self):
+        for n in range(2, 15):
+            with self.subTest(n=n):
+                self._assert_valid_single_round(n)
+
+    def test_home_away_counts_are_balanced(self):
+        # Each entrant hosts either floor((n-1)/2) or ceil((n-1)/2) of its games.
+        for n in range(2, 15):
+            with self.subTest(n=n):
+                pairings = berger.berger_pairings(n)
+                homes = collections.Counter(home for home, _ in pairings)
+                low, high = (n - 1) // 2, (n - 1 + 1) // 2
+                for x in range(1, n + 1):
+                    self.assertIn(homes[x], {low, high})
+
+
+class SingleRoundPairingsTest(unittest.TestCase):
+    def test_maps_numbers_onto_entrants_in_draw_order(self):
+        entrants = ["a", "b", "c", "d"]
+        pairings = berger.single_round_pairings(entrants)
+        number_pairings = berger.berger_pairings(4)
+        self.assertEqual(
+            [(entrants[h - 1], entrants[a - 1]) for h, a in number_pairings],
+            pairings,
+        )
+
+    def test_first_entrant_is_berger_position_one(self):
+        # Round 1 of the Berger table pairs position 1 (home) with position n.
+        entrants = ["p1", "p2", "p3", "p4", "p5", "p6"]
+        first = berger.single_round_pairings(entrants)[0]
+        self.assertEqual(("p1", "p6"), first)
+
+    def test_each_pair_once_over_arbitrary_entrants(self):
+        entrants = list("abcdefghij")  # 10
+        pairings = berger.single_round_pairings(entrants)
+        self.assertEqual(45, len(pairings))
+        self.assertEqual(
+            {frozenset(p) for p in itertools.combinations(entrants, 2)},
+            {frozenset(p) for p in pairings},
+        )
+
+    def test_empty(self):
+        self.assertEqual([], berger.single_round_pairings([]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_site_test.py
+++ b/build_site_test.py
@@ -49,7 +49,9 @@ teams:
     index: 1
 
 divisions:
-  1: [albany-1, hackney-1]
+  1:
+    scheme: double_round
+    teams: [albany-1, hackney-1]
 
 club_constraints:
   defaults:

--- a/fixturespec.py
+++ b/fixturespec.py
@@ -20,7 +20,6 @@ of the expected YAML structure; README.md covers how to use it.
 
 from __future__ import annotations
 
-import collections
 import dataclasses
 import itertools
 import logging
@@ -224,35 +223,89 @@ def _parse_teams(
     return teams
 
 
+@dataclasses.dataclass(frozen=True)
+class _Divisions:
+    """The parsed 'divisions' section: everything load_spec() needs to build teams
+    and hand fmodel.Parameters its per-division schemes. fmodel derives the grouped
+    fmodel.Division view itself, from teams + schemes."""
+
+    team_divisions: dict[str, int]  # team ID -> division number
+    ordered_team_ids: list[str]  # every team ID, in (division key, list position) order
+    schemes: dict[int, fmodel.FixtureScheme]  # division number -> fixture scheme
+
+
+_DIVISION_FIELD_KEYS = {"scheme", "teams"}
+
+
 def _parse_divisions(
     data: Mapping[str, Any], teams: Mapping[str, _TeamShell], path: Path
-) -> dict[str, int]:
-    """Parse the 'divisions' section (team IDs per division), returning each team's
-    division. This is the only place a team's division is given - 'teams' entries
-    don't repeat it."""
+) -> _Divisions:
+    """Parse the 'divisions' section: each division's fixture scheme and the team IDs
+    competing in it, keyed by division number. This is the only place a team's
+    division is given - 'teams' entries don't repeat it.
+
+    Every division entry is a mapping with a required 'scheme' (one of the
+    fmodel.FixtureScheme values, e.g. 'double_round' or 'single_round') and a
+    required non-empty 'teams' list. For a 'single_round' division the order of that
+    list is the Berger table draw - the first team is table position 1, the next
+    position 2, and so on - so it is significant, not merely cosmetic; ordered_team_ids
+    keeps it, and load_spec() builds fmodel.Parameters.teams in that order.
+    """
     divisions_spec = _require_mapping(data.get("divisions"), f"{path}: 'divisions'")
 
     team_divisions: dict[str, int] = {}
-    for division_key, team_ids in divisions_spec.items():
+    ordered_team_ids: list[str] = []
+    schemes: dict[int, fmodel.FixtureScheme] = {}
+    for division_key, division_spec in divisions_spec.items():
         context = f"{path}: divisions[{division_key!r}]"
         division = _require_int(division_key, f"{context} key")
+
+        if not isinstance(division_spec, dict):
+            raise SpecError(f"{context} must be a mapping with 'scheme' and 'teams'")
+        unsupported = division_spec.keys() - _DIVISION_FIELD_KEYS
+        if unsupported:
+            raise SpecError(
+                f"{context}: unsupported field(s) {sorted(unsupported)} "
+                f"(only {sorted(_DIVISION_FIELD_KEYS)} are)"
+            )
+        missing_fields = _DIVISION_FIELD_KEYS - division_spec.keys()
+        if missing_fields:
+            raise SpecError(
+                f"{context} missing required field(s) {sorted(missing_fields)}"
+            )
+
+        scheme_str = _require_str(division_spec["scheme"], f"{context}.scheme")
+        try:
+            schemes[division] = fmodel.FixtureScheme(scheme_str)
+        except ValueError:
+            allowed = ", ".join(repr(s.value) for s in fmodel.FixtureScheme)
+            raise SpecError(
+                f"{context}.scheme must be one of {allowed}, got {scheme_str!r}"
+            ) from None
+
+        team_ids = division_spec["teams"]
         if not isinstance(team_ids, list) or not team_ids:
-            raise SpecError(f"{context} must be a non-empty list of team IDs")
+            raise SpecError(f"{context}.teams must be a non-empty list of team IDs")
         for team_id in team_ids:
             if team_id not in teams:
-                raise SpecError(f"{context} references unknown team {team_id!r}")
+                raise SpecError(f"{context}.teams references unknown team {team_id!r}")
             if team_id in team_divisions:
                 raise SpecError(
                     f"{path}: team {team_id!r} listed in more than one division"
                 )
             team_divisions[team_id] = division
+            ordered_team_ids.append(team_id)
 
     missing = teams.keys() - team_divisions.keys()
     if missing:
         raise SpecError(
             f"{path}: team(s) {sorted(missing)} not listed under 'divisions'"
         )
-    return team_divisions
+    return _Divisions(
+        team_divisions=team_divisions,
+        ordered_team_ids=ordered_team_ids,
+        schemes=schemes,
+    )
 
 
 def _parse_max_concurrent_home_matches_value(
@@ -702,7 +755,9 @@ def _parse_exclude_fixtures(
     'clubs' and 'teams' exclude every fixture (in both directions) that any of the
     given clubs' or teams' teams would otherwise play within their division;
     'fixtures' excludes individual home/away pairs. Returns the fully expanded set
-    of excluded (home, away) Fixture pairs.
+    of excluded (home, away) Fixture pairs. Both directions are expanded even for a
+    single_round division (where only one is ever scheduled), so the exclusion
+    holds whichever way the Berger draw sends that pairing.
     """
     section_name = "exclude_fixtures"
     section_spec = data.get(section_name)
@@ -718,9 +773,9 @@ def _parse_exclude_fixtures(
             "(only 'clubs', 'teams' and 'fixtures' are)"
         )
 
-    teams_by_division: dict[int, list[fmodel.Team]] = collections.defaultdict(list)
+    teams_by_division: dict[int, list[fmodel.Team]] = {}
     for team in teams.values():
-        teams_by_division[team.division].append(team)
+        teams_by_division.setdefault(team.division, []).append(team)
 
     excluded: set[fmodel.Fixture] = set()
 
@@ -836,15 +891,18 @@ def load_spec(spec_path: str | Path) -> Spec:
 
     clubs = _parse_clubs(data, path)
     team_shells = _parse_teams(data, clubs, path)
-    team_divisions = _parse_divisions(data, team_shells, path)
+    divisions = _parse_divisions(data, team_shells, path)
+    # Build teams in 'divisions' order: a single_round division's team order is its
+    # Berger draw, and fmodel derives its grouped Division view (that order
+    # included) from Parameters.teams.
     teams = {
         team_id: fmodel.Team(
-            division=team_divisions[team_id],
-            club=shell.club,
-            index=shell.index,
-            name_override=shell.name_override,
+            division=divisions.team_divisions[team_id],
+            club=team_shells[team_id].club,
+            index=team_shells[team_id].index,
+            name_override=team_shells[team_id].name_override,
         )
-        for team_id, shell in team_shells.items()
+        for team_id in divisions.ordered_team_ids
     }
 
     avoid_dates = _parse_date_list(data.get("avoid_dates"), f"{path}: 'avoid_dates'")
@@ -912,6 +970,7 @@ def load_spec(spec_path: str | Path) -> Spec:
         home_dates=home_dates,
         unavailable_away_dates=unavailable_away_dates,
         max_concurrent_home_matches=max_concurrent_home_matches,
+        division_schemes=divisions.schemes,
         **kwargs,
     )
     name = _require_str(data.get("name", ""), f"{path}: 'name'")

--- a/fixturespec_test.py
+++ b/fixturespec_test.py
@@ -50,7 +50,9 @@ teams:
     index: 1
 
 divisions:
-  1: [albany-1, hackney-1]
+  1:
+    scheme: double_round
+    teams: [albany-1, hackney-1]
 """
 
 # A valid spec minus 'club_constraints.defaults' (so every club still needs its own
@@ -101,7 +103,9 @@ teams:
     index: 1
 
 divisions:
-  1: [albany-1, albany-2, hackney-1]
+  1:
+    scheme: double_round
+    teams: [albany-1, albany-2, hackney-1]
 
 club_constraints:
   defaults:
@@ -456,7 +460,9 @@ teams:
     club: hackney
     index: 1
 divisions:
-  1: [hackney-1]
+  1:
+    scheme: double_round
+    teams: [hackney-1]
 """)
         with self.assertRaisesRegex(fixturespec.SpecError, "hackney"):
             fixturespec.load_spec(path)
@@ -478,7 +484,9 @@ teams:
     club: albany
     index: 1
 divisions:
-  1: [albany-1, albany-1-again]
+  1:
+    scheme: double_round
+    teams: [albany-1, albany-1-again]
 """)
         with self.assertRaisesRegex(fixturespec.SpecError, "index 1"):
             fixturespec.load_spec(path)
@@ -517,7 +525,9 @@ teams:
     club: albany
     index: 2
 divisions:
-  1: [albany-1]
+  1:
+    scheme: double_round
+    teams: [albany-1]
 """)
         with self.assertRaisesRegex(fixturespec.SpecError, "albany-2"):
             fixturespec.load_spec(path)
@@ -536,7 +546,9 @@ teams:
     club: albany
     index: 1
 divisions:
-  "one": [albany-1]
+  "one":
+    scheme: double_round
+    teams: [albany-1]
 """)
         with self.assertRaisesRegex(fixturespec.SpecError, "integer"):
             fixturespec.load_spec(path)
@@ -555,11 +567,133 @@ teams:
     club: albany
     index: 1
 divisions:
-  1: [albany-1]
-  2: [albany-1]
+  1:
+    scheme: double_round
+    teams: [albany-1]
+  2:
+    scheme: double_round
+    teams: [albany-1]
 """)
         with self.assertRaisesRegex(fixturespec.SpecError, "more than one division"):
             fixturespec.load_spec(path)
+
+    _SCHEME_SPEC_HEAD = """
+clubs:
+  albany:
+    name: Albany
+    home_venue_name: x
+    home_venue_address: x
+    home_start_time: "19:30"
+    home_time_limit: "75+15"
+teams:
+  albany-1:
+    club: albany
+    index: 1
+  albany-2:
+    club: albany
+    index: 2
+divisions:
+"""
+
+    # Appended after a divisions block to make _SCHEME_SPEC_HEAD specs valid enough
+    # to load successfully (the failure-path tests don't get this far).
+    _SCHEME_SPEC_TAIL = (
+        "club_constraints:\n"
+        "  defaults:\n    max_concurrent_home_matches: 1\n"
+        "  albany:\n    home_dates: [2025-09-01, 2025-09-08, 2025-09-15]\n"
+    )
+
+    def test_division_scheme_single_round_is_parsed(self):
+        path = self._write(
+            self._SCHEME_SPEC_HEAD + "  1:\n    scheme: single_round\n"
+            "    teams: [albany-1, albany-2]\n" + self._SCHEME_SPEC_TAIL
+        )
+        spec = fixturespec.load_spec(path)
+        self.assertEqual(
+            {1: fmodel.FixtureScheme.SINGLE_ROUND},
+            {d.number: d.scheme for d in spec.parameters.divisions},
+        )
+
+    def test_division_scheme_double_round_is_parsed(self):
+        path = self._write(
+            self._SCHEME_SPEC_HEAD + "  1:\n    scheme: double_round\n"
+            "    teams: [albany-1, albany-2]\n" + self._SCHEME_SPEC_TAIL
+        )
+        spec = fixturespec.load_spec(path)
+        self.assertEqual(
+            {1: fmodel.FixtureScheme.DOUBLE_ROUND},
+            {d.number: d.scheme for d in spec.parameters.divisions},
+        )
+
+    def test_division_missing_scheme_rejected(self):
+        path = self._write(
+            self._SCHEME_SPEC_HEAD + "  1:\n    teams: [albany-1, albany-2]\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "scheme"):
+            fixturespec.load_spec(path)
+
+    def test_division_missing_teams_rejected(self):
+        path = self._write(self._SCHEME_SPEC_HEAD + "  1:\n    scheme: double_round\n")
+        with self.assertRaisesRegex(fixturespec.SpecError, "teams"):
+            fixturespec.load_spec(path)
+
+    def test_division_unknown_scheme_rejected(self):
+        path = self._write(
+            self._SCHEME_SPEC_HEAD + "  1:\n    scheme: triple_round\n"
+            "    teams: [albany-1, albany-2]\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "scheme.*triple_round"):
+            fixturespec.load_spec(path)
+
+    def test_division_bare_list_rejected(self):
+        path = self._write(self._SCHEME_SPEC_HEAD + "  1: [albany-1, albany-2]\n")
+        with self.assertRaisesRegex(fixturespec.SpecError, "mapping"):
+            fixturespec.load_spec(path)
+
+    def test_division_unsupported_field_rejected(self):
+        path = self._write(
+            self._SCHEME_SPEC_HEAD + "  1:\n    scheme: double_round\n"
+            "    teams: [albany-1, albany-2]\n    berger_seed: 3\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "berger_seed"):
+            fixturespec.load_spec(path)
+
+    def test_single_round_division_team_order_follows_the_divisions_list(self):
+        # teams: lists albany-2 before albany-1; the divisions list is the Berger
+        # draw order and must win, so parameters.teams reflects the divisions list.
+        path = self._write("""
+clubs:
+  albany:
+    name: Albany
+    home_venue_name: x
+    home_venue_address: x
+    home_start_time: "19:30"
+    home_time_limit: "75+15"
+teams:
+  albany-2:
+    club: albany
+    index: 2
+  albany-1:
+    club: albany
+    index: 1
+  albany-3:
+    club: albany
+    index: 3
+divisions:
+  1:
+    scheme: single_round
+    teams: [albany-1, albany-2, albany-3]
+club_constraints:
+  defaults:
+    max_concurrent_home_matches: 1
+  albany:
+    home_dates: [2025-09-01, 2025-09-08, 2025-09-15]
+""")
+        spec = fixturespec.load_spec(path)
+        self.assertEqual(
+            [(t.club, t.index) for t in spec.parameters.teams],
+            [("albany", 1), ("albany", 2), ("albany", 3)],
+        )
 
     def test_invalid_date_string(self):
         path = self._write("""
@@ -575,7 +709,9 @@ teams:
     club: albany
     index: 1
 divisions:
-  1: [albany-1]
+  1:
+    scheme: double_round
+    teams: [albany-1]
 club_constraints:
   albany:
     home_dates: ["not-a-date"]
@@ -597,7 +733,9 @@ teams:
     club: albany
     index: 1
 divisions:
-  1: [albany-1]
+  1:
+    scheme: double_round
+    teams: [albany-1]
 club_constraints:
   albany:
     home_dates: [2025-09-01, 2025-09-01]
@@ -619,7 +757,9 @@ teams:
     club: albany
     index: 1
 divisions:
-  1: [albany-1]
+  1:
+    scheme: double_round
+    teams: [albany-1]
 club_constraints:
   albany:
     unavailable_away_dates: [2025-09-01, 2025-09-01]
@@ -641,7 +781,9 @@ teams:
     club: albany
     index: 1
 divisions:
-  1: [albany-1]
+  1:
+    scheme: double_round
+    teams: [albany-1]
 club_constraints:
   albany:
     home_dates: [2025-09-01]
@@ -782,8 +924,9 @@ club_constraints:
     def test_fixed_fixtures_different_divisions_rejected(self):
         path = self._write(
             _MINIMAL_SPEC.replace(
-                "divisions:\n  1: [albany-1, hackney-1]",
-                "divisions:\n  1: [albany-1]\n  2: [hackney-1]",
+                "  1:\n    scheme: double_round\n    teams: [albany-1, hackney-1]",
+                "  1:\n    scheme: double_round\n    teams: [albany-1]\n"
+                "  2:\n    scheme: double_round\n    teams: [hackney-1]",
             )
             + "fixed_fixtures:\n"
             "  - home: hackney-1\n"
@@ -1200,8 +1343,10 @@ club_constraints:
     def test_exclude_fixtures_different_divisions_rejected(self):
         path = self._write(
             _THREE_TEAM_SPEC.replace(
-                "divisions:\n  1: [albany-1, albany-2, hackney-1]",
-                "divisions:\n  1: [albany-1, albany-2]\n  2: [hackney-1]",
+                "  1:\n    scheme: double_round\n"
+                "    teams: [albany-1, albany-2, hackney-1]",
+                "  1:\n    scheme: double_round\n    teams: [albany-1, albany-2]\n"
+                "  2:\n    scheme: double_round\n    teams: [hackney-1]",
             )
             + "exclude_fixtures:\n"
             "  fixtures:\n"

--- a/fmodel.py
+++ b/fmodel.py
@@ -20,11 +20,13 @@ import enum
 import functools
 import itertools
 import logging
-from collections.abc import Collection, Mapping, MutableMapping
+from collections.abc import Collection, Iterable, Mapping, MutableMapping
 from datetime import date
 from typing import Any
 
 from ortools.sat.python import cp_model
+
+import berger
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +91,50 @@ class MaxConcurrentHomeMatches:
 
     def for_date(self, d: date) -> int | None:
         return self.overrides.get(d, self.default)
+
+
+class FixtureScheme(enum.Enum):
+    """How a division's fixtures are generated.
+
+    DOUBLE_ROUND: every pair of teams plays twice, once at each team's home venue
+    -- the Middlesex League's default "Double Round All-Play-All" basis (League
+    Rules 7c).
+
+    SINGLE_ROUND: every pair plays once, with the home/away side of each match
+    taken from the Berger table for the division's entrants (see berger.py). The
+    draw order is the order of Division.teams. League Rules 7c switches a division
+    to this basis once it has more than eight teams.
+    """
+
+    DOUBLE_ROUND = "double_round"
+    SINGLE_ROUND = "single_round"
+
+
+@dataclasses.dataclass(frozen=True)
+class Division:
+    """One division's teams and how its fixtures are generated -- a grouped,
+    scheme-carrying view of Parameters.teams, derived by Parameters.divisions.
+
+    `teams` is ordered: for FixtureScheme.SINGLE_ROUND it is the Berger table draw
+    (teams[0] is table position 1, teams[1] position 2, and so on), which fixes the
+    home/away side of every match; this order comes straight from Parameters.teams.
+    """
+
+    number: int
+    scheme: FixtureScheme
+    teams: tuple[Team, ...]
+
+    def required_fixtures(self) -> list[Fixture]:
+        """Every fixture that must appear in the schedule for this division: both
+        directions of each pairing for DOUBLE_ROUND, one directed fixture per
+        pairing (home/away from the Berger table) for SINGLE_ROUND."""
+        if self.scheme is FixtureScheme.SINGLE_ROUND:
+            pairs: Iterable[tuple[Team, Team]] = berger.single_round_pairings(
+                self.teams
+            )
+        else:
+            pairs = itertools.permutations(self.teams, 2)
+        return [Fixture(home_team=home, away_team=away) for home, away in pairs]
 
 
 class CoschedulingScope(enum.Enum):
@@ -171,11 +217,43 @@ class Parameters:
         default_factory=dict
     )
     avoid_coscheduling_teams: Collection[AvoidCoschedulingConstraint] = ()
+    # Fixture generation scheme per division number (see FixtureScheme); a division
+    # with no entry here uses FixtureScheme.DOUBLE_ROUND. This is the only
+    # per-division input -- the `divisions` view below, including each SINGLE_ROUND
+    # division's Berger draw order, is derived from `teams` (grouped by
+    # Team.division, keeping `teams` order), so `teams` order is significant for a
+    # SINGLE_ROUND division, not just a listing convenience.
+    division_schemes: Mapping[int, FixtureScheme] = dataclasses.field(
+        default_factory=dict
+    )
 
     def __post_init__(self) -> None:
         _check_no_duplicate_teams(self.teams)
         _check_no_duplicate_home_dates(self.home_dates)
         _check_no_duplicate_home_dates(self.team_home_dates)
+        unknown = self.division_schemes.keys() - {t.division for t in self.teams}
+        if unknown:
+            raise ValueError(
+                f"division_schemes has entries for division(s) {sorted(unknown)} "
+                "with no teams"
+            )
+
+    @functools.cached_property
+    def divisions(self) -> tuple[Division, ...]:
+        """`teams` grouped into divisions, in first-seen order, each division's
+        teams kept in `teams` order (a SINGLE_ROUND division's Berger draw) and its
+        scheme taken from `division_schemes` (DOUBLE_ROUND if absent)."""
+        by_number: dict[int, list[Team]] = {}
+        for team in self.teams:
+            by_number.setdefault(team.division, []).append(team)
+        return tuple(
+            Division(
+                number=number,
+                scheme=self.division_schemes.get(number, FixtureScheme.DOUBLE_ROUND),
+                teams=tuple(division_teams),
+            )
+            for number, division_teams in by_number.items()
+        )
 
     @functools.cached_property
     def _teams_per_club(self) -> Mapping[ClubT, int]:
@@ -319,9 +397,6 @@ def _add_fixed_fixtures_constraints(
 
 def solve(params: Parameters) -> Collection[ScheduledFixture]:
     model = cp_model.CpModel()
-    teams_by_division = collections.defaultdict(list)
-    for team in params.teams:
-        teams_by_division[team.division].append(team)
 
     vars_by_fixture: MutableMapping[Fixture, list[cp_model.IntVar]] = (
         collections.defaultdict(list)
@@ -337,11 +412,12 @@ def solve(params: Parameters) -> Collection[ScheduledFixture]:
     excluded = set(params.excluded_fixtures)
     fixed_fixture_keys = {(sf.fixture, sf.date) for sf in params.fixed_fixtures}
 
-    for division_teams in teams_by_division.values():
-        for home_team, away_team in itertools.permutations(division_teams, 2):
-            fixture = Fixture(home_team=home_team, away_team=away_team)
+    for division in params.divisions:
+        for fixture in division.required_fixtures():
             if fixture in excluded:
                 continue
+            home_team = fixture.home_team
+            away_team = fixture.away_team
             is_internal = home_team.club == away_team.club
             for match_date in params.home_dates_for(home_team):
                 if match_date in params.unavailable_away_dates_for(away_team):

--- a/model_test.py
+++ b/model_test.py
@@ -19,6 +19,7 @@ import random
 import unittest
 from datetime import date, timedelta
 
+import berger
 import fmodel
 import genfixtures
 
@@ -753,6 +754,109 @@ class TestExcludedFixtures(unittest.TestCase):
         params = self._params(fixed_fixtures=[fixed], excluded_fixtures=[fixture])
         with self.assertRaises(ValueError):
             fmodel.solve(params)
+
+
+class TestDivisionSchemes(unittest.TestCase):
+    """Test cases for division_schemes and the fmodel.Division view Parameters
+    derives from it: DOUBLE_ROUND (the default for any unlisted division) vs
+    SINGLE_ROUND, the latter taking each match's home/away side from the Berger
+    table for that division's teams in Parameters.teams order.
+    """
+
+    def _params(
+        self,
+        teams: list[fmodel.Team],
+        division_schemes: dict[int, fmodel.FixtureScheme] | None = None,
+    ) -> fmodel.Parameters:
+        clubs = sorted({t.club for t in teams})
+        # A generous common pool of home dates, > min_gap_days apart, so date
+        # feasibility never masks a wrong fixture count.
+        dates = [date(2025, 1, 1) + timedelta(days=7 * i) for i in range(20)]
+        return fmodel.Parameters(
+            teams=teams,
+            home_dates={c: list(dates) for c in clubs},
+            unavailable_away_dates={c: [] for c in clubs},
+            max_concurrent_home_matches={
+                c: fmodel.MaxConcurrentHomeMatches(default=1) for c in clubs
+            },
+            min_gap_days=7,
+            division_schemes=division_schemes or {},
+        )
+
+    @staticmethod
+    def _teams(clubs: str, division: int = 1) -> list[fmodel.Team]:
+        return [fmodel.Team(division=division, club=c, index=1) for c in clubs]
+
+    def test_double_round_is_the_default_scheme(self):
+        params = self._params(self._teams("ABCD"))
+        fixtures = list(fmodel.solve(params))
+        # 4 teams, home and away: 4 * 3 = 12 fixtures.
+        self.assertEqual(12, len(fixtures))
+        self.assertEqual(1, len(params.divisions))
+        self.assertEqual(fmodel.FixtureScheme.DOUBLE_ROUND, params.divisions[0].scheme)
+
+    def test_single_round_plays_each_pair_once(self):
+        params = self._params(
+            self._teams("ABCD"),
+            division_schemes={1: fmodel.FixtureScheme.SINGLE_ROUND},
+        )
+        fixtures = list(fmodel.solve(params))
+        self.assertEqual(6, len(fixtures))
+        unordered = {
+            frozenset((sf.fixture.home_team, sf.fixture.away_team)) for sf in fixtures
+        }
+        self.assertEqual(6, len(unordered))
+
+    def test_single_round_home_away_follows_the_berger_table(self):
+        teams = self._teams("ABCD")
+        params = self._params(
+            teams, division_schemes={1: fmodel.FixtureScheme.SINGLE_ROUND}
+        )
+        fixtures = list(fmodel.solve(params))
+        got = {
+            (sf.fixture.home_team.club, sf.fixture.away_team.club) for sf in fixtures
+        }
+        expected = {
+            (home.club, away.club) for home, away in berger.single_round_pairings(teams)
+        }
+        self.assertEqual(expected, got)
+
+    def test_single_round_draw_order_comes_from_parameters_teams(self):
+        # teams order D, C, B, A: the Berger draw, and every H/A, follows it.
+        teams = self._teams("DCBA")
+        params = self._params(
+            teams, division_schemes={1: fmodel.FixtureScheme.SINGLE_ROUND}
+        )
+        fixtures = list(fmodel.solve(params))
+        got = {
+            (sf.fixture.home_team.club, sf.fixture.away_team.club) for sf in fixtures
+        }
+        expected = {
+            (home.club, away.club) for home, away in berger.single_round_pairings(teams)
+        }
+        self.assertEqual(expected, got)
+        # Round 1 of the Berger table pairs position 1 at home against position n:
+        # here that's D (first in teams) hosting A (last in teams).
+        self.assertIn(("D", "A"), got)
+
+    def test_schemes_are_per_division(self):
+        teams = self._teams("ABCD", division=1) + self._teams("EFGH", division=2)
+        params = self._params(
+            teams, division_schemes={1: fmodel.FixtureScheme.SINGLE_ROUND}
+        )
+        fixtures = list(fmodel.solve(params))
+        by_division = collections.Counter(
+            sf.fixture.home_team.division for sf in fixtures
+        )
+        self.assertEqual(6, by_division[1])  # single round
+        self.assertEqual(12, by_division[2])  # double round (the default)
+
+    def test_scheme_for_division_with_no_teams_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "division.*9.*no teams"):
+            self._params(
+                self._teams("ABCD"),
+                division_schemes={9: fmodel.FixtureScheme.SINGLE_ROUND},
+            )
 
 
 class TestTeamConstraints(unittest.TestCase):

--- a/report_test.py
+++ b/report_test.py
@@ -47,7 +47,9 @@ teams:
     index: 1
 
 divisions:
-  1: [albany-1, hackney-1]
+  1:
+    scheme: double_round
+    teams: [albany-1, hackney-1]
 
 club_constraints:
   defaults:

--- a/runs/example/spec.yaml
+++ b/runs/example/spec.yaml
@@ -153,33 +153,41 @@ teams:
     index: 1
 divisions:
   1:
-  - albany-1
-  - hackney-1
-  - hammersmith-1
-  - hendon-1
-  - kings-head-1
-  - metropolitan-1
-  - muswell-hill-1
-  - west-london-1
+    scheme: double_round
+    teams:
+    - albany-1
+    - hackney-1
+    - hammersmith-1
+    - hendon-1
+    - kings-head-1
+    - metropolitan-1
+    - muswell-hill-1
+    - west-london-1
   2:
-  - ealing-1
-  - hammersmith-2
-  - harrow-1
-  - harrow-2
-  - hendon-2
-  - hendon-3
-  - kings-head-2
-  - muswell-hill-2
-  - willesden-brent-1
+    # Nine teams here is over the Rule 7c limit of eight, but the division still
+    # played a double round in this (synthetic) season, so that's recorded as-is.
+    scheme: double_round
+    teams:
+    - ealing-1
+    - hammersmith-2
+    - harrow-1
+    - harrow-2
+    - hendon-2
+    - hendon-3
+    - kings-head-2
+    - muswell-hill-2
+    - willesden-brent-1
   3:
-  - ealing-2
-  - hackney-2
-  - hammersmith-3
-  - hammersmith-4
-  - hendon-4
-  - hendon-5
-  - kings-head-3
-  - potters-bar-1
+    scheme: double_round
+    teams:
+    - ealing-2
+    - hackney-2
+    - hammersmith-3
+    - hammersmith-4
+    - hendon-4
+    - hendon-5
+    - kings-head-3
+    - potters-bar-1
 club_constraints:
   defaults:
     max_concurrent_home_matches: 2

--- a/solve_test.py
+++ b/solve_test.py
@@ -47,7 +47,9 @@ teams:
     index: 1
 
 divisions:
-  1: [albany-1, hackney-1]
+  1:
+    scheme: double_round
+    teams: [albany-1, hackney-1]
 
 club_constraints:
   defaults:

--- a/spec-schema.json
+++ b/spec-schema.json
@@ -52,18 +52,30 @@
     },
     "divisions": {
       "type": "object",
-      "description": "Each team's division, keyed by division number -- the only place a team's division is given. Every team listed under 'teams' must appear in exactly one division's list, and no team ID may appear in more than one.",
+      "description": "Each division's fixture scheme and the teams competing in it, keyed by division number -- the only place a team's division is given. Every team listed under 'teams' must appear in exactly one division's 'teams' list, and no team ID may appear in more than one.",
       "minProperties": 1,
       "propertyNames": {
         "pattern": "^[0-9]+$",
         "description": "A division number."
       },
       "additionalProperties": {
-        "type": "array",
-        "description": "Team IDs (from 'teams') competing in this division.",
-        "items": { "type": "string" },
-        "minItems": 1,
-        "uniqueItems": true
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["scheme", "teams"],
+        "properties": {
+          "scheme": {
+            "type": "string",
+            "enum": ["double_round", "single_round"],
+            "description": "How this division's fixtures are generated. 'double_round': every pair of teams plays twice, once at each team's home venue -- the Double Round All-Play-All basis of Middlesex League Rule 7c. 'single_round': every pair plays once, with the home/away side of each match taken from the Berger table for this division's entrants, drawn in the order they are listed under 'teams' (first listed = table position 1) -- the basis Rule 7c switches to once a division has more than eight teams."
+          },
+          "teams": {
+            "type": "array",
+            "description": "Team IDs (from 'teams') competing in this division. For a 'single_round' division the list order is the Berger table draw: the first team is position 1, the second position 2, and so on.",
+            "items": { "type": "string" },
+            "minItems": 1,
+            "uniqueItems": true
+          }
+        }
       }
     },
     "club_constraints": {

--- a/spec_schema_test.py
+++ b/spec_schema_test.py
@@ -70,8 +70,12 @@ teams:
     name_override: "Hackney Herons"
 
 divisions:
-  1: [albany-1, hackney-1]
-  3: [hackney-5]
+  1:
+    scheme: double_round
+    teams: [albany-1, hackney-1]
+  3:
+    scheme: single_round
+    teams: [hackney-5]
 
 club_constraints:
   defaults:


### PR DESCRIPTION
Middlesex League Rule 7c: a division of more than eight teams plays a single round-robin, with the home/away side of each match taken from the draw for the appropriate Berger table. This adds that as an explicit per-division option.

- berger.py: Berger-table construction (verified against the canonical FIDE 9/10-player table), plus single_round_pairings() to map a drawn team list onto (home, away) fixtures.
- fmodel: FixtureScheme enum; Division value object that owns the double-round vs single-round choice (required_fixtures()); Parameters.division_schemes, a {division number: scheme} mapping from which Parameters.divisions derives the grouped, ordered Division view (a division's team order in Parameters.teams is its Berger draw). solve() now iterates params.divisions.
- Spec format: each `divisions` entry is now a mapping with required `scheme` (double_round | single_round) and `teams`; for single_round the teams list order is the draw. spec-schema.json and README updated to match, and every spec/fixture in the tests and runs/example migrated to the new shape.

All four CI steps pass.


Claude-Session: https://claude.ai/code/session_01SMpyJJQy4XQspvHdsPgALf