### PR TITLE
Show each division's fixture scheme in the HTML report

### DIFF
--- a/csvreport.py
+++ b/csvreport.py
@@ -45,6 +45,7 @@ from typing import TYPE_CHECKING
 import reportdata
 
 if TYPE_CHECKING:
+    import fixturespec
     import fmodel
 
 ALL_MATCHES_FILENAME = "all-matches.csv"
@@ -192,18 +193,22 @@ def _write_csv(path: Path, header: list[str], rows: list[list[str]]) -> None:
 
 
 def generate_csv(
+    spec: fixturespec.Spec,
     fixtures: Collection[fmodel.ScheduledFixture],
-    teams: Collection[fmodel.Team],
-    clubs: Mapping[str, fmodel.Club],
     output_dir: Path,
-    excluded_fixtures: Collection[fmodel.Fixture] = (),
 ) -> list[Path]:
     """Write the CSV exports of a solved fixture list into output_dir.
 
-    See the module docstring for the two files and their columns. Returns the
-    paths written, in the order (all-matches, all-matches-by-team).
+    `spec` supplies the teams, clubs and any excluded_fixtures (withheld matches,
+    written with an empty date); `fixtures` is the solved schedule for it. See the
+    module docstring for the two files and their columns. Returns the paths
+    written, in the order (all-matches, all-matches-by-team).
     """
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    teams = spec.parameters.teams
+    clubs = spec.clubs
+    excluded_fixtures = spec.parameters.excluded_fixtures
 
     all_matches_path = output_dir / ALL_MATCHES_FILENAME
     _write_csv(

--- a/csvreport_test.py
+++ b/csvreport_test.py
@@ -17,10 +17,12 @@
 import csv
 import tempfile
 import unittest
+from collections.abc import Collection, Mapping
 from datetime import date
 from pathlib import Path
 
 import csvreport
+import fixturespec
 import fmodel
 
 
@@ -28,6 +30,28 @@ def _sf(home: fmodel.Team, away: fmodel.Team, d: date) -> fmodel.ScheduledFixtur
     return fmodel.ScheduledFixture(
         fixture=fmodel.Fixture(home_team=home, away_team=away), date=d
     )
+
+
+def _generate_csv(
+    fixtures: Collection[fmodel.ScheduledFixture],
+    teams: Collection[fmodel.Team],
+    clubs: Mapping[str, fmodel.Club],
+    output_dir: Path,
+    *,
+    excluded_fixtures: Collection[fmodel.Fixture] = (),
+) -> list[Path]:
+    """Assemble a minimal fixturespec.Spec from the loose pieces these tests work
+    with and render its CSV exports, so the tests need not build a full
+    fmodel.Parameters just to exercise csvreport.generate_csv()."""
+    parameters = fmodel.Parameters(
+        teams=list(teams),
+        home_dates={},
+        unavailable_away_dates={},
+        max_concurrent_home_matches={},
+        excluded_fixtures=excluded_fixtures,
+    )
+    spec = fixturespec.Spec(parameters=parameters, clubs=clubs)
+    return csvreport.generate_csv(spec, fixtures, output_dir)
 
 
 def _club(name: str, venue: str, address: str, start: str, limit: str) -> fmodel.Club:
@@ -91,7 +115,7 @@ class CsvReportTest(unittest.TestCase):
             return list(csv.DictReader(f))
 
     def test_writes_both_files_and_returns_their_paths(self):
-        paths = csvreport.generate_csv(self.fixtures, self.teams, self.clubs, self.out)
+        paths = _generate_csv(self.fixtures, self.teams, self.clubs, self.out)
         self.assertEqual(
             paths,
             [
@@ -103,7 +127,7 @@ class CsvReportTest(unittest.TestCase):
             self.assertTrue(p.exists())
 
     def test_header_columns(self):
-        csvreport.generate_csv(self.fixtures, self.teams, self.clubs, self.out)
+        _generate_csv(self.fixtures, self.teams, self.clubs, self.out)
         with (self.out / "all-matches.csv").open(newline="") as f:
             self.assertEqual(
                 next(csv.reader(f)),
@@ -143,7 +167,7 @@ class CsvReportTest(unittest.TestCase):
             )
 
     def test_all_matches_one_row_per_match_sorted_by_date(self):
-        csvreport.generate_csv(self.fixtures, self.teams, self.clubs, self.out)
+        _generate_csv(self.fixtures, self.teams, self.clubs, self.out)
         rows = self._rows("all-matches.csv")
 
         self.assertEqual(len(rows), 3)
@@ -165,7 +189,7 @@ class CsvReportTest(unittest.TestCase):
         self.assertEqual(first["time_limit"], "75+15")
 
     def test_all_matches_gives_name_override_plus_club_and_index(self):
-        csvreport.generate_csv(self.fixtures, self.teams, self.clubs, self.out)
+        _generate_csv(self.fixtures, self.teams, self.clubs, self.out)
         hendon_row = next(
             r for r in self._rows("all-matches.csv") if r["date"] == "2025-09-03"
         )
@@ -175,7 +199,7 @@ class CsvReportTest(unittest.TestCase):
         self.assertEqual(hendon_row["away_team_index"], "2")
 
     def test_by_team_has_two_rows_per_match_from_each_side(self):
-        csvreport.generate_csv(self.fixtures, self.teams, self.clubs, self.out)
+        _generate_csv(self.fixtures, self.teams, self.clubs, self.out)
         rows = self._rows("all-matches-by-team.csv")
 
         # 3 matches -> 6 rows.
@@ -199,7 +223,7 @@ class CsvReportTest(unittest.TestCase):
             self.assertEqual(r["start_time"], "19:30")
 
     def test_by_team_grouped_by_team_then_ordered_by_date(self):
-        csvreport.generate_csv(self.fixtures, self.teams, self.clubs, self.out)
+        _generate_csv(self.fixtures, self.teams, self.clubs, self.out)
         rows = self._rows("all-matches-by-team.csv")
 
         # Each team's rows are contiguous, and teams come in (club, index) order.
@@ -217,7 +241,7 @@ class CsvReportTest(unittest.TestCase):
 
     def test_excluded_fixtures_listed_with_empty_date_at_the_end(self):
         excluded = [fmodel.Fixture(home_team=self.harrow1, away_team=self.harrow2)]
-        csvreport.generate_csv(
+        _generate_csv(
             self.fixtures,
             self.teams,
             self.clubs,
@@ -238,7 +262,7 @@ class CsvReportTest(unittest.TestCase):
         self.assertEqual(harrow1_rows[-1]["opponent"], "Harrow 2")
 
     def test_empty_fixture_list_writes_header_only(self):
-        csvreport.generate_csv([], [], self.clubs, self.out)
+        _generate_csv([], [], self.clubs, self.out)
 
         for name in ("all-matches.csv", "all-matches-by-team.csv"):
             text = (self.out / name).read_text()
@@ -246,7 +270,7 @@ class CsvReportTest(unittest.TestCase):
             self.assertTrue(text.endswith("\n"))
 
     def test_uses_unix_line_endings(self):
-        csvreport.generate_csv(self.fixtures, self.teams, self.clubs, self.out)
+        _generate_csv(self.fixtures, self.teams, self.clubs, self.out)
         raw = (self.out / "all-matches.csv").read_bytes()
         self.assertNotIn(b"\r", raw)
 

--- a/htmlreport.py
+++ b/htmlreport.py
@@ -16,9 +16,8 @@
 
 The index-building helpers here (build_run_index and write_runs_index) derive
 the per-run and top-level index.html pages purely from the report files present
-on disk, without needing the original fixtures/teams data or any third-party
-dependency. build_site.py calls them after re-rendering the report pages during
-a GitHub Pages deploy.
+on disk, without needing the original fixtures/teams data. build_site.py calls
+them after re-rendering the report pages during a GitHub Pages deploy.
 """
 
 from __future__ import annotations
@@ -32,10 +31,11 @@ from datetime import date
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import fmodel
 import reportdata
 
 if TYPE_CHECKING:
-    import fmodel
+    import fixturespec
 
 _STYLE = """
     body { font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
@@ -323,6 +323,19 @@ def _anchored_heading(level: int, text: str, anchor_id: str) -> str:
     )
 
 
+def _scheme_subheading(
+    level: int,
+    division_schemes: Mapping[int, fmodel.FixtureScheme],
+    division: int,
+) -> str:
+    """An <hN> sub-heading naming one division's fixture-generation scheme, for the
+    pages and sections that show a single unambiguous division. A division not
+    present in division_schemes uses the default (a double round)."""
+    single = division_schemes.get(division) is fmodel.FixtureScheme.SINGLE_ROUND
+    text = "Single-round all-play-all" if single else "Double-round all-play-all"
+    return f"<h{level}>{html.escape(text)}</h{level}>\n"
+
+
 def _venue_header(club: fmodel.Club) -> str:
     return (
         f'<p class="venue"><strong>{html.escape(club.home_venue_name)}</strong><br>\n'
@@ -385,24 +398,27 @@ _MATCH_HEADERS_WITH_DIVISION = [
 
 
 def generate_report(
+    spec: fixturespec.Spec,
     fixtures: Collection[fmodel.ScheduledFixture],
-    teams: Collection[fmodel.Team],
-    clubs: Mapping[str, fmodel.Club],
     output_dir: Path,
-    excluded_fixtures: Collection[fmodel.Fixture] = (),
-    name: str = "",
-    draft: bool = False,
-    description: str = "",
 ) -> Path:
     """Write all HTML report pages for a solved fixture list into output_dir.
 
-    excluded_fixtures (fixtures withheld from scheduling entirely, to be arranged
-    in a later run) are appended to the bottom of every relevant table with "TBC"
-    in place of a date.
+    `spec` supplies everything about the season except the solved dates -- teams,
+    clubs, the run name/draft/description banners, each division's fixture scheme,
+    and any excluded_fixtures (withheld from scheduling entirely, to be arranged
+    in a later run; these are appended to the bottom of every relevant table with
+    "TBC" in place of a date). `fixtures` is the solved schedule for that spec.
 
     Returns the path to the run's index.html.
     """
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    teams = spec.parameters.teams
+    clubs = spec.clubs
+    excluded_fixtures = spec.parameters.excluded_fixtures
+    schemes = spec.parameters.division_schemes
+    name, draft, description = spec.name, spec.draft, spec.description
 
     fixtures_by_division: dict[int, list[fmodel.ScheduledFixture]] = defaultdict(list)
     for sf in fixtures:
@@ -455,7 +471,8 @@ def generate_report(
         (output_dir / f"division-{division}.html").write_text(
             _page(
                 f"Division {division}",
-                _table(
+                _scheme_subheading(2, schemes, division)
+                + _table(
                     _MATCH_HEADERS,
                     _rows(fixtures_by_division[division], clubs)
                     + _excluded_rows(excluded_by_division[division], clubs),
@@ -489,6 +506,7 @@ def generate_report(
             team_name = reportdata.team_name(team, clubs)
             body += _anchored_heading(2, team_name, slugify(team_name))
             body += f"<h3>Division {team.division}</h3>\n"
+            body += _scheme_subheading(4, schemes, team.division)
             body += _table(
                 _TEAM_MATCH_HEADERS,
                 _team_rows(team, team_fixtures, clubs)

--- a/htmlreport_test.py
+++ b/htmlreport_test.py
@@ -16,9 +16,11 @@
 
 import tempfile
 import unittest
+from collections.abc import Collection, Mapping
 from datetime import date
 from pathlib import Path
 
+import fixturespec
 import fmodel
 import htmlreport
 
@@ -27,6 +29,39 @@ def _sf(home: fmodel.Team, away: fmodel.Team, d: date) -> fmodel.ScheduledFixtur
     return fmodel.ScheduledFixture(
         fixture=fmodel.Fixture(home_team=home, away_team=away), date=d
     )
+
+
+def _generate(
+    fixtures: Collection[fmodel.ScheduledFixture],
+    teams: Collection[fmodel.Team],
+    clubs: Mapping[str, fmodel.Club],
+    output_dir: Path,
+    *,
+    excluded_fixtures: Collection[fmodel.Fixture] = (),
+    name: str = "",
+    draft: bool = False,
+    description: str = "",
+    division_schemes: Mapping[int, fmodel.FixtureScheme] | None = None,
+) -> Path:
+    """Assemble a minimal fixturespec.Spec from the loose pieces these tests work
+    with and render its HTML report, so the tests need not build a full
+    fmodel.Parameters just to exercise htmlreport.generate_report()."""
+    parameters = fmodel.Parameters(
+        teams=list(teams),
+        home_dates={},
+        unavailable_away_dates={},
+        max_concurrent_home_matches={},
+        excluded_fixtures=excluded_fixtures,
+        division_schemes=division_schemes or {},
+    )
+    spec = fixturespec.Spec(
+        parameters=parameters,
+        clubs=clubs,
+        name=name,
+        draft=draft,
+        description=description,
+    )
+    return htmlreport.generate_report(spec, fixtures, output_dir)
 
 
 def _club(
@@ -116,7 +151,7 @@ class TestGenerateReport(unittest.TestCase):
             _sf(self.hendon1, self.willesden1, date(2025, 9, 3)),
         ]
 
-        self.index_path = htmlreport.generate_report(
+        self.index_path = _generate(
             self.fixtures, self.teams, self.clubs, self.output_dir
         )
 
@@ -180,6 +215,41 @@ class TestGenerateReport(unittest.TestCase):
         div2 = (self.output_dir / "division-2.html").read_text()
         self.assertIn("Hendon 1", div2)
         self.assertIn("Willesden Warriors", div2)
+
+    def test_division_page_has_fixture_scheme_subheading(self):
+        # No division_schemes passed -> every division defaults to a double round.
+        div1 = (self.output_dir / "division-1.html").read_text()
+        self.assertIn("<h2>Double-round all-play-all</h2>", div1)
+        self.assertNotIn("Single-round", div1)
+
+    def test_club_per_team_section_has_fixture_scheme_subheading(self):
+        harrow_page = (self.output_dir / "club-harrow.html").read_text()
+        harrow1_section = harrow_page.split('<h2 id="harrow-1">')[1].split("<h2")[0]
+        self.assertIn("<h3>Division 1</h3>", harrow1_section)
+        self.assertIn("<h4>Double-round all-play-all</h4>", harrow1_section)
+        # The consolidated table above the per-team sections spans divisions, so it
+        # gets no scheme sub-heading.
+        consolidated = harrow_page.split("<h2")[0]
+        self.assertNotIn("all-play-all", consolidated)
+
+    def test_single_round_division_scheme_shown_on_its_pages_only(self):
+        out2 = Path(self._tmpdir.name) / "out-scheme"
+        _generate(
+            self.fixtures,
+            self.teams,
+            self.clubs,
+            out2,
+            division_schemes={2: fmodel.FixtureScheme.SINGLE_ROUND},
+        )
+        div2 = (out2 / "division-2.html").read_text()
+        self.assertIn("<h2>Single-round all-play-all</h2>", div2)
+        # Division 1 has no entry, so it stays a double round.
+        div1 = (out2 / "division-1.html").read_text()
+        self.assertIn("<h2>Double-round all-play-all</h2>", div1)
+        # Hendon 1 is in division 2, so its per-team section reflects single round.
+        hendon_page = (out2 / "club-hendon.html").read_text()
+        hendon1_section = hendon_page.split('<h2 id="hendon-1">')[1]
+        self.assertIn("<h4>Single-round all-play-all</h4>", hendon1_section)
 
     def test_club_page_consolidated_and_per_team(self):
         harrow_page = (self.output_dir / "club-harrow.html").read_text()
@@ -245,7 +315,7 @@ class TestGenerateReport(unittest.TestCase):
         )
 
     def test_run_index_has_no_csv_links_when_exports_absent(self):
-        # setUp's generate_report() writes HTML pages only, no CSV files.
+        # setUp's _generate() writes HTML pages only, no CSV files.
         self.assertNotIn(".csv", self.index_path.read_text())
 
     def test_build_run_index_is_rebuildable_from_disk_alone(self):
@@ -277,7 +347,7 @@ class TestGenerateReport(unittest.TestCase):
         lonely_clubs = {"lonely-fc": _club("Lonely FC")}
         lonely = fmodel.Team(division=3, club="lonely-fc", index=1)
         out2 = Path(self._tmpdir.name) / "out2"
-        htmlreport.generate_report([], [lonely], lonely_clubs, out2)
+        _generate([], [lonely], lonely_clubs, out2)
         content = (out2 / "club-lonely-fc.html").read_text()
         self.assertIn("No matches", content)
 
@@ -296,7 +366,7 @@ class TestGenerateReport(unittest.TestCase):
 
     def test_run_name_and_draft_shown_on_every_page(self):
         out2 = Path(self._tmpdir.name) / "out-named"
-        index_path = htmlreport.generate_report(
+        index_path = _generate(
             self.fixtures,
             self.teams,
             self.clubs,
@@ -319,7 +389,7 @@ class TestGenerateReport(unittest.TestCase):
         """Rebuilding index.html from scratch must recover the run name/draft status
         from the other report files, since build_run_index has no other source for them."""
         out2 = Path(self._tmpdir.name) / "out-rebuilt"
-        index_path = htmlreport.generate_report(
+        index_path = _generate(
             self.fixtures, self.teams, self.clubs, out2, name="Test Run", draft=True
         )
         index_path.unlink()
@@ -330,7 +400,7 @@ class TestGenerateReport(unittest.TestCase):
 
     def test_description_shown_on_every_page(self):
         out2 = Path(self._tmpdir.name) / "out-described"
-        index_path = htmlreport.generate_report(
+        index_path = _generate(
             self.fixtures,
             self.teams,
             self.clubs,
@@ -350,7 +420,7 @@ class TestGenerateReport(unittest.TestCase):
     def test_index_recovers_description_from_disk_alone(self):
         """Rebuilding index.html must recover the description from the other report files."""
         out2 = Path(self._tmpdir.name) / "out-desc-rebuilt"
-        index_path = htmlreport.generate_report(
+        index_path = _generate(
             self.fixtures,
             self.teams,
             self.clubs,
@@ -386,7 +456,7 @@ class TestExcludedFixturesInReport(unittest.TestCase):
         self.fixtures = [_sf(self.harrow1, self.ealing1, date(2025, 9, 1))]
         self.excluded = [fmodel.Fixture(home_team=self.harrow2, away_team=self.ealing1)]
 
-        self.index_path = htmlreport.generate_report(
+        self.index_path = _generate(
             self.fixtures,
             self.teams,
             self.clubs,
@@ -429,7 +499,7 @@ class TestExcludedFixturesInReport(unittest.TestCase):
 
     def test_no_excluded_fixtures_by_default(self):
         out2 = Path(self._tmpdir.name) / "out-no-excluded"
-        htmlreport.generate_report(self.fixtures, self.teams, self.clubs, out2)
+        _generate(self.fixtures, self.teams, self.clubs, out2)
         content = (out2 / "all-matches.html").read_text()
         self.assertNotIn("TBC", content)
 
@@ -446,9 +516,7 @@ class TestExcludedFixturesInReport(unittest.TestCase):
         ]
 
         out2 = Path(self._tmpdir.name) / "out-div2"
-        htmlreport.generate_report(
-            self.fixtures, teams, clubs, out2, excluded_fixtures=excluded
-        )
+        _generate(self.fixtures, teams, clubs, out2, excluded_fixtures=excluded)
         div2 = (out2 / "division-2.html").read_text()
         self.assertIn("TBC", div2)
         self.assertIn("Hendon 1", div2)

--- a/report.py
+++ b/report.py
@@ -47,23 +47,8 @@ def report(spec_path: Path, solution_path: Path, output_dir: Path) -> Path:
     fixtures = fixturesolution.load_solution(
         solution_path, spec.parameters.teams, team_ids
     )
-    csvreport.generate_csv(
-        fixtures,
-        spec.parameters.teams,
-        spec.clubs,
-        output_dir,
-        excluded_fixtures=spec.parameters.excluded_fixtures,
-    )
-    return htmlreport.generate_report(
-        fixtures,
-        spec.parameters.teams,
-        spec.clubs,
-        output_dir,
-        excluded_fixtures=spec.parameters.excluded_fixtures,
-        name=spec.name,
-        draft=spec.draft,
-        description=spec.description,
-    )
+    csvreport.generate_csv(spec, fixtures, output_dir)
+    return htmlreport.generate_report(spec, fixtures, output_dir)
 
 
 def main() -> None:


### PR DESCRIPTION
Add a sub-heading naming the fixture-generation scheme ("Single-round all-play-all" / "Double-round all-play-all") to every report section that covers a single unambiguous division: an `h2` on the division pages and an `h4` under the per-team headings on the club pages. The consolidated club table and the all-matches page span divisions, so they are left alone.

While here, simplify the two report entry points to take the loaded spec directly instead of a spread of its members:

  htmlreport.generate_report(spec, fixtures, output_dir)
  csvreport.generate_csv(spec, fixtures, output_dir)

teams, clubs, excluded_fixtures, the name/draft/description banners and the division schemes are all read off `spec` inside. The tests gain a small helper that builds a minimal fixturespec.Spec from the loose pieces they work with.

htmlreport.py now imports fmodel directly rather than under TYPE_CHECKING: nothing imports it (or csvreport/reportdata) without ortools already loaded, and the Pages build runs `uv sync --dev`, so the "no third-party dependency" contortion (a FixtureScheme.value string compare) bought nothing.


Claude-Session: https://claude.ai/code/session_01SMpyJJQy4XQspvHdsPgALf