### PR TITLE
Put the per-team scheme label in the division heading

### DIFF
--- a/htmlreport.py
+++ b/htmlreport.py
@@ -323,17 +323,14 @@ def _anchored_heading(level: int, text: str, anchor_id: str) -> str:
     )
 
 
-def _scheme_subheading(
-    level: int,
-    division_schemes: Mapping[int, fmodel.FixtureScheme],
-    division: int,
+def _scheme_label(
+    division_schemes: Mapping[int, fmodel.FixtureScheme], division: int
 ) -> str:
-    """An <hN> sub-heading naming one division's fixture-generation scheme, for the
-    pages and sections that show a single unambiguous division. A division not
-    present in division_schemes uses the default (a double round)."""
+    """The name of a division's fixture-generation scheme, for the pages and
+    sections that cover a single unambiguous division. A division not present in
+    division_schemes uses the default (a double round)."""
     single = division_schemes.get(division) is fmodel.FixtureScheme.SINGLE_ROUND
-    text = "Single-round all-play-all" if single else "Double-round all-play-all"
-    return f"<h{level}>{html.escape(text)}</h{level}>\n"
+    return "Single-round all-play-all" if single else "Double-round all-play-all"
 
 
 def _venue_header(club: fmodel.Club) -> str:
@@ -471,7 +468,7 @@ def generate_report(
         (output_dir / f"division-{division}.html").write_text(
             _page(
                 f"Division {division}",
-                _scheme_subheading(2, schemes, division)
+                f"<h2>{html.escape(_scheme_label(schemes, division))}</h2>\n"
                 + _table(
                     _MATCH_HEADERS,
                     _rows(fixtures_by_division[division], clubs)
@@ -505,8 +502,8 @@ def generate_report(
             ]
             team_name = reportdata.team_name(team, clubs)
             body += _anchored_heading(2, team_name, slugify(team_name))
-            body += f"<h3>Division {team.division}</h3>\n"
-            body += _scheme_subheading(4, schemes, team.division)
+            scheme_label = _scheme_label(schemes, team.division)
+            body += f"<h3>Division {team.division} ({html.escape(scheme_label)})</h3>\n"
             body += _table(
                 _TEAM_MATCH_HEADERS,
                 _team_rows(team, team_fixtures, clubs)

--- a/htmlreport_test.py
+++ b/htmlreport_test.py
@@ -216,19 +216,20 @@ class TestGenerateReport(unittest.TestCase):
         self.assertIn("Hendon 1", div2)
         self.assertIn("Willesden Warriors", div2)
 
-    def test_division_page_has_fixture_scheme_subheading(self):
+    def test_division_page_names_the_fixture_scheme_in_a_subheading(self):
         # No division_schemes passed -> every division defaults to a double round.
         div1 = (self.output_dir / "division-1.html").read_text()
         self.assertIn("<h2>Double-round all-play-all</h2>", div1)
         self.assertNotIn("Single-round", div1)
 
-    def test_club_per_team_section_has_fixture_scheme_subheading(self):
+    def test_club_per_team_heading_names_the_fixture_scheme_in_brackets(self):
         harrow_page = (self.output_dir / "club-harrow.html").read_text()
         harrow1_section = harrow_page.split('<h2 id="harrow-1">')[1].split("<h2")[0]
-        self.assertIn("<h3>Division 1</h3>", harrow1_section)
-        self.assertIn("<h4>Double-round all-play-all</h4>", harrow1_section)
+        self.assertIn(
+            "<h3>Division 1 (Double-round all-play-all)</h3>", harrow1_section
+        )
         # The consolidated table above the per-team sections spans divisions, so it
-        # gets no scheme sub-heading.
+        # names no scheme.
         consolidated = harrow_page.split("<h2")[0]
         self.assertNotIn("all-play-all", consolidated)
 
@@ -246,10 +247,12 @@ class TestGenerateReport(unittest.TestCase):
         # Division 1 has no entry, so it stays a double round.
         div1 = (out2 / "division-1.html").read_text()
         self.assertIn("<h2>Double-round all-play-all</h2>", div1)
-        # Hendon 1 is in division 2, so its per-team section reflects single round.
+        # Hendon 1 is in division 2, so its per-team heading reflects single round.
         hendon_page = (out2 / "club-hendon.html").read_text()
         hendon1_section = hendon_page.split('<h2 id="hendon-1">')[1]
-        self.assertIn("<h4>Single-round all-play-all</h4>", hendon1_section)
+        self.assertIn(
+            "<h3>Division 2 (Single-round all-play-all)</h3>", hendon1_section
+        )
 
     def test_club_page_consolidated_and_per_team(self):
         harrow_page = (self.output_dir / "club-harrow.html").read_text()


### PR DESCRIPTION
On the club pages, show a team's division fixture scheme in brackets after the division name ("Division 3 (Single-round all-play-all)") rather than as a separate, smaller `h4` beneath it. The division pages keep the scheme as their `h2` sub-heading. _scheme_subheading is replaced by _scheme_label, which returns just the text for each caller to place.


Claude-Session: https://claude.ai/code/session_01SMpyJJQy4XQspvHdsPgALf