### PR TITLE
Upgrade astral-sh/setup-uv v6 -> v10.0.1 (closes #57)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        # Pinned to an exact version: setup-uv stopped publishing floating
+        # major/minor tags (e.g. @v10) from v8 onwards for supply-chain safety.
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,7 +24,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        # Pinned to an exact version: setup-uv stopped publishing floating
+        # major/minor tags (e.g. @v10) from v8 onwards for supply-chain safety.
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           python-version: "3.14"
 


### PR DESCRIPTION
v6 runs on the deprecated Node 20, triggering GitHub Actions warnings. The Node 24 switch landed in setup-uv v7.0.0; v10.0.1 is the latest.

Pinned to an exact version because setup-uv stopped publishing floating major/minor tags from v8 onwards. None of the v7-v10 breaking changes (Node 24, tag scheme, prune-cache default, sensitive-event cache disabling) affect these workflows, which only pass python-version and run on push/pull_request.

The other actions (checkout@v7, upload-pages-artifact@v5, deploy-pages@v5) are already on their latest majors and Node 24.


Claude-Session: https://claude.ai/code/session_01LT8XLuSXsQsXiNDAigCS1X