### PR TITLE
Replace max_home_dates_used with home_dates_used {min, max} (closes #49)

### DIFF
--- a/fixturespec.py
+++ b/fixturespec.py
@@ -343,11 +343,46 @@ def _parse_max_concurrent_home_matches_value(
     )
 
 
+def _parse_home_dates_used_value(
+    value: Any, context: str
+) -> fmodel.HomeDatesUsedBounds:
+    """A club's home_dates_used value: a mapping with 'min', 'max', or both (each a
+    positive integer). Bounds how many of the club's home_dates end up hosting a
+    match -- 'max' to pack matches onto fewer evenings, 'min' to spread them out.
+    """
+    if not isinstance(value, dict):
+        raise SpecError(
+            f"{context}: expected a mapping with 'min' and/or 'max', got {value!r}"
+        )
+    unsupported = value.keys() - _HOME_DATES_USED_FIELD_KEYS
+    if unsupported:
+        raise SpecError(
+            f"{context}.{sorted(unsupported)} not supported (only "
+            f"{sorted(_HOME_DATES_USED_FIELD_KEYS)} are)"
+        )
+    if not value:
+        raise SpecError(f"{context}: needs at least one of 'min', 'max'")
+
+    bounds: dict[str, int] = {}
+    for key in ("min", "max"):
+        if key in value:
+            n = _require_int(value[key], f"{context}.{key}")
+            if n < 1:
+                raise SpecError(f"{context}.{key} must be at least 1, got {n}")
+            bounds[key] = n
+    try:
+        return fmodel.HomeDatesUsedBounds(
+            minimum=bounds.get("min"), maximum=bounds.get("max")
+        )
+    except ValueError as e:
+        raise SpecError(f"{context}: {e}") from e
+
+
 _CLUB_CONSTRAINT_FIELD_KEYS = {
     "home_dates",
     "unavailable_away_dates",
     "max_concurrent_home_matches",
-    "max_home_dates_used",
+    "home_dates_used",
     "teams",
     "avoid_coscheduling_teams",
 }
@@ -356,8 +391,10 @@ _TEAM_CONSTRAINT_FIELD_KEYS = {"unavailable_home_dates", "unavailable_away_dates
 
 _AVOID_COSCHEDULING_FIELD_KEYS = {"teams", "within_days", "applies_to"}
 
+_HOME_DATES_USED_FIELD_KEYS = {"min", "max"}
+
 # Constraint types with a notion of a default, overridable per club. Other constraint
-# types (home_dates, unavailable_away_dates, max_home_dates_used, teams,
+# types (home_dates, unavailable_away_dates, home_dates_used, teams,
 # avoid_coscheduling_teams) have no meaningful spec-wide default, so aren't accepted
 # under 'defaults'.
 _CLUB_CONSTRAINT_DEFAULTS_KEYS = {"max_concurrent_home_matches"}
@@ -368,7 +405,7 @@ class _ClubConstraints:
     home_dates: dict[str, list[date]]
     unavailable_away_dates: dict[str, list[date]]
     max_concurrent_home_matches: dict[str, fmodel.MaxConcurrentHomeMatches]
-    max_home_dates_used: dict[str, int]
+    home_dates_used: dict[str, fmodel.HomeDatesUsedBounds]
     team_home_dates: dict[fmodel.Team, list[date]]
     team_unavailable_away_dates: dict[fmodel.Team, list[date]]
     avoid_coscheduling_teams: list[fmodel.AvoidCoschedulingConstraint]
@@ -381,7 +418,7 @@ def _parse_club_constraints(
     path: Path,
 ) -> _ClubConstraints:
     """Parse the 'club_constraints' section: per-club home_dates, unavailable_away_dates,
-    max_concurrent_home_matches, max_home_dates_used, teams and
+    max_concurrent_home_matches, home_dates_used, teams and
     avoid_coscheduling_teams, keyed directly by club ID.
 
     An optional 'defaults' entry (a sibling of the club entries) supplies a spec-wide
@@ -429,7 +466,7 @@ def _parse_club_constraints(
     home_dates: dict[str, list[date]] = {}
     unavailable_away_dates: dict[str, list[date]] = {}
     max_concurrent_home_matches: dict[str, fmodel.MaxConcurrentHomeMatches] = {}
-    max_home_dates_used: dict[str, int] = {}
+    home_dates_used: dict[str, fmodel.HomeDatesUsedBounds] = {}
     team_home_dates: dict[fmodel.Team, list[date]] = {}
     team_unavailable_away_dates: dict[fmodel.Team, list[date]] = {}
     avoid_coscheduling_teams: list[fmodel.AvoidCoschedulingConstraint] = []
@@ -467,10 +504,10 @@ def _parse_club_constraints(
         else:
             missing_max_concurrent.append(club_id)
 
-        if "max_home_dates_used" in club_spec:
-            max_home_dates_used[club_id] = _require_int(
-                club_spec["max_home_dates_used"],
-                f"{path}: {section_name}[{club_id!r}].max_home_dates_used",
+        if "home_dates_used" in club_spec:
+            home_dates_used[club_id] = _parse_home_dates_used_value(
+                club_spec["home_dates_used"],
+                f"{path}: {section_name}[{club_id!r}].home_dates_used",
             )
 
         club_team_home_dates, club_team_unavailable_away_dates = (
@@ -505,7 +542,7 @@ def _parse_club_constraints(
         home_dates=home_dates,
         unavailable_away_dates=unavailable_away_dates,
         max_concurrent_home_matches=max_concurrent_home_matches,
-        max_home_dates_used=max_home_dates_used,
+        home_dates_used=home_dates_used,
         team_home_dates=team_home_dates,
         team_unavailable_away_dates=team_unavailable_away_dates,
         avoid_coscheduling_teams=avoid_coscheduling_teams,
@@ -920,8 +957,8 @@ def load_spec(spec_path: str | Path) -> Spec:
     kwargs: dict[str, Any] = {}
     if "min_gap_days" in data:
         kwargs["min_gap_days"] = data["min_gap_days"]
-    if club_constraints.max_home_dates_used:
-        kwargs["max_home_dates_used"] = club_constraints.max_home_dates_used
+    if club_constraints.home_dates_used:
+        kwargs["home_dates_used"] = club_constraints.home_dates_used
     if team_home_dates:
         kwargs["team_home_dates"] = team_home_dates
     if team_unavailable_away_dates:

--- a/fixturespec_test.py
+++ b/fixturespec_test.py
@@ -797,60 +797,130 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "mapping"):
             fixturespec.load_spec(path)
 
-    def test_max_home_dates_used_per_club(self):
+    def test_home_dates_used_per_club(self):
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    max_concurrent_home_matches: 1\n"
             "  albany:\n"
-            "    max_home_dates_used: 1\n"
+            "    home_dates_used:\n"
+            "      max: 1\n"
             "  hackney:\n"
-            "    max_home_dates_used: 1\n"
+            "    home_dates_used:\n"
+            "      min: 2\n"
+            "      max: 4\n"
         )
         spec = fixturespec.load_spec(path)
         self.assertEqual(
-            spec.parameters.max_home_dates_used, {"albany": 1, "hackney": 1}
+            spec.parameters.home_dates_used,
+            {
+                "albany": fmodel.HomeDatesUsedBounds(maximum=1),
+                "hackney": fmodel.HomeDatesUsedBounds(minimum=2, maximum=4),
+            },
         )
 
-    def test_max_home_dates_used_partial_clubs(self):
+    def test_home_dates_used_partial_clubs(self):
         """Only the clubs given their own entry are constrained."""
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    max_concurrent_home_matches: 1\n"
             "  albany:\n"
-            "    max_home_dates_used: 1\n"
+            "    home_dates_used:\n"
+            "      min: 3\n"
         )
         spec = fixturespec.load_spec(path)
-        self.assertEqual(spec.parameters.max_home_dates_used, {"albany": 1})
+        self.assertEqual(
+            spec.parameters.home_dates_used,
+            {"albany": fmodel.HomeDatesUsedBounds(minimum=3)},
+        )
 
-    def test_max_home_dates_used_absent(self):
+    def test_home_dates_used_absent(self):
         path = self._write(_MINIMAL_SPEC)
         spec = fixturespec.load_spec(path)
-        self.assertEqual(spec.parameters.max_home_dates_used, {})
+        self.assertEqual(spec.parameters.home_dates_used, {})
 
-    def test_max_home_dates_used_unknown_club(self):
+    def test_home_dates_used_unknown_club(self):
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    max_concurrent_home_matches: 1\n"
             "  unknown-club:\n"
-            "    max_home_dates_used: 1\n"
+            "    home_dates_used:\n"
+            "      max: 1\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "unknown-club"):
             fixturespec.load_spec(path)
 
-    def test_max_home_dates_used_not_int(self):
+    def test_home_dates_used_not_int(self):
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    max_concurrent_home_matches: 1\n"
             "  albany:\n"
-            "    max_home_dates_used: not-an-int\n"
-            "  hackney:\n"
-            "    max_home_dates_used: 1\n"
+            "    home_dates_used:\n"
+            "      max: not-an-int\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "integer"):
+            fixturespec.load_spec(path)
+
+    def test_home_dates_used_not_a_mapping(self):
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  defaults:\n"
+            "    max_concurrent_home_matches: 1\n"
+            "  albany:\n"
+            "    home_dates_used: 1\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "mapping"):
+            fixturespec.load_spec(path)
+
+    def test_home_dates_used_empty_mapping(self):
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  defaults:\n"
+            "    max_concurrent_home_matches: 1\n"
+            "  albany:\n"
+            "    home_dates_used: {}\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "min.*max"):
+            fixturespec.load_spec(path)
+
+    def test_home_dates_used_unsupported_key(self):
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  defaults:\n"
+            "    max_concurrent_home_matches: 1\n"
+            "  albany:\n"
+            "    home_dates_used:\n"
+            "      minimum: 2\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "minimum"):
+            fixturespec.load_spec(path)
+
+    def test_home_dates_used_below_one(self):
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  defaults:\n"
+            "    max_concurrent_home_matches: 1\n"
+            "  albany:\n"
+            "    home_dates_used:\n"
+            "      min: 0\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "at least 1"):
+            fixturespec.load_spec(path)
+
+    def test_home_dates_used_min_exceeds_max(self):
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  defaults:\n"
+            "    max_concurrent_home_matches: 1\n"
+            "  albany:\n"
+            "    home_dates_used:\n"
+            "      min: 5\n"
+            "      max: 3\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "exceeds"):
             fixturespec.load_spec(path)
 
     def test_fixed_fixture(self):

--- a/fmodel.py
+++ b/fmodel.py
@@ -93,6 +93,34 @@ class MaxConcurrentHomeMatches:
         return self.overrides.get(d, self.default)
 
 
+@dataclasses.dataclass(frozen=True)
+class HomeDatesUsedBounds:
+    """Bounds on how many distinct dates a club actually hosts home matches on in
+    the solved schedule (out of the dates offered in its home_dates).
+
+    A `maximum` packs the club's home matches onto fewer dates -- more matches per
+    evening on average; a `minimum` spreads them over more dates -- fewer per
+    evening. Either bound may be None (unbounded on that side), but at least one
+    must be set.
+    """
+
+    minimum: int | None = None
+    maximum: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.minimum is None and self.maximum is None:
+            raise ValueError("HomeDatesUsedBounds needs a minimum or a maximum")
+        if (
+            self.minimum is not None
+            and self.maximum is not None
+            and self.minimum > self.maximum
+        ):
+            raise ValueError(
+                f"HomeDatesUsedBounds minimum {self.minimum} exceeds "
+                f"maximum {self.maximum}"
+            )
+
+
 class FixtureScheme(enum.Enum):
     """How a division's fixtures are generated.
 
@@ -197,7 +225,9 @@ class Parameters:
     unavailable_away_dates: Mapping[ClubT, list[date]]
     max_concurrent_home_matches: Mapping[ClubT, MaxConcurrentHomeMatches]
     min_gap_days: int = 7
-    max_home_dates_used: Mapping[ClubT, int] = dataclasses.field(default_factory=dict)
+    home_dates_used: Mapping[ClubT, HomeDatesUsedBounds] = dataclasses.field(
+        default_factory=dict
+    )
     fixed_fixtures: Collection[ScheduledFixture] = ()
     excluded_fixtures: Collection[Fixture] = ()
     latest_internal_match_date: date | None = None
@@ -306,19 +336,20 @@ def date_windows(dates: Collection[date], window_days: int) -> list[frozenset[da
     return result
 
 
-def _add_max_home_dates_used_constraints(
+def _add_home_dates_used_constraints(
     model: cp_model.CpModel,
-    max_home_dates_used: Mapping[ClubT, int],
+    home_dates_used: Mapping[ClubT, HomeDatesUsedBounds],
     vars_by_club_home_date: Mapping[tuple[str, date], list[cp_model.IntVar]],
 ) -> None:
-    """For each club in max_home_dates_used, add constraints limiting the number of home dates used."""
+    """For each club in home_dates_used, bound the number of its home dates that
+    end up hosting at least one match (below by `minimum`, above by `maximum`)."""
     # Collect the set of home dates per club that appear in the variable map
     clubs_home_dates: MutableMapping[str, list[date]] = collections.defaultdict(list)
     for club, d in vars_by_club_home_date:
-        if club in max_home_dates_used:
+        if club in home_dates_used:
             clubs_home_dates[club].append(d)
 
-    for club, limit in max_home_dates_used.items():
+    for club, bounds in home_dates_used.items():
         date_used_vars = []
         for d in clubs_home_dates[club]:
             date_vars = vars_by_club_home_date[(club, d)]
@@ -331,7 +362,11 @@ def _add_max_home_dates_used_constraints(
                 date_used.negated()
             )
             date_used_vars.append(date_used)
-        model.add(cp_model.LinearExpr.Sum(date_used_vars) <= limit)
+        total_used = cp_model.LinearExpr.Sum(date_used_vars)
+        if bounds.maximum is not None:
+            model.add(total_used <= bounds.maximum)
+        if bounds.minimum is not None:
+            model.add(total_used >= bounds.minimum)
 
 
 def _add_avoid_coscheduling_constraints(
@@ -469,8 +504,8 @@ def solve(params: Parameters) -> Collection[ScheduledFixture]:
         if max_matches is not None:
             model.add(cp_model.LinearExpr.Sum(club_home_date_vars) <= max_matches)
 
-    _add_max_home_dates_used_constraints(
-        model, params.max_home_dates_used, vars_by_club_home_date
+    _add_home_dates_used_constraints(
+        model, params.home_dates_used, vars_by_club_home_date
     )
     _add_avoid_coscheduling_constraints(
         model, params.avoid_coscheduling_teams, vars_by_fixture_date

--- a/model_test.py
+++ b/model_test.py
@@ -290,16 +290,32 @@ class TestMaxConcurrentHomeMatchesFor(unittest.TestCase):
         self.assertIsNone(params.max_concurrent_home_matches_for("A", date(2025, 1, 1)))
 
 
-class TestMaxHomeDatesUsed(unittest.TestCase):
-    """Test cases for the max_home_dates_used constraint."""
+class TestHomeDatesUsedBounds(unittest.TestCase):
+    """Validation of the HomeDatesUsedBounds value object itself."""
+
+    def test_requires_at_least_one_bound(self):
+        with self.assertRaises(ValueError):
+            fmodel.HomeDatesUsedBounds()
+
+    def test_rejects_min_above_max(self):
+        with self.assertRaises(ValueError):
+            fmodel.HomeDatesUsedBounds(minimum=5, maximum=3)
+
+    def test_equal_min_and_max_allowed(self):
+        bounds = fmodel.HomeDatesUsedBounds(minimum=3, maximum=3)
+        self.assertEqual((bounds.minimum, bounds.maximum), (3, 3))
+
+
+class TestHomeDatesUsed(unittest.TestCase):
+    """Test cases for the home_dates_used (min/max) constraint."""
 
     def test_constraint_limits_dates_used(self):
-        """Solver uses at most max_home_dates_used home dates for a club.
+        """Solver uses at most home_dates_used.maximum home dates for a club.
 
         Club "A" has two teams in a division with six other teams (one each from
         clubs B-G).  Each A team plays seven home matches (one vs each of the
         other seven teams, including the intra-club match).  A has twelve weekly
-        home dates available but max_home_dates_used is set to 8.  With
+        home dates available but home_dates_used.maximum is set to 8.  With
         max_concurrent_home_matches=2, the solver can pack two home matches per
         date, so 14 total A home matches fit in 8 dates (capacity 16).  This
         leaves at least four of A's twelve available home dates completely unused.
@@ -332,7 +348,7 @@ class TestMaxHomeDatesUsed(unittest.TestCase):
                 **{c: fmodel.MaxConcurrentHomeMatches(default=1) for c in other_clubs},
             },
             min_gap_days=0,
-            max_home_dates_used={"A": 8},
+            home_dates_used={"A": fmodel.HomeDatesUsedBounds(maximum=8)},
         )
         fixtures = list(fmodel.solve(params))
 
@@ -341,11 +357,77 @@ class TestMaxHomeDatesUsed(unittest.TestCase):
         unused_a_dates = set(a_home_dates) - a_dates_used
         self.assertGreaterEqual(len(unused_a_dates), 4)
 
+    def test_min_constraint_spreads_dates_used(self):
+        """Solver uses at least home_dates_used.minimum home dates for a club.
+
+        Same shape as test_constraint_limits_dates_used: club "A" has two teams
+        playing 14 home matches between them, 12 weekly home dates available, and
+        max_concurrent_home_matches=2 -- so absent any spread constraint the solver
+        could pack them onto as few as 7 dates.  home_dates_used.minimum=10 forces
+        it to use at least 10 distinct dates instead.
+        """
+        other_clubs = ["B", "C", "D", "E", "F", "G"]
+        teams = [
+            fmodel.Team(division=1, club="A", index=1),
+            fmodel.Team(division=1, club="A", index=2),
+        ] + [fmodel.Team(division=1, club=c, index=1) for c in other_clubs]
+
+        a_start = date(2025, 1, 6)
+        a_home_dates = [a_start + timedelta(weeks=i) for i in range(12)]
+        other_home_dates = {
+            c: [date(2025, 9, 1) + timedelta(days=i, weeks=j) for j in range(8)]
+            for i, c in enumerate(other_clubs)
+        }
+        home_dates = {"A": a_home_dates} | other_home_dates
+
+        all_clubs = ["A"] + other_clubs
+        params = fmodel.Parameters(
+            teams=teams,
+            home_dates=home_dates,
+            unavailable_away_dates={c: [] for c in all_clubs},
+            max_concurrent_home_matches={
+                "A": fmodel.MaxConcurrentHomeMatches(default=2),
+                **{c: fmodel.MaxConcurrentHomeMatches(default=1) for c in other_clubs},
+            },
+            min_gap_days=0,
+            home_dates_used={"A": fmodel.HomeDatesUsedBounds(minimum=10)},
+        )
+        fixtures = list(fmodel.solve(params))
+
+        a_dates_used = {sf.date for sf in fixtures if sf.fixture.home_team.club == "A"}
+        self.assertGreaterEqual(len(a_dates_used), 10)
+
+    def test_min_constraint_enforced_strictly(self):
+        """A club whose schedule can't reach home_dates_used.minimum is infeasible."""
+        # A's single team plays one home match, so at most one home date can ever be
+        # used; requiring a minimum of 2 is impossible.
+        teams = [
+            fmodel.Team(division=1, club="A", index=1),
+            fmodel.Team(division=1, club="B", index=1),
+        ]
+        home_dates = {
+            "A": [date(2025, 1, 1), date(2025, 2, 1), date(2025, 3, 1)],
+            "B": [date(2025, 4, 1), date(2025, 5, 1), date(2025, 6, 1)],
+        }
+        params = fmodel.Parameters(
+            teams=teams,
+            home_dates=home_dates,
+            unavailable_away_dates={"A": [], "B": []},
+            max_concurrent_home_matches={
+                "A": fmodel.MaxConcurrentHomeMatches(default=1),
+                "B": fmodel.MaxConcurrentHomeMatches(default=1),
+            },
+            min_gap_days=7,
+            home_dates_used={"A": fmodel.HomeDatesUsedBounds(minimum=2)},
+        )
+        with self.assertRaises(ValueError):
+            fmodel.solve(params)
+
     def test_constraint_enforced_strictly(self):
         """A club with two teams needs two home dates; a limit of 1 makes it infeasible."""
         # A has two teams in the same division, requiring 2 home matches on different dates
-        # (min_gap_days=7 forces different dates). But max_home_dates_used=1 for A means
-        # only 1 date can be used — impossible.
+        # (min_gap_days=7 forces different dates). But home_dates_used.maximum=1 for A
+        # means only 1 date can be used — impossible.
         teams = [
             fmodel.Team(division=1, club="A", index=1),
             fmodel.Team(division=1, club="A", index=2),
@@ -364,7 +446,10 @@ class TestMaxHomeDatesUsed(unittest.TestCase):
                 "B": fmodel.MaxConcurrentHomeMatches(default=2),
             },
             min_gap_days=7,
-            max_home_dates_used={"A": 1, "B": 3},
+            home_dates_used={
+                "A": fmodel.HomeDatesUsedBounds(maximum=1),
+                "B": fmodel.HomeDatesUsedBounds(maximum=3),
+            },
         )
         with self.assertRaises(ValueError):
             fmodel.solve(params)

--- a/spec-schema.json
+++ b/spec-schema.json
@@ -80,7 +80,7 @@
     },
     "club_constraints": {
       "type": "object",
-      "description": "Every constraint that can vary by club -- home_dates, unavailable_away_dates, max_concurrent_home_matches, max_home_dates_used, teams and avoid_coscheduling_teams -- keyed by that club's own ID, alongside an optional 'defaults' entry.",
+      "description": "Every constraint that can vary by club -- home_dates, unavailable_away_dates, max_concurrent_home_matches, home_dates_used, teams and avoid_coscheduling_teams -- keyed by that club's own ID, alongside an optional 'defaults' entry.",
       "additionalProperties": { "$ref": "#/$defs/club_constraints_entry" },
       "properties": {
         "defaults": {
@@ -225,9 +225,23 @@
           "uniqueItems": true
         },
         "max_concurrent_home_matches": { "$ref": "#/$defs/max_concurrent_home_matches" },
-        "max_home_dates_used": {
-          "type": "integer",
-          "description": "Caps how many of this club's 'home_dates' actually get used in the solved schedule."
+        "home_dates_used": {
+          "type": "object",
+          "additionalProperties": false,
+          "minProperties": 1,
+          "description": "Bounds how many of this club's 'home_dates' actually host a match in the solved schedule. Give 'min', 'max', or both. 'max' packs the club's home matches onto fewer dates (more matches per evening on average); 'min' spreads them over more dates (fewer per evening).",
+          "properties": {
+            "min": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "At least this many distinct home dates must host a match."
+            },
+            "max": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "At most this many distinct home dates may host a match."
+            }
+          }
         },
         "teams": {
           "type": "object",

--- a/spec_schema_test.py
+++ b/spec_schema_test.py
@@ -92,7 +92,9 @@ club_constraints:
       default: 2
       overrides:
         2025-09-08: 3
-    max_home_dates_used: 1
+    home_dates_used:
+      min: 1
+      max: 2
     teams:
       hackney-5:
         unavailable_home_dates: [2025-09-08]


### PR DESCRIPTION
Some clubs want to spread their home matches over more dates (fewer per evening on average) rather than fewer. Introduce a lower bound on the number of home dates a club uses, and group it with the existing upper bound under a single per-club key:

  club_constraints:
    <club>:
      home_dates_used:
        min: 6
        max: 8

min, max, or both; each a positive integer; min <= max. The solver reuses the per-date "date used" bool vars it already built for the max bound and adds sum >= min alongside sum <= max.

This drops the old max_home_dates_used integer key. Nothing committed uses it and there's no spec versioning, so the format just changes.


Claude-Session: https://claude.ai/code/session_01CKx79LnDrvYTRmmhtr84c9