### PR TITLE
Enable mypy disallow_untyped_defs / disallow_incomplete_defs / no_imp…

### DIFF
--- a/all_tests.py
+++ b/all_tests.py
@@ -19,7 +19,7 @@ import sys
 import unittest
 
 
-def main():
+def main() -> None:
     """Run all tests using discovery with our custom pattern."""
     # Configure test discovery
     loader = unittest.TestLoader()

--- a/berger_test.py
+++ b/berger_test.py
@@ -62,16 +62,16 @@ _FIDE_12 = [
 
 
 class BergerPairingsTest(unittest.TestCase):
-    def test_matches_canonical_fide_tables(self):
+    def test_matches_canonical_fide_tables(self) -> None:
         for n, table in ((8, _FIDE_8), (10, _FIDE_10), (12, _FIDE_12)):
             with self.subTest(n=n):
                 expected = [pair for rnd in table for pair in rnd]
                 self.assertEqual(expected, berger.berger_pairings(n))
 
-    def test_two_entrants(self):
+    def test_two_entrants(self) -> None:
         self.assertEqual([(1, 2)], berger.berger_pairings(2))
 
-    def test_degenerate_sizes(self):
+    def test_degenerate_sizes(self) -> None:
         self.assertEqual([], berger.berger_pairings(0))
         self.assertEqual([], berger.berger_pairings(1))
 
@@ -89,12 +89,12 @@ class BergerPairingsTest(unittest.TestCase):
         self.assertEqual({x: n - 1 for x in range(1, n + 1)}, dict(appearances))
         return pairings
 
-    def test_valid_single_round_for_even_and_odd_sizes(self):
+    def test_valid_single_round_for_even_and_odd_sizes(self) -> None:
         for n in range(2, 15):
             with self.subTest(n=n):
                 self._assert_valid_single_round(n)
 
-    def test_home_away_counts_are_balanced(self):
+    def test_home_away_counts_are_balanced(self) -> None:
         # Each entrant hosts either floor((n-1)/2) or ceil((n-1)/2) of its games.
         for n in range(2, 15):
             with self.subTest(n=n):
@@ -106,7 +106,7 @@ class BergerPairingsTest(unittest.TestCase):
 
 
 class SingleRoundPairingsTest(unittest.TestCase):
-    def test_maps_numbers_onto_entrants_in_draw_order(self):
+    def test_maps_numbers_onto_entrants_in_draw_order(self) -> None:
         entrants = ["a", "b", "c", "d"]
         pairings = berger.single_round_pairings(entrants)
         number_pairings = berger.berger_pairings(4)
@@ -115,13 +115,13 @@ class SingleRoundPairingsTest(unittest.TestCase):
             pairings,
         )
 
-    def test_first_entrant_is_berger_position_one(self):
+    def test_first_entrant_is_berger_position_one(self) -> None:
         # Round 1 of the Berger table pairs position 1 (home) with position n.
         entrants = ["p1", "p2", "p3", "p4", "p5", "p6"]
         first = berger.single_round_pairings(entrants)[0]
         self.assertEqual(("p1", "p6"), first)
 
-    def test_each_pair_once_over_arbitrary_entrants(self):
+    def test_each_pair_once_over_arbitrary_entrants(self) -> None:
         entrants = list("abcdefghij")  # 10
         pairings = berger.single_round_pairings(entrants)
         self.assertEqual(45, len(pairings))
@@ -130,7 +130,7 @@ class SingleRoundPairingsTest(unittest.TestCase):
             {frozenset(p) for p in pairings},
         )
 
-    def test_empty(self):
+    def test_empty(self) -> None:
         self.assertEqual([], berger.single_round_pairings([]))
 
 

--- a/build_site_test.py
+++ b/build_site_test.py
@@ -73,13 +73,13 @@ def _make_run(run_dir: Path, name: str) -> None:
 
 
 class TestFindRunSpecs(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self._tmpdir = tempfile.TemporaryDirectory()
         self.addCleanup(self._tmpdir.cleanup)
         self.runs_dir = Path(self._tmpdir.name) / "runs"
 
-    def test_finds_runs_at_any_depth(self):
+    def test_finds_runs_at_any_depth(self) -> None:
         flat = self.runs_dir / "example"
         nested = self.runs_dir / "2026-27" / "draft1"
         for d in (flat, nested):
@@ -89,7 +89,7 @@ class TestFindRunSpecs(unittest.TestCase):
 
         self.assertEqual(build_site.find_run_specs(self.runs_dir), [nested, flat])
 
-    def test_ignores_dirs_missing_spec_or_solution(self):
+    def test_ignores_dirs_missing_spec_or_solution(self) -> None:
         (self.runs_dir / "spec-only").mkdir(parents=True)
         (self.runs_dir / "spec-only" / "spec.yaml").write_text("clubs: {}\n")
         (self.runs_dir / "solution-only").mkdir(parents=True)
@@ -97,12 +97,12 @@ class TestFindRunSpecs(unittest.TestCase):
 
         self.assertEqual(build_site.find_run_specs(self.runs_dir), [])
 
-    def test_missing_runs_dir(self):
+    def test_missing_runs_dir(self) -> None:
         self.assertEqual(build_site.find_run_specs(self.runs_dir), [])
 
 
 class TestBuildReports(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self._tmpdir = tempfile.TemporaryDirectory()
         self.addCleanup(self._tmpdir.cleanup)
@@ -124,7 +124,7 @@ class TestBuildReports(unittest.TestCase):
         ):
             build_site.main()
 
-    def test_regenerates_report_and_index_pages_from_source(self):
+    def test_regenerates_report_and_index_pages_from_source(self) -> None:
         flat = self.runs_dir / "example"
         nested = self.runs_dir / "2026-27" / "draft1"
         _make_run(flat, "Example Season")
@@ -153,7 +153,7 @@ class TestBuildReports(unittest.TestCase):
         self.assertIn("runs/example/index.html", root)
         self.assertIn("runs/2026-27/draft1/index.html", root)
 
-    def test_writes_nothing_into_the_source_runs_dir(self):
+    def test_writes_nothing_into_the_source_runs_dir(self) -> None:
         _make_run(self.runs_dir / "example", "Example Season")
 
         self._run_cli()
@@ -167,7 +167,7 @@ class TestBuildReports(unittest.TestCase):
             strays, [], f"build_site.py wrote {strays} back into the source runs dir"
         )
 
-    def test_drops_runs_removed_from_the_source(self):
+    def test_drops_runs_removed_from_the_source(self) -> None:
         _make_run(self.runs_dir / "keep", "Keep")
         _make_run(self.runs_dir / "drop", "Drop")
         self._run_cli()
@@ -180,7 +180,7 @@ class TestBuildReports(unittest.TestCase):
         self.assertTrue((self.out_dir / "runs" / "keep" / "index.html").exists())
         self.assertNotIn("runs/drop/index.html", self.root_index.read_text())
 
-    def test_does_not_re_solve(self):
+    def test_does_not_re_solve(self) -> None:
         run_dir = self.runs_dir / "example"
         _make_run(run_dir, "Example Season")
         before = (run_dir / "solution.yaml").read_text()
@@ -189,7 +189,7 @@ class TestBuildReports(unittest.TestCase):
 
         self.assertEqual((run_dir / "solution.yaml").read_text(), before)
 
-    def test_no_runs_writes_empty_index(self):
+    def test_no_runs_writes_empty_index(self) -> None:
         self.runs_dir.mkdir()
         self._run_cli()
         self.assertIn("No runs yet", self.root_index.read_text())

--- a/csvreport_test.py
+++ b/csvreport_test.py
@@ -65,7 +65,7 @@ def _club(name: str, venue: str, address: str, start: str, limit: str) -> fmodel
 
 
 class CsvReportTest(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self._tmpdir = tempfile.TemporaryDirectory()
         self.addCleanup(self._tmpdir.cleanup)
@@ -114,7 +114,7 @@ class CsvReportTest(unittest.TestCase):
         with (self.out / name).open(newline="") as f:
             return list(csv.DictReader(f))
 
-    def test_writes_both_files_and_returns_their_paths(self):
+    def test_writes_both_files_and_returns_their_paths(self) -> None:
         paths = _generate_csv(self.fixtures, self.teams, self.clubs, self.out)
         self.assertEqual(
             paths,
@@ -126,7 +126,7 @@ class CsvReportTest(unittest.TestCase):
         for p in paths:
             self.assertTrue(p.exists())
 
-    def test_header_columns(self):
+    def test_header_columns(self) -> None:
         _generate_csv(self.fixtures, self.teams, self.clubs, self.out)
         with (self.out / "all-matches.csv").open(newline="") as f:
             self.assertEqual(
@@ -166,7 +166,7 @@ class CsvReportTest(unittest.TestCase):
                 ],
             )
 
-    def test_all_matches_one_row_per_match_sorted_by_date(self):
+    def test_all_matches_one_row_per_match_sorted_by_date(self) -> None:
         _generate_csv(self.fixtures, self.teams, self.clubs, self.out)
         rows = self._rows("all-matches.csv")
 
@@ -188,7 +188,7 @@ class CsvReportTest(unittest.TestCase):
         self.assertEqual(first["start_time"], "19:30")
         self.assertEqual(first["time_limit"], "75+15")
 
-    def test_all_matches_gives_name_override_plus_club_and_index(self):
+    def test_all_matches_gives_name_override_plus_club_and_index(self) -> None:
         _generate_csv(self.fixtures, self.teams, self.clubs, self.out)
         hendon_row = next(
             r for r in self._rows("all-matches.csv") if r["date"] == "2025-09-03"
@@ -198,7 +198,7 @@ class CsvReportTest(unittest.TestCase):
         self.assertEqual(hendon_row["away_team_club"], "Hendon")
         self.assertEqual(hendon_row["away_team_index"], "2")
 
-    def test_by_team_has_two_rows_per_match_from_each_side(self):
+    def test_by_team_has_two_rows_per_match_from_each_side(self) -> None:
         _generate_csv(self.fixtures, self.teams, self.clubs, self.out)
         rows = self._rows("all-matches-by-team.csv")
 
@@ -222,7 +222,7 @@ class CsvReportTest(unittest.TestCase):
             self.assertEqual(r["venue"], "Harrow Leisure Centre")
             self.assertEqual(r["start_time"], "19:30")
 
-    def test_by_team_grouped_by_team_then_ordered_by_date(self):
+    def test_by_team_grouped_by_team_then_ordered_by_date(self) -> None:
         _generate_csv(self.fixtures, self.teams, self.clubs, self.out)
         rows = self._rows("all-matches-by-team.csv")
 
@@ -239,7 +239,7 @@ class CsvReportTest(unittest.TestCase):
         ealing_dates = [r["date"] for r in rows if r["team"] == "Ealing 1"]
         self.assertEqual(ealing_dates, ["2025-09-01", "2025-09-08"])
 
-    def test_excluded_fixtures_listed_with_empty_date_at_the_end(self):
+    def test_excluded_fixtures_listed_with_empty_date_at_the_end(self) -> None:
         excluded = [fmodel.Fixture(home_team=self.harrow1, away_team=self.harrow2)]
         _generate_csv(
             self.fixtures,
@@ -261,7 +261,7 @@ class CsvReportTest(unittest.TestCase):
         self.assertEqual(harrow1_rows[-1]["date"], "")
         self.assertEqual(harrow1_rows[-1]["opponent"], "Harrow 2")
 
-    def test_empty_fixture_list_writes_header_only(self):
+    def test_empty_fixture_list_writes_header_only(self) -> None:
         _generate_csv([], [], self.clubs, self.out)
 
         for name in ("all-matches.csv", "all-matches-by-team.csv"):
@@ -269,7 +269,7 @@ class CsvReportTest(unittest.TestCase):
             self.assertEqual(text.splitlines()[1:], [], f"{name} has data rows")
             self.assertTrue(text.endswith("\n"))
 
-    def test_uses_unix_line_endings(self):
+    def test_uses_unix_line_endings(self) -> None:
         _generate_csv(self.fixtures, self.teams, self.clubs, self.out)
         raw = (self.out / "all-matches.csv").read_bytes()
         self.assertNotIn(b"\r", raw)

--- a/fixturesolution.py
+++ b/fixturesolution.py
@@ -56,7 +56,7 @@ class _NoAliasDumper(yaml.SafeDumper):
     needlessly hard to read and diff.
     """
 
-    def ignore_aliases(self, data):
+    def ignore_aliases(self, data: Any) -> bool:
         return True
 
 

--- a/fixturesolution_test.py
+++ b/fixturesolution_test.py
@@ -42,13 +42,13 @@ def _sf(home: fmodel.Team, away: fmodel.Team, d: date) -> fmodel.ScheduledFixtur
 
 
 class TestSaveAndLoadSolution(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self._tmpdir = tempfile.TemporaryDirectory()
         self.addCleanup(self._tmpdir.cleanup)
         self.path = Path(self._tmpdir.name) / "solution.yaml"
 
-    def test_round_trip(self):
+    def test_round_trip(self) -> None:
         fixtures = [
             _sf(_ALBANY_1, _HACKNEY_1, date(2025, 9, 1)),
             _sf(_HACKNEY_2, _ALBANY_1, date(2025, 9, 15)),
@@ -60,7 +60,7 @@ class TestSaveAndLoadSolution(unittest.TestCase):
         )
         self.assertCountEqual(loaded, fixtures)
 
-    def test_load_recovers_division_and_name_override(self):
+    def test_load_recovers_division_and_name_override(self) -> None:
         """Loading resolves each entry against the given teams, so fields not stored
         in the solution file itself (division, name_override) come back correctly."""
         fixturesolution.save_solution(
@@ -73,7 +73,7 @@ class TestSaveAndLoadSolution(unittest.TestCase):
         self.assertEqual(loaded.fixture.home_team, _HACKNEY_2)
         self.assertEqual(loaded.fixture.home_team.name_override, "Hackney Herons")
 
-    def test_written_format_uses_team_ids(self):
+    def test_written_format_uses_team_ids(self) -> None:
         fixturesolution.save_solution(
             [_sf(_ALBANY_1, _HACKNEY_1, date(2025, 9, 1))], _TEAM_IDS, self.path
         )
@@ -82,7 +82,7 @@ class TestSaveAndLoadSolution(unittest.TestCase):
         self.assertIn("away: hackney-1", contents)
         self.assertIn("date: 2025-09-01", contents)
 
-    def test_no_anchors_or_aliases_for_repeated_dates(self):
+    def test_no_anchors_or_aliases_for_repeated_dates(self) -> None:
         """Regression test: PyYAML's default dumper would alias repeated identical
         date objects (&id001/*id001) rather than writing them out literally, since
         fmodel.solve() reuses the same date object for every fixture on a given
@@ -98,7 +98,7 @@ class TestSaveAndLoadSolution(unittest.TestCase):
         self.assertNotIn("*id", contents)
         self.assertEqual(contents.count("2025-09-01"), 2)
 
-    def test_save_unknown_team(self):
+    def test_save_unknown_team(self) -> None:
         with self.assertRaisesRegex(fixturesolution.SolutionError, "albany"):
             fixturesolution.save_solution(
                 [_sf(_ALBANY_1, _HACKNEY_1, date(2025, 9, 1))],
@@ -106,36 +106,36 @@ class TestSaveAndLoadSolution(unittest.TestCase):
                 self.path,
             )
 
-    def test_missing_fixtures_key(self):
+    def test_missing_fixtures_key(self) -> None:
         self.path.write_text("not_fixtures: []\n")
         with self.assertRaisesRegex(fixturesolution.SolutionError, "fixtures"):
             fixturesolution.load_solution(self.path, [_ALBANY_1, _HACKNEY_1], _TEAM_IDS)
 
-    def test_fixtures_not_a_list(self):
+    def test_fixtures_not_a_list(self) -> None:
         self.path.write_text("fixtures: not-a-list\n")
         with self.assertRaisesRegex(fixturesolution.SolutionError, "list"):
             fixturesolution.load_solution(self.path, [_ALBANY_1, _HACKNEY_1], _TEAM_IDS)
 
-    def test_entry_missing_field(self):
+    def test_entry_missing_field(self) -> None:
         self.path.write_text("fixtures:\n  - home: albany-1\n    date: 2025-09-01\n")
         with self.assertRaisesRegex(fixturesolution.SolutionError, "away"):
             fixturesolution.load_solution(self.path, [_ALBANY_1, _HACKNEY_1], _TEAM_IDS)
 
-    def test_unknown_team_reference(self):
+    def test_unknown_team_reference(self) -> None:
         self.path.write_text(
             "fixtures:\n  - home: nonexistent\n    away: hackney-1\n    date: 2025-09-01\n"
         )
         with self.assertRaisesRegex(fixturesolution.SolutionError, "nonexistent"):
             fixturesolution.load_solution(self.path, [_ALBANY_1, _HACKNEY_1], _TEAM_IDS)
 
-    def test_invalid_date(self):
+    def test_invalid_date(self) -> None:
         self.path.write_text(
             "fixtures:\n  - home: albany-1\n    away: hackney-1\n    date: not-a-date\n"
         )
         with self.assertRaisesRegex(fixturesolution.SolutionError, "not-a-date"):
             fixturesolution.load_solution(self.path, [_ALBANY_1, _HACKNEY_1], _TEAM_IDS)
 
-    def test_empty_fixtures_list(self):
+    def test_empty_fixtures_list(self) -> None:
         fixturesolution.save_solution([], _TEAM_IDS, self.path)
         loaded = fixturesolution.load_solution(
             self.path, [_ALBANY_1, _HACKNEY_1], _TEAM_IDS

--- a/fixturespec.py
+++ b/fixturespec.py
@@ -48,7 +48,9 @@ class _NoDuplicateKeysSafeLoader(yaml.SafeLoader):
     elsewhere in the file). Failing loudly instead catches that class of mistake.
     """
 
-    def construct_mapping(self, node, deep=False):
+    def construct_mapping(
+        self, node: yaml.MappingNode, deep: bool = False
+    ) -> dict[Any, Any]:
         seen: set[Any] = set()
         for key_node, _value_node in node.value:
             key = self.construct_object(key_node, deep=deep)

--- a/fixturespec_test.py
+++ b/fixturespec_test.py
@@ -120,7 +120,7 @@ club_constraints:
 class TestLoadSpec(unittest.TestCase):
     """Test cases for load_spec()."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self._tmpdir = tempfile.TemporaryDirectory()
         self.addCleanup(self._tmpdir.cleanup)
@@ -131,7 +131,7 @@ class TestLoadSpec(unittest.TestCase):
         path.write_text(contents)
         return path
 
-    def test_minimal_spec(self):
+    def test_minimal_spec(self) -> None:
         path = self._write(_MINIMAL_SPEC)
         spec = fixturespec.load_spec(path)
 
@@ -176,13 +176,13 @@ class TestLoadSpec(unittest.TestCase):
         self.assertEqual(spec.name, "")
         self.assertFalse(spec.draft)
 
-    def test_run_name_and_draft(self):
+    def test_run_name_and_draft(self) -> None:
         path = self._write(_MINIMAL_SPEC + '\nname: "2025-26 Season"\ndraft: true\n')
         spec = fixturespec.load_spec(path)
         self.assertEqual(spec.name, "2025-26 Season")
         self.assertTrue(spec.draft)
 
-    def test_description(self):
+    def test_description(self) -> None:
         path = self._write(
             _MINIMAL_SPEC
             + '\ndescription: "Final schedule; refer to ECF LMS for authoritative dates."\n'
@@ -193,22 +193,22 @@ class TestLoadSpec(unittest.TestCase):
             "Final schedule; refer to ECF LMS for authoritative dates.",
         )
 
-    def test_description_defaults_to_empty(self):
+    def test_description_defaults_to_empty(self) -> None:
         path = self._write(_MINIMAL_SPEC)
         spec = fixturespec.load_spec(path)
         self.assertEqual(spec.description, "")
 
-    def test_draft_must_be_a_boolean(self):
+    def test_draft_must_be_a_boolean(self) -> None:
         path = self._write(_MINIMAL_SPEC + "\ndraft: notabool\n")
         with self.assertRaisesRegex(fixturespec.SpecError, "draft"):
             fixturespec.load_spec(path)
 
-    def test_name_must_be_a_string(self):
+    def test_name_must_be_a_string(self) -> None:
         path = self._write(_MINIMAL_SPEC + "\nname: [1, 2]\n")
         with self.assertRaisesRegex(fixturespec.SpecError, "name"):
             fixturespec.load_spec(path)
 
-    def test_name_override(self):
+    def test_name_override(self) -> None:
         path = self._write(
             _MINIMAL_SPEC.replace(
                 "  hackney-1:\n    club: hackney\n    index: 1",
@@ -220,27 +220,27 @@ class TestLoadSpec(unittest.TestCase):
         team = next(t for t in spec.parameters.teams if t.club == "hackney")
         self.assertEqual(team.name_override, "Hackney Herons")
 
-    def test_overridden_constraints(self):
+    def test_overridden_constraints(self) -> None:
         path = self._write(_MINIMAL_SPEC + "\nmin_gap_days: 10\n")
         spec = fixturespec.load_spec(path)
         self.assertEqual(spec.parameters.min_gap_days, 10)
 
-    def test_latest_internal_match_date_absent(self):
+    def test_latest_internal_match_date_absent(self) -> None:
         path = self._write(_MINIMAL_SPEC)
         spec = fixturespec.load_spec(path)
         self.assertIsNone(spec.parameters.latest_internal_match_date)
 
-    def test_latest_internal_match_date_parsed(self):
+    def test_latest_internal_match_date_parsed(self) -> None:
         path = self._write(_MINIMAL_SPEC + "latest_internal_match_date: 2025-12-31\n")
         spec = fixturespec.load_spec(path)
         self.assertEqual(spec.parameters.latest_internal_match_date, date(2025, 12, 31))
 
-    def test_latest_internal_match_date_invalid(self):
+    def test_latest_internal_match_date_invalid(self) -> None:
         path = self._write(_MINIMAL_SPEC + "latest_internal_match_date: not-a-date\n")
         with self.assertRaisesRegex(fixturespec.SpecError, "not-a-date"):
             fixturespec.load_spec(path)
 
-    def test_avoid_dates_absent(self):
+    def test_avoid_dates_absent(self) -> None:
         path = self._write(_MINIMAL_SPEC)
         spec = fixturespec.load_spec(path)
         self.assertEqual(
@@ -248,7 +248,7 @@ class TestLoadSpec(unittest.TestCase):
         )
         self.assertEqual(spec.parameters.unavailable_away_dates["hackney"], [])
 
-    def test_avoid_dates_merged_into_every_clubs_unavailable_away_dates(self):
+    def test_avoid_dates_merged_into_every_clubs_unavailable_away_dates(self) -> None:
         path = self._write(_MINIMAL_SPEC + "avoid_dates: [2025-12-25, 2026-01-01]\n")
         spec = fixturespec.load_spec(path)
         # albany already had 2025-12-25 of its own; avoid_dates adds 2026-01-01
@@ -263,22 +263,22 @@ class TestLoadSpec(unittest.TestCase):
             [date(2025, 12, 25), date(2026, 1, 1)],
         )
 
-    def test_avoid_dates_invalid_date(self):
+    def test_avoid_dates_invalid_date(self) -> None:
         path = self._write(_MINIMAL_SPEC + "avoid_dates: [not-a-date]\n")
         with self.assertRaisesRegex(fixturespec.SpecError, "not-a-date"):
             fixturespec.load_spec(path)
 
-    def test_avoid_dates_duplicate_rejected(self):
+    def test_avoid_dates_duplicate_rejected(self) -> None:
         path = self._write(_MINIMAL_SPEC + "avoid_dates: [2025-12-25, 2025-12-25]\n")
         with self.assertRaisesRegex(fixturespec.SpecError, "duplicate date"):
             fixturespec.load_spec(path)
 
-    def test_duplicate_top_level_key_rejected(self):
+    def test_duplicate_top_level_key_rejected(self) -> None:
         path = self._write(_MINIMAL_SPEC + "\nmin_gap_days: 7\nmin_gap_days: 10\n")
         with self.assertRaisesRegex(fixturespec.SpecError, "duplicate key"):
             fixturespec.load_spec(path)
 
-    def test_duplicate_nested_key_rejected(self):
+    def test_duplicate_nested_key_rejected(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
@@ -296,7 +296,7 @@ class TestLoadSpec(unittest.TestCase):
     # club already present) would create a duplicate YAML key, which PyYAML resolves
     # by silently letting the later one clobber the earlier one.
 
-    def test_max_concurrent_home_matches_shorthand_int(self):
+    def test_max_concurrent_home_matches_shorthand_int(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
@@ -315,7 +315,7 @@ class TestLoadSpec(unittest.TestCase):
             fmodel.MaxConcurrentHomeMatches(default=1),
         )
 
-    def test_max_concurrent_home_matches_default_and_overrides(self):
+    def test_max_concurrent_home_matches_default_and_overrides(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
@@ -332,7 +332,7 @@ class TestLoadSpec(unittest.TestCase):
             fmodel.MaxConcurrentHomeMatches(default=2, overrides={date(2025, 9, 1): 3}),
         )
 
-    def test_max_concurrent_home_matches_null_shorthand(self):
+    def test_max_concurrent_home_matches_null_shorthand(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
@@ -346,7 +346,7 @@ class TestLoadSpec(unittest.TestCase):
             fmodel.MaxConcurrentHomeMatches(default=None),
         )
 
-    def test_max_concurrent_home_matches_null_default_with_override(self):
+    def test_max_concurrent_home_matches_null_default_with_override(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
@@ -365,7 +365,7 @@ class TestLoadSpec(unittest.TestCase):
             ),
         )
 
-    def test_max_concurrent_home_matches_missing_default(self):
+    def test_max_concurrent_home_matches_missing_default(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
@@ -378,7 +378,7 @@ class TestLoadSpec(unittest.TestCase):
         with self.assertRaisesRegex(fixturespec.SpecError, "default"):
             fixturespec.load_spec(path)
 
-    def test_club_constraints_unknown_club(self):
+    def test_club_constraints_unknown_club(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
@@ -391,7 +391,9 @@ class TestLoadSpec(unittest.TestCase):
         with self.assertRaisesRegex(fixturespec.SpecError, "nonexistent"):
             fixturespec.load_spec(path)
 
-    def test_max_concurrent_home_matches_missing_club_without_section_default(self):
+    def test_max_concurrent_home_matches_missing_club_without_section_default(
+        self,
+    ) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
@@ -400,12 +402,12 @@ class TestLoadSpec(unittest.TestCase):
         with self.assertRaisesRegex(fixturespec.SpecError, "hackney"):
             fixturespec.load_spec(path)
 
-    def test_max_concurrent_home_matches_section_omitted_entirely(self):
+    def test_max_concurrent_home_matches_section_omitted_entirely(self) -> None:
         path = self._write(_BOILERPLATE)
         with self.assertRaisesRegex(fixturespec.SpecError, "albany.*hackney"):
             fixturespec.load_spec(path)
 
-    def test_club_constraints_defaults_unsupported_field(self):
+    def test_club_constraints_defaults_unsupported_field(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
@@ -414,12 +416,12 @@ class TestLoadSpec(unittest.TestCase):
         with self.assertRaisesRegex(fixturespec.SpecError, "not supported"):
             fixturespec.load_spec(path)
 
-    def test_missing_clubs(self):
+    def test_missing_clubs(self) -> None:
         path = self._write("teams: {}\ndivisions: {}\n")
         with self.assertRaisesRegex(fixturespec.SpecError, "clubs"):
             fixturespec.load_spec(path)
 
-    def test_club_missing_field(self):
+    def test_club_missing_field(self) -> None:
         path = self._write("""
 clubs:
   albany:
@@ -433,7 +435,7 @@ divisions: {}
         with self.assertRaisesRegex(fixturespec.SpecError, "home_time_limit"):
             fixturespec.load_spec(path)
 
-    def test_missing_teams(self):
+    def test_missing_teams(self) -> None:
         path = self._write("""
 clubs:
   albany:
@@ -446,7 +448,7 @@ clubs:
         with self.assertRaisesRegex(fixturespec.SpecError, "teams"):
             fixturespec.load_spec(path)
 
-    def test_team_references_unknown_club(self):
+    def test_team_references_unknown_club(self) -> None:
         path = self._write("""
 clubs:
   albany:
@@ -467,7 +469,7 @@ divisions:
         with self.assertRaisesRegex(fixturespec.SpecError, "hackney"):
             fixturespec.load_spec(path)
 
-    def test_duplicate_club_index(self):
+    def test_duplicate_club_index(self) -> None:
         path = self._write("""
 clubs:
   albany:
@@ -491,7 +493,7 @@ divisions:
         with self.assertRaisesRegex(fixturespec.SpecError, "index 1"):
             fixturespec.load_spec(path)
 
-    def test_missing_divisions_section(self):
+    def test_missing_divisions_section(self) -> None:
         path = self._write("""
 clubs:
   albany:
@@ -508,7 +510,7 @@ teams:
         with self.assertRaisesRegex(fixturespec.SpecError, "divisions"):
             fixturespec.load_spec(path)
 
-    def test_team_missing_from_divisions(self):
+    def test_team_missing_from_divisions(self) -> None:
         path = self._write("""
 clubs:
   albany:
@@ -532,7 +534,7 @@ divisions:
         with self.assertRaisesRegex(fixturespec.SpecError, "albany-2"):
             fixturespec.load_spec(path)
 
-    def test_division_key_not_an_integer(self):
+    def test_division_key_not_an_integer(self) -> None:
         path = self._write("""
 clubs:
   albany:
@@ -553,7 +555,7 @@ divisions:
         with self.assertRaisesRegex(fixturespec.SpecError, "integer"):
             fixturespec.load_spec(path)
 
-    def test_team_listed_in_two_divisions(self):
+    def test_team_listed_in_two_divisions(self) -> None:
         path = self._write("""
 clubs:
   albany:
@@ -603,7 +605,7 @@ divisions:
         "  albany:\n    home_dates: [2025-09-01, 2025-09-08, 2025-09-15]\n"
     )
 
-    def test_division_scheme_single_round_is_parsed(self):
+    def test_division_scheme_single_round_is_parsed(self) -> None:
         path = self._write(
             self._SCHEME_SPEC_HEAD + "  1:\n    scheme: single_round\n"
             "    teams: [albany-1, albany-2]\n" + self._SCHEME_SPEC_TAIL
@@ -614,7 +616,7 @@ divisions:
             {d.number: d.scheme for d in spec.parameters.divisions},
         )
 
-    def test_division_scheme_double_round_is_parsed(self):
+    def test_division_scheme_double_round_is_parsed(self) -> None:
         path = self._write(
             self._SCHEME_SPEC_HEAD + "  1:\n    scheme: double_round\n"
             "    teams: [albany-1, albany-2]\n" + self._SCHEME_SPEC_TAIL
@@ -625,19 +627,19 @@ divisions:
             {d.number: d.scheme for d in spec.parameters.divisions},
         )
 
-    def test_division_missing_scheme_rejected(self):
+    def test_division_missing_scheme_rejected(self) -> None:
         path = self._write(
             self._SCHEME_SPEC_HEAD + "  1:\n    teams: [albany-1, albany-2]\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "scheme"):
             fixturespec.load_spec(path)
 
-    def test_division_missing_teams_rejected(self):
+    def test_division_missing_teams_rejected(self) -> None:
         path = self._write(self._SCHEME_SPEC_HEAD + "  1:\n    scheme: double_round\n")
         with self.assertRaisesRegex(fixturespec.SpecError, "teams"):
             fixturespec.load_spec(path)
 
-    def test_division_unknown_scheme_rejected(self):
+    def test_division_unknown_scheme_rejected(self) -> None:
         path = self._write(
             self._SCHEME_SPEC_HEAD + "  1:\n    scheme: triple_round\n"
             "    teams: [albany-1, albany-2]\n"
@@ -645,12 +647,12 @@ divisions:
         with self.assertRaisesRegex(fixturespec.SpecError, "scheme.*triple_round"):
             fixturespec.load_spec(path)
 
-    def test_division_bare_list_rejected(self):
+    def test_division_bare_list_rejected(self) -> None:
         path = self._write(self._SCHEME_SPEC_HEAD + "  1: [albany-1, albany-2]\n")
         with self.assertRaisesRegex(fixturespec.SpecError, "mapping"):
             fixturespec.load_spec(path)
 
-    def test_division_unsupported_field_rejected(self):
+    def test_division_unsupported_field_rejected(self) -> None:
         path = self._write(
             self._SCHEME_SPEC_HEAD + "  1:\n    scheme: double_round\n"
             "    teams: [albany-1, albany-2]\n    berger_seed: 3\n"
@@ -658,7 +660,7 @@ divisions:
         with self.assertRaisesRegex(fixturespec.SpecError, "berger_seed"):
             fixturespec.load_spec(path)
 
-    def test_single_round_division_team_order_follows_the_divisions_list(self):
+    def test_single_round_division_team_order_follows_the_divisions_list(self) -> None:
         # teams: lists albany-2 before albany-1; the divisions list is the Berger
         # draw order and must win, so parameters.teams reflects the divisions list.
         path = self._write("""
@@ -695,7 +697,7 @@ club_constraints:
             [("albany", 1), ("albany", 2), ("albany", 3)],
         )
 
-    def test_invalid_date_string(self):
+    def test_invalid_date_string(self) -> None:
         path = self._write("""
 clubs:
   albany:
@@ -719,7 +721,7 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "not-a-date"):
             fixturespec.load_spec(path)
 
-    def test_duplicate_date_in_home_dates_rejected(self):
+    def test_duplicate_date_in_home_dates_rejected(self) -> None:
         path = self._write("""
 clubs:
   albany:
@@ -743,7 +745,7 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "duplicate date"):
             fixturespec.load_spec(path)
 
-    def test_duplicate_date_in_unavailable_away_dates_rejected(self):
+    def test_duplicate_date_in_unavailable_away_dates_rejected(self) -> None:
         path = self._write("""
 clubs:
   albany:
@@ -767,7 +769,7 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "duplicate date"):
             fixturespec.load_spec(path)
 
-    def test_unsupported_club_constraint_field(self):
+    def test_unsupported_club_constraint_field(self) -> None:
         path = self._write("""
 clubs:
   albany:
@@ -792,12 +794,12 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "not supported"):
             fixturespec.load_spec(path)
 
-    def test_top_level_not_a_mapping(self):
+    def test_top_level_not_a_mapping(self) -> None:
         path = self._write("- just\n- a\n- list\n")
         with self.assertRaisesRegex(fixturespec.SpecError, "mapping"):
             fixturespec.load_spec(path)
 
-    def test_home_dates_used_per_club(self):
+    def test_home_dates_used_per_club(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
@@ -819,7 +821,7 @@ club_constraints:
             },
         )
 
-    def test_home_dates_used_partial_clubs(self):
+    def test_home_dates_used_partial_clubs(self) -> None:
         """Only the clubs given their own entry are constrained."""
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
@@ -835,12 +837,12 @@ club_constraints:
             {"albany": fmodel.HomeDatesUsedBounds(minimum=3)},
         )
 
-    def test_home_dates_used_absent(self):
+    def test_home_dates_used_absent(self) -> None:
         path = self._write(_MINIMAL_SPEC)
         spec = fixturespec.load_spec(path)
         self.assertEqual(spec.parameters.home_dates_used, {})
 
-    def test_home_dates_used_unknown_club(self):
+    def test_home_dates_used_unknown_club(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
@@ -852,7 +854,7 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "unknown-club"):
             fixturespec.load_spec(path)
 
-    def test_home_dates_used_not_int(self):
+    def test_home_dates_used_not_int(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
@@ -864,7 +866,7 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "integer"):
             fixturespec.load_spec(path)
 
-    def test_home_dates_used_not_a_mapping(self):
+    def test_home_dates_used_not_a_mapping(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
@@ -875,7 +877,7 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "mapping"):
             fixturespec.load_spec(path)
 
-    def test_home_dates_used_empty_mapping(self):
+    def test_home_dates_used_empty_mapping(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
@@ -886,7 +888,7 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "min.*max"):
             fixturespec.load_spec(path)
 
-    def test_home_dates_used_unsupported_key(self):
+    def test_home_dates_used_unsupported_key(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
@@ -898,7 +900,7 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "minimum"):
             fixturespec.load_spec(path)
 
-    def test_home_dates_used_below_one(self):
+    def test_home_dates_used_below_one(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
@@ -910,7 +912,7 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "at least 1"):
             fixturespec.load_spec(path)
 
-    def test_home_dates_used_min_exceeds_max(self):
+    def test_home_dates_used_min_exceeds_max(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
@@ -923,7 +925,7 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "exceeds"):
             fixturespec.load_spec(path)
 
-    def test_fixed_fixture(self):
+    def test_fixed_fixture(self) -> None:
         path = self._write(
             _MINIMAL_SPEC + "fixed_fixtures:\n"
             "  - home: hackney-1\n"
@@ -943,24 +945,24 @@ club_constraints:
             ],
         )
 
-    def test_fixed_fixtures_absent(self):
+    def test_fixed_fixtures_absent(self) -> None:
         path = self._write(_MINIMAL_SPEC)
         spec = fixturespec.load_spec(path)
         self.assertEqual(spec.parameters.fixed_fixtures, ())
 
-    def test_fixed_fixtures_not_a_list(self):
+    def test_fixed_fixtures_not_a_list(self) -> None:
         path = self._write(_MINIMAL_SPEC + "fixed_fixtures:\n  home: hackney-1\n")
         with self.assertRaisesRegex(fixturespec.SpecError, "list"):
             fixturespec.load_spec(path)
 
-    def test_fixed_fixtures_missing_field(self):
+    def test_fixed_fixtures_missing_field(self) -> None:
         path = self._write(
             _MINIMAL_SPEC + "fixed_fixtures:\n  - home: hackney-1\n    away: albany-1\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "date"):
             fixturespec.load_spec(path)
 
-    def test_fixed_fixtures_unsupported_field(self):
+    def test_fixed_fixtures_unsupported_field(self) -> None:
         path = self._write(
             _MINIMAL_SPEC + "fixed_fixtures:\n"
             "  - home: hackney-1\n"
@@ -971,7 +973,7 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "venue"):
             fixturespec.load_spec(path)
 
-    def test_fixed_fixtures_unknown_team(self):
+    def test_fixed_fixtures_unknown_team(self) -> None:
         path = self._write(
             _MINIMAL_SPEC + "fixed_fixtures:\n"
             "  - home: nonexistent\n"
@@ -981,7 +983,7 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "nonexistent"):
             fixturespec.load_spec(path)
 
-    def test_fixed_fixtures_home_equals_away(self):
+    def test_fixed_fixtures_home_equals_away(self) -> None:
         path = self._write(
             _MINIMAL_SPEC + "fixed_fixtures:\n"
             "  - home: hackney-1\n"
@@ -991,7 +993,7 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "hackney-1"):
             fixturespec.load_spec(path)
 
-    def test_fixed_fixtures_different_divisions_rejected(self):
+    def test_fixed_fixtures_different_divisions_rejected(self) -> None:
         path = self._write(
             _MINIMAL_SPEC.replace(
                 "  1:\n    scheme: double_round\n    teams: [albany-1, hackney-1]",
@@ -1006,7 +1008,7 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "not in the same division"):
             fixturespec.load_spec(path)
 
-    def test_fixed_fixtures_date_not_a_home_date_rejected(self):
+    def test_fixed_fixtures_date_not_a_home_date_rejected(self) -> None:
         path = self._write(
             _MINIMAL_SPEC + "fixed_fixtures:\n"
             "  - home: hackney-1\n"
@@ -1026,13 +1028,13 @@ club_constraints:
             "    unavailable_away_dates: [2025-12-25]\n" + teams_block,
         )
 
-    def test_team_constraints_absent(self):
+    def test_team_constraints_absent(self) -> None:
         path = self._write(_MINIMAL_SPEC)
         spec = fixturespec.load_spec(path)
         self.assertEqual(spec.parameters.team_home_dates, {})
         self.assertEqual(spec.parameters.team_unavailable_away_dates, {})
 
-    def test_team_constraints_unavailable_home_dates_excludes_from_clubs(self):
+    def test_team_constraints_unavailable_home_dates_excludes_from_clubs(self) -> None:
         path = self._write(
             self._with_albany_teams(
                 "    teams:\n      albany-1:\n"
@@ -1049,7 +1051,7 @@ club_constraints:
 
     def test_team_constraints_unavailable_home_dates_not_yet_in_clubs_logs_warning(
         self,
-    ):
+    ) -> None:
         """An unavailable_home_dates entry not currently in the club's home_dates
         (e.g. a date held in reserve, commented out) is accepted rather than
         rejected -- it just has no effect yet -- but logs a warning so the mismatch
@@ -1074,7 +1076,7 @@ club_constraints:
             {albany_1: [date(2025, 9, 1), date(2025, 9, 29)]},
         )
 
-    def test_team_constraints_unavailable_away_dates_additive(self):
+    def test_team_constraints_unavailable_away_dates_additive(self) -> None:
         path = self._write(
             self._with_albany_teams(
                 "    teams:\n      albany-1:\n"
@@ -1092,7 +1094,7 @@ club_constraints:
             spec.parameters.unavailable_away_dates["albany"], [date(2025, 12, 25)]
         )
 
-    def test_team_constraints_unknown_team(self):
+    def test_team_constraints_unknown_team(self) -> None:
         path = self._write(
             self._with_albany_teams(
                 "    teams:\n      nonexistent:\n"
@@ -1102,7 +1104,7 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "nonexistent"):
             fixturespec.load_spec(path)
 
-    def test_team_constraints_team_belongs_to_different_club(self):
+    def test_team_constraints_team_belongs_to_different_club(self) -> None:
         """A team can only be listed under its own club's club_constraints entry."""
         path = self._write(
             self._with_albany_teams(
@@ -1113,7 +1115,7 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "hackney-1"):
             fixturespec.load_spec(path)
 
-    def test_team_constraints_unsupported_field(self):
+    def test_team_constraints_unsupported_field(self) -> None:
         path = self._write(
             self._with_albany_teams(
                 "    teams:\n      albany-1:\n        max_concurrent_home_matches: 2\n"
@@ -1122,7 +1124,7 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "not supported"):
             fixturespec.load_spec(path)
 
-    def test_team_constraints_home_dates_not_supported(self):
+    def test_team_constraints_home_dates_not_supported(self) -> None:
         """Per-team home_dates are not supported; only exclusions via
         unavailable_home_dates are. home_dates at the team level should be
         rejected as an unsupported field."""
@@ -1134,7 +1136,7 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "not supported"):
             fixturespec.load_spec(path)
 
-    def test_fixed_fixtures_date_must_be_one_of_teams_own_home_dates(self):
+    def test_fixed_fixtures_date_must_be_one_of_teams_own_home_dates(self) -> None:
         """When a team has a club_constraints[club].teams[team].unavailable_home_dates
         entry, fixed_fixtures validates against the club's home_dates minus that
         exclusion, not the club's full home_dates list."""
@@ -1163,12 +1165,12 @@ club_constraints:
             + block,
         )
 
-    def test_avoid_coscheduling_teams_absent(self):
+    def test_avoid_coscheduling_teams_absent(self) -> None:
         path = self._write(_THREE_TEAM_SPEC)
         spec = fixturespec.load_spec(path)
         self.assertEqual(spec.parameters.avoid_coscheduling_teams, ())
 
-    def test_avoid_coscheduling_teams_parsed(self):
+    def test_avoid_coscheduling_teams_parsed(self) -> None:
         path = self._write(
             self._with_albany_avoid_coscheduling(
                 "    avoid_coscheduling_teams:\n      - teams: [albany-1, albany-2]\n"
@@ -1190,7 +1192,7 @@ club_constraints:
             ],
         )
 
-    def test_avoid_coscheduling_teams_within_days_parsed(self):
+    def test_avoid_coscheduling_teams_within_days_parsed(self) -> None:
         path = self._write(
             self._with_albany_avoid_coscheduling(
                 "    avoid_coscheduling_teams:\n"
@@ -1202,7 +1204,7 @@ club_constraints:
         constraints = list(spec.parameters.avoid_coscheduling_teams)
         self.assertEqual(constraints[0].within_days, 3)
 
-    def test_avoid_coscheduling_teams_applies_to_defaults_to_both(self):
+    def test_avoid_coscheduling_teams_applies_to_defaults_to_both(self) -> None:
         path = self._write(
             self._with_albany_avoid_coscheduling(
                 "    avoid_coscheduling_teams:\n      - teams: [albany-1, albany-2]\n"
@@ -1212,7 +1214,7 @@ club_constraints:
         constraints = list(spec.parameters.avoid_coscheduling_teams)
         self.assertEqual(constraints[0].applies_to, fmodel.CoschedulingScope.BOTH)
 
-    def test_avoid_coscheduling_teams_applies_to_parsed(self):
+    def test_avoid_coscheduling_teams_applies_to_parsed(self) -> None:
         path = self._write(
             self._with_albany_avoid_coscheduling(
                 "    avoid_coscheduling_teams:\n"
@@ -1224,7 +1226,7 @@ club_constraints:
         constraints = list(spec.parameters.avoid_coscheduling_teams)
         self.assertEqual(constraints[0].applies_to, fmodel.CoschedulingScope.AWAY)
 
-    def test_avoid_coscheduling_teams_invalid_applies_to_rejected(self):
+    def test_avoid_coscheduling_teams_invalid_applies_to_rejected(self) -> None:
         path = self._write(
             self._with_albany_avoid_coscheduling(
                 "    avoid_coscheduling_teams:\n"
@@ -1235,14 +1237,14 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "applies_to"):
             fixturespec.load_spec(path)
 
-    def test_avoid_coscheduling_teams_not_a_list(self):
+    def test_avoid_coscheduling_teams_not_a_list(self) -> None:
         path = self._write(
             self._with_albany_avoid_coscheduling("    avoid_coscheduling_teams: {}\n")
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "list"):
             fixturespec.load_spec(path)
 
-    def test_avoid_coscheduling_teams_entry_not_a_mapping(self):
+    def test_avoid_coscheduling_teams_entry_not_a_mapping(self) -> None:
         path = self._write(
             self._with_albany_avoid_coscheduling(
                 "    avoid_coscheduling_teams:\n      - just-a-string\n"
@@ -1251,7 +1253,7 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "mapping"):
             fixturespec.load_spec(path)
 
-    def test_avoid_coscheduling_teams_missing_teams_field(self):
+    def test_avoid_coscheduling_teams_missing_teams_field(self) -> None:
         path = self._write(
             self._with_albany_avoid_coscheduling(
                 "    avoid_coscheduling_teams:\n      - within_days: 1\n"
@@ -1260,7 +1262,7 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "teams"):
             fixturespec.load_spec(path)
 
-    def test_avoid_coscheduling_teams_empty_teams_list(self):
+    def test_avoid_coscheduling_teams_empty_teams_list(self) -> None:
         path = self._write(
             self._with_albany_avoid_coscheduling(
                 "    avoid_coscheduling_teams:\n      - teams: []\n"
@@ -1269,7 +1271,7 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "non-empty"):
             fixturespec.load_spec(path)
 
-    def test_avoid_coscheduling_teams_duplicate_team(self):
+    def test_avoid_coscheduling_teams_duplicate_team(self) -> None:
         path = self._write(
             self._with_albany_avoid_coscheduling(
                 "    avoid_coscheduling_teams:\n      - teams: [albany-1, albany-1]\n"
@@ -1278,7 +1280,7 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "duplicate"):
             fixturespec.load_spec(path)
 
-    def test_avoid_coscheduling_teams_unknown_team(self):
+    def test_avoid_coscheduling_teams_unknown_team(self) -> None:
         path = self._write(
             self._with_albany_avoid_coscheduling(
                 "    avoid_coscheduling_teams:\n"
@@ -1288,7 +1290,7 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "nonexistent"):
             fixturespec.load_spec(path)
 
-    def test_avoid_coscheduling_teams_team_belongs_to_different_club(self):
+    def test_avoid_coscheduling_teams_team_belongs_to_different_club(self) -> None:
         path = self._write(
             self._with_albany_avoid_coscheduling(
                 "    avoid_coscheduling_teams:\n      - teams: [albany-1, hackney-1]\n"
@@ -1297,7 +1299,7 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "hackney-1"):
             fixturespec.load_spec(path)
 
-    def test_avoid_coscheduling_teams_unsupported_field(self):
+    def test_avoid_coscheduling_teams_unsupported_field(self) -> None:
         path = self._write(
             self._with_albany_avoid_coscheduling(
                 "    avoid_coscheduling_teams:\n"
@@ -1308,7 +1310,7 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "not supported"):
             fixturespec.load_spec(path)
 
-    def test_avoid_coscheduling_teams_negative_within_days_rejected(self):
+    def test_avoid_coscheduling_teams_negative_within_days_rejected(self) -> None:
         path = self._write(
             self._with_albany_avoid_coscheduling(
                 "    avoid_coscheduling_teams:\n"
@@ -1319,12 +1321,12 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "within_days"):
             fixturespec.load_spec(path)
 
-    def test_exclude_fixtures_absent(self):
+    def test_exclude_fixtures_absent(self) -> None:
         path = self._write(_MINIMAL_SPEC)
         spec = fixturespec.load_spec(path)
         self.assertEqual(spec.parameters.excluded_fixtures, ())
 
-    def test_exclude_specific_fixture(self):
+    def test_exclude_specific_fixture(self) -> None:
         path = self._write(
             _THREE_TEAM_SPEC + "exclude_fixtures:\n"
             "  fixtures:\n"
@@ -1343,7 +1345,7 @@ club_constraints:
             [fmodel.Fixture(home_team=albany1, away_team=albany2)],
         )
 
-    def test_exclude_team(self):
+    def test_exclude_team(self) -> None:
         """Excluding a team excludes all its fixtures, in both directions."""
         path = self._write(
             _THREE_TEAM_SPEC + "exclude_fixtures:\n  teams: [hackney-1]\n"
@@ -1357,7 +1359,7 @@ club_constraints:
             expected.add(fmodel.Fixture(home_team=other, away_team=hackney1))
         self.assertEqual(set(spec.parameters.excluded_fixtures), expected)
 
-    def test_exclude_club(self):
+    def test_exclude_club(self) -> None:
         """Excluding a club excludes all of that club's teams' fixtures."""
         path = self._write(_THREE_TEAM_SPEC + "exclude_fixtures:\n  clubs: [hackney]\n")
         spec = fixturespec.load_spec(path)
@@ -1369,28 +1371,28 @@ club_constraints:
             expected.add(fmodel.Fixture(home_team=other, away_team=hackney1))
         self.assertEqual(set(spec.parameters.excluded_fixtures), expected)
 
-    def test_exclude_fixtures_unknown_club(self):
+    def test_exclude_fixtures_unknown_club(self) -> None:
         path = self._write(
             _THREE_TEAM_SPEC + "exclude_fixtures:\n  clubs: [nonexistent]\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "nonexistent"):
             fixturespec.load_spec(path)
 
-    def test_exclude_fixtures_unknown_team(self):
+    def test_exclude_fixtures_unknown_team(self) -> None:
         path = self._write(
             _THREE_TEAM_SPEC + "exclude_fixtures:\n  teams: [nonexistent]\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "nonexistent"):
             fixturespec.load_spec(path)
 
-    def test_exclude_fixtures_unsupported_key(self):
+    def test_exclude_fixtures_unsupported_key(self) -> None:
         path = self._write(
             _THREE_TEAM_SPEC + "exclude_fixtures:\n  players: [nonexistent]\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "not supported"):
             fixturespec.load_spec(path)
 
-    def test_exclude_fixtures_unknown_team_in_fixtures_list(self):
+    def test_exclude_fixtures_unknown_team_in_fixtures_list(self) -> None:
         path = self._write(
             _THREE_TEAM_SPEC + "exclude_fixtures:\n"
             "  fixtures:\n"
@@ -1400,7 +1402,7 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "nonexistent"):
             fixturespec.load_spec(path)
 
-    def test_exclude_fixtures_home_equals_away(self):
+    def test_exclude_fixtures_home_equals_away(self) -> None:
         path = self._write(
             _THREE_TEAM_SPEC + "exclude_fixtures:\n"
             "  fixtures:\n"
@@ -1410,7 +1412,7 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "albany-1"):
             fixturespec.load_spec(path)
 
-    def test_exclude_fixtures_different_divisions_rejected(self):
+    def test_exclude_fixtures_different_divisions_rejected(self) -> None:
         path = self._write(
             _THREE_TEAM_SPEC.replace(
                 "  1:\n    scheme: double_round\n"
@@ -1426,14 +1428,14 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "not in the same division"):
             fixturespec.load_spec(path)
 
-    def test_exclude_fixtures_missing_field(self):
+    def test_exclude_fixtures_missing_field(self) -> None:
         path = self._write(
             _THREE_TEAM_SPEC + "exclude_fixtures:\n  fixtures:\n    - home: albany-1\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "away"):
             fixturespec.load_spec(path)
 
-    def test_exclude_fixtures_conflicts_with_fixed_fixtures(self):
+    def test_exclude_fixtures_conflicts_with_fixed_fixtures(self) -> None:
         path = self._write(
             _THREE_TEAM_SPEC + "fixed_fixtures:\n"
             "  - home: albany-1\n"
@@ -1447,7 +1449,7 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "also excluded"):
             fixturespec.load_spec(path)
 
-    def test_exclude_fixtures_solves_end_to_end(self):
+    def test_exclude_fixtures_solves_end_to_end(self) -> None:
         path = self._write(
             _THREE_TEAM_SPEC + "exclude_fixtures:\n"
             "  fixtures:\n"
@@ -1470,7 +1472,7 @@ club_constraints:
             )
         )
 
-    def test_latest_internal_match_date_conflicts_with_fixed_fixtures(self):
+    def test_latest_internal_match_date_conflicts_with_fixed_fixtures(self) -> None:
         path = self._write(
             _THREE_TEAM_SPEC + "fixed_fixtures:\n"
             "  - home: albany-1\n"
@@ -1483,7 +1485,7 @@ club_constraints:
         ):
             fixturespec.load_spec(path)
 
-    def test_latest_internal_match_date_ignores_cross_club_fixed_fixtures(self):
+    def test_latest_internal_match_date_ignores_cross_club_fixed_fixtures(self) -> None:
         """The cutoff only applies to fixtures between two teams of the same club."""
         path = self._write(
             _THREE_TEAM_SPEC + "fixed_fixtures:\n"
@@ -1495,7 +1497,7 @@ club_constraints:
         spec = fixturespec.load_spec(path)  # must not raise
         self.assertEqual(spec.parameters.latest_internal_match_date, date(2025, 10, 15))
 
-    def test_latest_internal_match_date_solves_end_to_end(self):
+    def test_latest_internal_match_date_solves_end_to_end(self) -> None:
         path = self._write(
             _THREE_TEAM_SPEC + "latest_internal_match_date: 2025-10-15\n"
         )
@@ -1516,7 +1518,7 @@ club_constraints:
         for sf in internal:
             self.assertLessEqual(sf.date, date(2025, 10, 15))
 
-    def test_solves_end_to_end(self):
+    def test_solves_end_to_end(self) -> None:
         """A loaded spec's Parameters should be usable directly with fmodel.solve()."""
         path = self._write(_MINIMAL_SPEC)
         spec = fixturespec.load_spec(path)
@@ -1527,7 +1529,7 @@ club_constraints:
 class TestLoadTeamIds(unittest.TestCase):
     """Test cases for load_team_ids()."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self._tmpdir = tempfile.TemporaryDirectory()
         self.addCleanup(self._tmpdir.cleanup)
@@ -1538,14 +1540,14 @@ class TestLoadTeamIds(unittest.TestCase):
         path.write_text(contents)
         return path
 
-    def test_maps_team_ids_to_club_and_index(self):
+    def test_maps_team_ids_to_club_and_index(self) -> None:
         path = self._write(_MINIMAL_SPEC)
         self.assertEqual(
             fixturespec.load_team_ids(path),
             {"albany-1": ("albany", 1), "hackney-1": ("hackney", 1)},
         )
 
-    def test_does_not_require_divisions_or_club_constraints(self):
+    def test_does_not_require_divisions_or_club_constraints(self) -> None:
         """Unlike load_spec(), only 'clubs' and 'teams' need to be valid."""
         path = self._write(_BOILERPLATE)  # no club_constraints, no divisions issues
         self.assertEqual(
@@ -1553,7 +1555,7 @@ class TestLoadTeamIds(unittest.TestCase):
             {"albany-1": ("albany", 1), "hackney-1": ("hackney", 1)},
         )
 
-    def test_unknown_club_still_rejected(self):
+    def test_unknown_club_still_rejected(self) -> None:
         path = self._write(
             "clubs:\n"
             "  hackney:\n"

--- a/helpers_test.py
+++ b/helpers_test.py
@@ -29,7 +29,7 @@ import genfixtures
 class TestGenDates(unittest.TestCase):
     """Test cases for gen_dates function."""
 
-    def test_basic_weekday_generation(self):
+    def test_basic_weekday_generation(self) -> None:
         """Test generating all Mondays in a range."""
         start = date(2025, 1, 6)  # Monday
         end = date(2025, 1, 20)  # Monday
@@ -39,7 +39,7 @@ class TestGenDates(unittest.TestCase):
 
         self.assertEqual(result, expected)
 
-    def test_different_weekday(self):
+    def test_different_weekday(self) -> None:
         """Test generating Thursdays."""
         start = date(2025, 1, 1)  # Wednesday
         end = date(2025, 1, 31)  # Friday
@@ -55,7 +55,7 @@ class TestGenDates(unittest.TestCase):
 
         self.assertEqual(result, expected)
 
-    def test_exclude_first_occurrence(self):
+    def test_exclude_first_occurrence(self) -> None:
         """Test excluding first occurrence of each month."""
         start = date(2025, 1, 1)
         end = date(2025, 3, 31)
@@ -83,7 +83,7 @@ class TestGenDates(unittest.TestCase):
 
         self.assertEqual(result, expected)
 
-    def test_exclude_multiple_occurrences(self):
+    def test_exclude_multiple_occurrences(self) -> None:
         """Test excluding first and third occurrence of each month."""
         start = date(2025, 1, 1)
         end = date(2025, 2, 28)
@@ -103,7 +103,7 @@ class TestGenDates(unittest.TestCase):
 
         self.assertEqual(result, expected)
 
-    def test_single_day_range(self):
+    def test_single_day_range(self) -> None:
         """Test with start and end on same weekday."""
         start = date(2025, 1, 6)  # Monday
         end = date(2025, 1, 6)  # Same Monday
@@ -113,7 +113,7 @@ class TestGenDates(unittest.TestCase):
 
         self.assertEqual(result, expected)
 
-    def test_no_matching_weekdays(self):
+    def test_no_matching_weekdays(self) -> None:
         """Test range with no matching weekdays."""
         start = date(2025, 1, 6)  # Monday
         end = date(2025, 1, 7)  # Tuesday
@@ -130,8 +130,12 @@ class TestGenDates(unittest.TestCase):
         exclude_occurrences=st.lists(st.integers(min_value=1, max_value=5), max_size=3),
     )
     def test_gen_dates_properties(
-        self, start_date, days_span, day_of_week, exclude_occurrences
-    ):
+        self,
+        start_date: date,
+        days_span: int,
+        day_of_week: int,
+        exclude_occurrences: list[int],
+    ) -> None:
         """Test key properties of gen_dates output."""
         end_date = start_date + timedelta(days=days_span)
 
@@ -158,7 +162,7 @@ class TestGenDates(unittest.TestCase):
 class TestRemoveRandom(unittest.TestCase):
     """Test cases for remove_random function."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
 
         # Set up the patch
@@ -169,7 +173,7 @@ class TestRemoveRandom(unittest.TestCase):
         # Default to identity shuffle (no actual shuffling) for most tests
         self.mock_shuffle.side_effect = lambda x: None
 
-    def test_remove_half(self):
+    def test_remove_half(self) -> None:
         """Test removing 50% of dates."""
         dates = [
             date(2025, 1, 1),
@@ -186,7 +190,7 @@ class TestRemoveRandom(unittest.TestCase):
         expected = [date(2025, 1, 1), date(2025, 1, 8)]
         self.assertEqual(result, expected)
 
-    def test_remove_none(self):
+    def test_remove_none(self) -> None:
         """Test removing 0% of dates (keep all)."""
         dates = [
             date(2025, 1, 1),
@@ -202,7 +206,7 @@ class TestRemoveRandom(unittest.TestCase):
         expected = dates  # Same order since no shuffling
         self.assertEqual(result, expected)
 
-    def test_remove_all(self):
+    def test_remove_all(self) -> None:
         """Test removing 100% of dates (keep none)."""
         dates = [
             date(2025, 1, 1),
@@ -217,7 +221,7 @@ class TestRemoveRandom(unittest.TestCase):
         self.assertEqual(len(result), 0)
         self.assertEqual(result, [])
 
-    def test_shuffle_called(self):
+    def test_shuffle_called(self) -> None:
         """Test that shuffle is actually called."""
         dates = [
             date(2025, 1, 1),
@@ -230,7 +234,7 @@ class TestRemoveRandom(unittest.TestCase):
         genfixtures.remove_random(dates, 0.2)
         self.mock_shuffle.assert_called_once()
 
-    def test_empty_input(self):
+    def test_empty_input(self) -> None:
         """Test with empty date list."""
         result = genfixtures.remove_random([], 0.5)
         self.assertEqual(result, [])
@@ -244,7 +248,9 @@ class TestRemoveRandom(unittest.TestCase):
         ),
         fraction=st.floats(min_value=0.0, max_value=1.0),
     )
-    def test_remove_random_properties(self, dates_list, fraction):
+    def test_remove_random_properties(
+        self, dates_list: list[date], fraction: float
+    ) -> None:
         """Test key properties of remove_random output."""
         # Sort input to make test deterministic
         dates_list = sorted(dates_list)
@@ -277,7 +283,7 @@ class TestRemoveRandom(unittest.TestCase):
 class TestDateWindows(unittest.TestCase):
     """Test cases for date_windows function."""
 
-    def test_basic_windows(self):
+    def test_basic_windows(self) -> None:
         """Test basic window generation."""
         dates = [date(2025, 1, 1), date(2025, 1, 3), date(2025, 1, 8)]
 
@@ -294,7 +300,7 @@ class TestDateWindows(unittest.TestCase):
 
         self.assertCountEqual(result, expected)
 
-    def test_single_date(self):
+    def test_single_date(self) -> None:
         """Test with single date."""
         dates = [date(2025, 1, 1)]
 
@@ -303,7 +309,7 @@ class TestDateWindows(unittest.TestCase):
 
         self.assertEqual(result, expected)
 
-    def test_all_dates_in_window(self):
+    def test_all_dates_in_window(self) -> None:
         """Test when all dates fit in one window."""
         dates = [date(2025, 1, 1), date(2025, 1, 2), date(2025, 1, 3)]
 
@@ -312,7 +318,7 @@ class TestDateWindows(unittest.TestCase):
 
         self.assertEqual(result, expected)
 
-    def test_no_overlapping_windows(self):
+    def test_no_overlapping_windows(self) -> None:
         """Test dates that don't create overlapping windows."""
         dates = [date(2025, 1, 1), date(2025, 1, 10), date(2025, 1, 20)]
 
@@ -327,7 +333,7 @@ class TestDateWindows(unittest.TestCase):
 
         self.assertCountEqual(result, expected)
 
-    def test_subset_removal(self):
+    def test_subset_removal(self) -> None:
         """Test that subset windows are properly removed."""
         dates = [date(2025, 1, 1), date(2025, 1, 2), date(2025, 1, 3), date(2025, 1, 4)]
 
@@ -337,12 +343,12 @@ class TestDateWindows(unittest.TestCase):
         expected = [frozenset(dates)]
         self.assertEqual(result, expected)
 
-    def test_empty_input(self):
+    def test_empty_input(self) -> None:
         """Test with empty date list."""
         result = fmodel.date_windows([], window_days=7)
         self.assertEqual(result, [])
 
-    def test_window_size_zero(self):
+    def test_window_size_zero(self) -> None:
         """Test with zero window size."""
         dates = [date(2025, 1, 1), date(2025, 1, 2)]
 
@@ -353,7 +359,7 @@ class TestDateWindows(unittest.TestCase):
 
         self.assertCountEqual(result, expected)
 
-    def test_unsorted_input(self):
+    def test_unsorted_input(self) -> None:
         """Test that function handles unsorted input correctly."""
         dates = [date(2025, 1, 8), date(2025, 1, 1), date(2025, 1, 3)]
 
@@ -376,7 +382,9 @@ class TestDateWindows(unittest.TestCase):
         ),
         window_days=st.integers(min_value=0, max_value=30),
     )
-    def test_date_windows_properties(self, dates_list, window_days):
+    def test_date_windows_properties(
+        self, dates_list: list[date], window_days: int
+    ) -> None:
         """Test key properties of date_windows output."""
         assume(len(dates_list) > 0 or window_days >= 0)  # Avoid trivial cases
 

--- a/htmlreport_test.py
+++ b/htmlreport_test.py
@@ -81,21 +81,21 @@ def _club(
 
 
 class TestSlugify(unittest.TestCase):
-    def test_simple(self):
+    def test_simple(self) -> None:
         self.assertEqual(htmlreport.slugify("Albany"), "albany")
 
-    def test_spaces_and_punctuation(self):
+    def test_spaces_and_punctuation(self) -> None:
         self.assertEqual(htmlreport.slugify("Willesden & Brent"), "willesden-brent")
 
-    def test_leading_trailing_punctuation(self):
+    def test_leading_trailing_punctuation(self) -> None:
         self.assertEqual(htmlreport.slugify("  Kings Head!!"), "kings-head")
 
-    def test_empty(self):
+    def test_empty(self) -> None:
         self.assertEqual(htmlreport.slugify("---"), "unnamed")
 
 
 class TestGenerateReport(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self._tmpdir = tempfile.TemporaryDirectory()
         self.addCleanup(self._tmpdir.cleanup)
@@ -155,11 +155,11 @@ class TestGenerateReport(unittest.TestCase):
             self.fixtures, self.teams, self.clubs, self.output_dir
         )
 
-    def test_returns_index_path(self):
+    def test_returns_index_path(self) -> None:
         self.assertEqual(self.index_path, self.output_dir / "index.html")
         self.assertTrue(self.index_path.exists())
 
-    def test_all_matches_page(self):
+    def test_all_matches_page(self) -> None:
         content = (self.output_dir / "all-matches.html").read_text()
         self.assertIn("Harrow 1", content)
         self.assertIn("Ealing 1", content)
@@ -167,7 +167,7 @@ class TestGenerateReport(unittest.TestCase):
         # 4 fixtures -> 4 data rows (plus header row)
         self.assertEqual(content.count("<tr>"), 5)
 
-    def test_match_annotated_with_venue_start_and_time_limit(self):
+    def test_match_annotated_with_venue_start_and_time_limit(self) -> None:
         content = (self.output_dir / "all-matches.html").read_text()
         self.assertIn("<th>Venue</th>", content)
         self.assertIn("<th>Start</th>", content)
@@ -176,13 +176,13 @@ class TestGenerateReport(unittest.TestCase):
         self.assertIn("19:30", content)
         self.assertIn("75+15", content)
 
-    def test_match_table_shows_venue_name_but_not_address(self):
+    def test_match_table_shows_venue_name_but_not_address(self) -> None:
         content = (self.output_dir / "all-matches.html").read_text()
         table_part = content.split("<h2>Venues</h2>")[0]
         self.assertIn("Harrow Leisure Centre", table_part)
         self.assertNotIn("1 Harrow Road, London", table_part)
 
-    def test_all_matches_venues_section_lists_name_and_address(self):
+    def test_all_matches_venues_section_lists_name_and_address(self) -> None:
         content = (self.output_dir / "all-matches.html").read_text()
         self.assertIn("<h2>Venues</h2>", content)
         venues_part = content.split("<h2>Venues</h2>")[1]
@@ -192,19 +192,19 @@ class TestGenerateReport(unittest.TestCase):
         self.assertIn("2 Ealing Road, London", venues_part)
         self.assertIn("Hendon Club", venues_part)
 
-    def test_division_venues_section_only_lists_that_divisions_clubs(self):
+    def test_division_venues_section_only_lists_that_divisions_clubs(self) -> None:
         div1 = (self.output_dir / "division-1.html").read_text()
         venues_part = div1.split("<h2>Venues</h2>")[1]
         self.assertIn("Harrow Leisure Centre", venues_part)
         self.assertIn("Ealing Sports Hall", venues_part)
         self.assertNotIn("Hendon Club", venues_part)
 
-    def test_name_override_used_throughout(self):
+    def test_name_override_used_throughout(self) -> None:
         content = (self.output_dir / "all-matches.html").read_text()
         self.assertIn("Willesden Warriors", content)
         self.assertNotIn("Willesden &amp; Brent 1", content)
 
-    def test_division_pages(self):
+    def test_division_pages(self) -> None:
         div1 = (self.output_dir / "division-1.html").read_text()
         self.assertIn("Harrow 1", div1)
         self.assertNotIn("Hendon 1", div1)
@@ -216,13 +216,13 @@ class TestGenerateReport(unittest.TestCase):
         self.assertIn("Hendon 1", div2)
         self.assertIn("Willesden Warriors", div2)
 
-    def test_division_page_names_the_fixture_scheme_in_a_subheading(self):
+    def test_division_page_names_the_fixture_scheme_in_a_subheading(self) -> None:
         # No division_schemes passed -> every division defaults to a double round.
         div1 = (self.output_dir / "division-1.html").read_text()
         self.assertIn("<h2>Double-round all-play-all</h2>", div1)
         self.assertNotIn("Single-round", div1)
 
-    def test_club_per_team_heading_names_the_fixture_scheme_in_brackets(self):
+    def test_club_per_team_heading_names_the_fixture_scheme_in_brackets(self) -> None:
         harrow_page = (self.output_dir / "club-harrow.html").read_text()
         harrow1_section = harrow_page.split('<h2 id="harrow-1">')[1].split("<h2")[0]
         self.assertIn(
@@ -233,7 +233,7 @@ class TestGenerateReport(unittest.TestCase):
         consolidated = harrow_page.split("<h2")[0]
         self.assertNotIn("all-play-all", consolidated)
 
-    def test_single_round_division_scheme_shown_on_its_pages_only(self):
+    def test_single_round_division_scheme_shown_on_its_pages_only(self) -> None:
         out2 = Path(self._tmpdir.name) / "out-scheme"
         _generate(
             self.fixtures,
@@ -254,7 +254,7 @@ class TestGenerateReport(unittest.TestCase):
             "<h3>Division 2 (Single-round all-play-all)</h3>", hendon1_section
         )
 
-    def test_club_page_consolidated_and_per_team(self):
+    def test_club_page_consolidated_and_per_team(self) -> None:
         harrow_page = (self.output_dir / "club-harrow.html").read_text()
         # 3 distinct fixtures touch Harrow (incl. the Harrow 1 v Harrow 2 derby); the
         # consolidated table must list each exactly once, not twice for the derby.
@@ -266,7 +266,7 @@ class TestGenerateReport(unittest.TestCase):
         harrow1_section = harrow_page.split('<h2 id="harrow-1">')[1].split("<h2")[0]
         self.assertEqual(harrow1_section.count("<tr>"), 4)  # header + 3 fixtures
 
-    def test_team_heading_has_stable_anchor_id(self):
+    def test_team_heading_has_stable_anchor_id(self) -> None:
         harrow_page = (self.output_dir / "club-harrow.html").read_text()
         self.assertIn('<h2 id="harrow-1">', harrow_page)
         self.assertIn('<h2 id="harrow-2">', harrow_page)
@@ -274,26 +274,26 @@ class TestGenerateReport(unittest.TestCase):
         # A name_override should be slugified for the anchor, same as everywhere else.
         self.assertIn('<h2 id="willesden-warriors">', willesden_page)
 
-    def test_team_heading_has_self_link_icon_pointing_at_its_own_anchor(self):
+    def test_team_heading_has_self_link_icon_pointing_at_its_own_anchor(self) -> None:
         harrow_page = (self.output_dir / "club-harrow.html").read_text()
         self.assertIn(
             '<a class="anchor-link" href="#harrow-1" aria-label="Link to Harrow 1">',
             harrow_page,
         )
 
-    def test_club_page_header_shows_venue_name_and_address(self):
+    def test_club_page_header_shows_venue_name_and_address(self) -> None:
         harrow_page = (self.output_dir / "club-harrow.html").read_text()
         header_part = harrow_page.split("<table>")[0]
         self.assertIn("Harrow Leisure Centre", header_part)
         self.assertIn("1 Harrow Road, London", header_part)
 
-    def test_ampersand_club_name_slugified_and_escaped(self):
+    def test_ampersand_club_name_slugified_and_escaped(self) -> None:
         path = self.output_dir / "club-willesden-brent.html"
         self.assertTrue(path.exists())
         content = path.read_text()
         self.assertIn("Willesden &amp; Brent", content)
 
-    def test_run_index_links_to_all_pages(self):
+    def test_run_index_links_to_all_pages(self) -> None:
         content = self.index_path.read_text()
         self.assertIn("all-matches.html", content)
         self.assertIn("division-1.html", content)
@@ -304,7 +304,7 @@ class TestGenerateReport(unittest.TestCase):
         self.assertIn(">Division 1<", content)
         self.assertIn(">Willesden &amp; Brent<", content)
 
-    def test_run_index_links_to_csv_exports_when_present(self):
+    def test_run_index_links_to_csv_exports_when_present(self) -> None:
         for name in ("all-matches.csv", "all-matches-by-team.csv"):
             (self.output_dir / name).write_text("date\n")
 
@@ -317,11 +317,11 @@ class TestGenerateReport(unittest.TestCase):
             content.index("all-matches.csv"), content.index("<h2>Divisions</h2>")
         )
 
-    def test_run_index_has_no_csv_links_when_exports_absent(self):
+    def test_run_index_has_no_csv_links_when_exports_absent(self) -> None:
         # setUp's _generate() writes HTML pages only, no CSV files.
         self.assertNotIn(".csv", self.index_path.read_text())
 
-    def test_build_run_index_is_rebuildable_from_disk_alone(self):
+    def test_build_run_index_is_rebuildable_from_disk_alone(self) -> None:
         """Deleting index.html and rebuilding from the other report files must reproduce it."""
         self.index_path.unlink()
         rebuilt_path = htmlreport.build_run_index(self.output_dir)
@@ -330,7 +330,7 @@ class TestGenerateReport(unittest.TestCase):
         self.assertIn("division-1.html", content)
         self.assertIn("club-harrow.html", content)
 
-    def test_division_numbers_sort_numerically_not_lexically(self):
+    def test_division_numbers_sort_numerically_not_lexically(self) -> None:
         out2 = Path(self._tmpdir.name) / "out3"
         out2.mkdir()
         for n in [1, 2, 10]:
@@ -346,7 +346,7 @@ class TestGenerateReport(unittest.TestCase):
             content.index("division-2.html"), content.index("division-10.html")
         )
 
-    def test_team_with_no_fixtures_gets_empty_table(self):
+    def test_team_with_no_fixtures_gets_empty_table(self) -> None:
         lonely_clubs = {"lonely-fc": _club("Lonely FC")}
         lonely = fmodel.Team(division=3, club="lonely-fc", index=1)
         out2 = Path(self._tmpdir.name) / "out2"
@@ -354,20 +354,20 @@ class TestGenerateReport(unittest.TestCase):
         content = (out2 / "club-lonely-fc.html").read_text()
         self.assertIn("No matches", content)
 
-    def test_no_name_or_draft_by_default(self):
+    def test_no_name_or_draft_by_default(self) -> None:
         for filename in ["all-matches.html", "division-1.html", "club-harrow.html"]:
             content = (self.output_dir / filename).read_text()
             self.assertNotIn('class="banner"', content)
             self.assertNotIn('class="draft-label"', content)
         self.assertNotIn('class="banner"', self.index_path.read_text())
 
-    def test_no_description_by_default(self):
+    def test_no_description_by_default(self) -> None:
         for filename in ["all-matches.html", "division-1.html", "club-harrow.html"]:
             content = (self.output_dir / filename).read_text()
             self.assertNotIn('class="description"', content)
         self.assertNotIn('class="description"', self.index_path.read_text())
 
-    def test_run_name_and_draft_shown_on_every_page(self):
+    def test_run_name_and_draft_shown_on_every_page(self) -> None:
         out2 = Path(self._tmpdir.name) / "out-named"
         index_path = _generate(
             self.fixtures,
@@ -388,7 +388,7 @@ class TestGenerateReport(unittest.TestCase):
             self.assertIn('<span class="draft-label">DRAFT</span>', content)
             self.assertIn('<span class="run-name">2025-26 Season</span>', content)
 
-    def test_index_recovers_name_and_draft_from_disk_alone(self):
+    def test_index_recovers_name_and_draft_from_disk_alone(self) -> None:
         """Rebuilding index.html from scratch must recover the run name/draft status
         from the other report files, since build_run_index has no other source for them."""
         out2 = Path(self._tmpdir.name) / "out-rebuilt"
@@ -401,7 +401,7 @@ class TestGenerateReport(unittest.TestCase):
         self.assertIn('<span class="draft-label">DRAFT</span>', content)
         self.assertIn('<span class="run-name">Test Run</span>', content)
 
-    def test_description_shown_on_every_page(self):
+    def test_description_shown_on_every_page(self) -> None:
         out2 = Path(self._tmpdir.name) / "out-described"
         index_path = _generate(
             self.fixtures,
@@ -420,7 +420,7 @@ class TestGenerateReport(unittest.TestCase):
             self.assertIn('<p class="description">', content)
             self.assertIn("Final schedule", content)
 
-    def test_index_recovers_description_from_disk_alone(self):
+    def test_index_recovers_description_from_disk_alone(self) -> None:
         """Rebuilding index.html must recover the description from the other report files."""
         out2 = Path(self._tmpdir.name) / "out-desc-rebuilt"
         index_path = _generate(
@@ -437,7 +437,7 @@ class TestGenerateReport(unittest.TestCase):
 
 
 class TestExcludedFixturesInReport(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self._tmpdir = tempfile.TemporaryDirectory()
         self.addCleanup(self._tmpdir.cleanup)
@@ -467,18 +467,18 @@ class TestExcludedFixturesInReport(unittest.TestCase):
             excluded_fixtures=self.excluded,
         )
 
-    def test_all_matches_page_shows_tbc_row_after_dated_rows(self):
+    def test_all_matches_page_shows_tbc_row_after_dated_rows(self) -> None:
         content = (self.output_dir / "all-matches.html").read_text()
         self.assertIn("<td><strong>TBC</strong></td>", content)
         self.assertIn("Harrow 2", content)
         self.assertLess(content.index("2025"), content.index("TBC"))
 
-    def test_division_page_shows_excluded_fixture(self):
+    def test_division_page_shows_excluded_fixture(self) -> None:
         div1 = (self.output_dir / "division-1.html").read_text()
         self.assertIn("<td><strong>TBC</strong></td>", div1)
         self.assertIn("Harrow 2", div1)
 
-    def test_club_page_consolidated_shows_excluded_fixture(self):
+    def test_club_page_consolidated_shows_excluded_fixture(self) -> None:
         harrow_page = (self.output_dir / "club-harrow.html").read_text()
         consolidated_table = harrow_page.split("<h2")[0]
         self.assertIn("TBC", consolidated_table)
@@ -486,7 +486,7 @@ class TestExcludedFixturesInReport(unittest.TestCase):
         consolidated_table = ealing_page.split("<h2")[0]
         self.assertIn("TBC", consolidated_table)
 
-    def test_team_page_shows_excluded_fixture_with_blank_days_since(self):
+    def test_team_page_shows_excluded_fixture_with_blank_days_since(self) -> None:
         harrow_page = (self.output_dir / "club-harrow.html").read_text()
         harrow2_section = harrow_page.split('<h2 id="harrow-2">')[1].split("<h2")[0]
         expected_row = (
@@ -495,18 +495,18 @@ class TestExcludedFixturesInReport(unittest.TestCase):
         )
         self.assertIn(expected_row, harrow2_section)
 
-    def test_team_not_involved_in_excluded_fixture_unaffected(self):
+    def test_team_not_involved_in_excluded_fixture_unaffected(self) -> None:
         harrow_page = (self.output_dir / "club-harrow.html").read_text()
         harrow1_section = harrow_page.split('<h2 id="harrow-1">')[1].split("<h2")[0]
         self.assertNotIn("TBC", harrow1_section)
 
-    def test_no_excluded_fixtures_by_default(self):
+    def test_no_excluded_fixtures_by_default(self) -> None:
         out2 = Path(self._tmpdir.name) / "out-no-excluded"
         _generate(self.fixtures, self.teams, self.clubs, out2)
         content = (out2 / "all-matches.html").read_text()
         self.assertNotIn("TBC", content)
 
-    def test_division_with_only_excluded_fixtures_still_gets_a_page(self):
+    def test_division_with_only_excluded_fixtures_still_gets_a_page(self) -> None:
         clubs = dict(self.clubs)
         clubs["hendon"] = _club("Hendon")
         clubs["wembley"] = _club("Wembley")
@@ -527,7 +527,7 @@ class TestExcludedFixturesInReport(unittest.TestCase):
 
 
 class TestWriteRunsIndex(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self._tmpdir = tempfile.TemporaryDirectory()
         self.addCleanup(self._tmpdir.cleanup)
@@ -535,12 +535,12 @@ class TestWriteRunsIndex(unittest.TestCase):
         self.runs_dir = self.root / "runs"
         self.index_path = self.root / "index.html"
 
-    def test_no_runs(self):
+    def test_no_runs(self) -> None:
         htmlreport.write_runs_index(self.runs_dir, self.index_path)
         content = self.index_path.read_text()
         self.assertIn("No runs yet", content)
 
-    def test_lists_runs_with_report_only(self):
+    def test_lists_runs_with_report_only(self) -> None:
         for name in ["2024-25-season", "2025-26-season"]:
             run_dir = self.runs_dir / name
             run_dir.mkdir(parents=True)
@@ -560,7 +560,7 @@ class TestWriteRunsIndex(unittest.TestCase):
             content.index("2025-26-season"), content.index("2024-25-season")
         )
 
-    def test_nested_run(self):
+    def test_nested_run(self) -> None:
         """A run need not sit directly under runs_dir -- e.g. several drafts of the
         same season grouped under a season folder -- and should still be found and
         linked correctly, nested under a heading for the grouping folder(s)."""
@@ -576,7 +576,7 @@ class TestWriteRunsIndex(unittest.TestCase):
         self.assertNotIn('<a href="runs/2026-27/index.html"', content)
         self.assertIn("2026-27", content)
 
-    def test_nested_and_flat_runs_combined(self):
+    def test_nested_and_flat_runs_combined(self) -> None:
         (self.runs_dir / "example").mkdir(parents=True)
         (self.runs_dir / "example" / "all-matches.html").write_text("<html></html>")
         nested_run_dir = self.runs_dir / "2026-27" / "draft1"
@@ -591,16 +591,16 @@ class TestWriteRunsIndex(unittest.TestCase):
 
 
 class TestFindRunDirs(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self._tmpdir = tempfile.TemporaryDirectory()
         self.addCleanup(self._tmpdir.cleanup)
         self.runs_dir = Path(self._tmpdir.name) / "runs"
 
-    def test_missing_runs_dir(self):
+    def test_missing_runs_dir(self) -> None:
         self.assertEqual(htmlreport.find_run_dirs(self.runs_dir), [])
 
-    def test_finds_runs_at_any_depth(self):
+    def test_finds_runs_at_any_depth(self) -> None:
         flat_run = self.runs_dir / "example"
         flat_run.mkdir(parents=True)
         (flat_run / "all-matches.html").write_text("<html></html>")

--- a/model_test.py
+++ b/model_test.py
@@ -18,6 +18,7 @@ import collections
 import random
 import unittest
 from datetime import date, timedelta
+from typing import Any
 
 import berger
 import fmodel
@@ -31,20 +32,20 @@ class TestSolve(unittest.TestCase):
     fixtures: list[fmodel.ScheduledFixture]
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         """Set up class-level data by solving once with real parameters."""
         # Seed random number generator for reproducible test results
         random.seed(42)
         cls.params = genfixtures.build_params()
         cls.fixtures = list(fmodel.solve(cls.params))
 
-    def test_basic_solve(self):
+    def test_basic_solve(self) -> None:
         """Test that solve produces fixtures with real parameters."""
         self.assertGreater(len(self.fixtures), 0, "Should generate some fixtures")
         for sf in self.fixtures:
             self.assertIsInstance(sf, fmodel.ScheduledFixture)
 
-    def test_fixture_uniqueness(self):
+    def test_fixture_uniqueness(self) -> None:
         """Test that all fixtures are unique."""
         fixture_pairs: set[tuple[fmodel.Team, fmodel.Team]] = set()
         for sf in self.fixtures:
@@ -52,7 +53,7 @@ class TestSolve(unittest.TestCase):
             self.assertNotIn(pair, fixture_pairs, f"Duplicate fixture: {pair}")
             fixture_pairs.add(pair)
 
-    def test_valid_home_dates(self):
+    def test_valid_home_dates(self) -> None:
         """Test that all fixtures are on valid home dates."""
         for sf in self.fixtures:
             home_club = sf.fixture.home_team.club
@@ -62,7 +63,7 @@ class TestSolve(unittest.TestCase):
                 f"Fixture on {sf.date} not on valid home date for {home_club}",
             )
 
-    def test_team_constraints(self):
+    def test_team_constraints(self) -> None:
         """Test that team constraints are satisfied with real parameters."""
         # Verify no team plays more than one fixture on the same date
         team_schedule = collections.defaultdict(list)
@@ -78,7 +79,7 @@ class TestSolve(unittest.TestCase):
                 f"Team {team.name} has multiple fixtures on same date",
             )
 
-    def test_min_gap_constraint(self):
+    def test_min_gap_constraint(self) -> None:
         """Test minimum gap days constraint with real parameters."""
         # Verify minimum gap constraint for each team
         team_dates = collections.defaultdict(list)
@@ -96,7 +97,7 @@ class TestSolve(unittest.TestCase):
                     f"Team {team.name} has fixtures too close: {sorted_dates[i - 1]} and {sorted_dates[i]} (gap: {gap} days)",
                 )
 
-    def test_max_concurrent_home_constraint(self):
+    def test_max_concurrent_home_constraint(self) -> None:
         """Test max concurrent home matches constraint with real parameters."""
         # Count home fixtures per club per date
         home_fixtures_by_club_date: dict[tuple[str, date], int] = (
@@ -119,7 +120,7 @@ class TestSolve(unittest.TestCase):
                 f"Club {club} has {count} home matches on {fixture_date}, exceeding limit of {limit}",
             )
 
-    def test_unavailable_away_dates(self):
+    def test_unavailable_away_dates(self) -> None:
         """Test that unavailable away dates are respected with real parameters."""
         # Verify clubs don't play away on their unavailable dates
         for sf in self.fixtures:
@@ -131,7 +132,7 @@ class TestSolve(unittest.TestCase):
                     f"Club {away_club} scheduled away on unavailable date {sf.date}",
                 )
 
-    def test_division_separation(self):
+    def test_division_separation(self) -> None:
         """Test that teams only play within their division with real parameters."""
         # Verify no cross-division fixtures
         for sf in self.fixtures:
@@ -144,7 +145,7 @@ class TestSolve(unittest.TestCase):
                 f"{sf.fixture.away_team.name} (div {away_division})",
             )
 
-    def test_completeness(self):
+    def test_completeness(self) -> None:
         """Test that all required fixtures within divisions are scheduled with real parameters."""
         # Calculate expected fixtures by division
         teams_by_division = collections.defaultdict(list)
@@ -174,7 +175,7 @@ class TestSolve(unittest.TestCase):
             "Not all required fixtures were scheduled",
         )
 
-    def test_fixture_count_by_division(self):
+    def test_fixture_count_by_division(self) -> None:
         """Test that fixture counts are correct for each division with real parameters."""
         # Count fixtures by division
         fixtures_by_division: dict[int, int] = collections.defaultdict(int)
@@ -196,7 +197,7 @@ class TestSolve(unittest.TestCase):
                 f"Division {division}: expected {expected_fixture_count} fixtures, got {actual_fixture_count}",
             )
 
-    def test_teams_play_both_home_and_away(self):
+    def test_teams_play_both_home_and_away(self) -> None:
         """Test that each team plays both home and away fixtures with real parameters."""
         home_fixtures_by_team: dict[fmodel.Team, int] = collections.defaultdict(int)
         away_fixtures_by_team: dict[fmodel.Team, int] = collections.defaultdict(int)
@@ -213,7 +214,7 @@ class TestSolve(unittest.TestCase):
                 away_fixtures_by_team[team], 0, f"Team {team.name} has no away fixtures"
             )
 
-    def test_simple_impossible_constraint(self):
+    def test_simple_impossible_constraint(self) -> None:
         """Test that impossible constraints result in no fixtures being scheduled."""
         # Create a scenario that's impossible to solve
         team1 = fmodel.Team(division=1, club="Test Club A", index=1)
@@ -258,7 +259,7 @@ class TestMaxConcurrentHomeMatchesFor(unittest.TestCase):
     should report it as unlimited (None) too. See issue #22.
     """
 
-    def _params(self, num_teams, limit):
+    def _params(self, num_teams: int, limit: int | None) -> fmodel.Parameters:
         teams = [
             fmodel.Team(division=1, club="A", index=i) for i in range(1, num_teams + 1)
         ]
@@ -271,21 +272,21 @@ class TestMaxConcurrentHomeMatchesFor(unittest.TestCase):
             },
         )
 
-    def test_limit_below_team_count_is_kept(self):
+    def test_limit_below_team_count_is_kept(self) -> None:
         params = self._params(num_teams=3, limit=2)
         self.assertEqual(
             params.max_concurrent_home_matches_for("A", date(2025, 1, 1)), 2
         )
 
-    def test_limit_equal_to_team_count_is_reported_as_unlimited(self):
+    def test_limit_equal_to_team_count_is_reported_as_unlimited(self) -> None:
         params = self._params(num_teams=2, limit=2)
         self.assertIsNone(params.max_concurrent_home_matches_for("A", date(2025, 1, 1)))
 
-    def test_limit_above_team_count_is_reported_as_unlimited(self):
+    def test_limit_above_team_count_is_reported_as_unlimited(self) -> None:
         params = self._params(num_teams=2, limit=5)
         self.assertIsNone(params.max_concurrent_home_matches_for("A", date(2025, 1, 1)))
 
-    def test_explicit_unlimited_stays_unlimited(self):
+    def test_explicit_unlimited_stays_unlimited(self) -> None:
         params = self._params(num_teams=2, limit=None)
         self.assertIsNone(params.max_concurrent_home_matches_for("A", date(2025, 1, 1)))
 
@@ -293,15 +294,15 @@ class TestMaxConcurrentHomeMatchesFor(unittest.TestCase):
 class TestHomeDatesUsedBounds(unittest.TestCase):
     """Validation of the HomeDatesUsedBounds value object itself."""
 
-    def test_requires_at_least_one_bound(self):
+    def test_requires_at_least_one_bound(self) -> None:
         with self.assertRaises(ValueError):
             fmodel.HomeDatesUsedBounds()
 
-    def test_rejects_min_above_max(self):
+    def test_rejects_min_above_max(self) -> None:
         with self.assertRaises(ValueError):
             fmodel.HomeDatesUsedBounds(minimum=5, maximum=3)
 
-    def test_equal_min_and_max_allowed(self):
+    def test_equal_min_and_max_allowed(self) -> None:
         bounds = fmodel.HomeDatesUsedBounds(minimum=3, maximum=3)
         self.assertEqual((bounds.minimum, bounds.maximum), (3, 3))
 
@@ -309,7 +310,7 @@ class TestHomeDatesUsedBounds(unittest.TestCase):
 class TestHomeDatesUsed(unittest.TestCase):
     """Test cases for the home_dates_used (min/max) constraint."""
 
-    def test_constraint_limits_dates_used(self):
+    def test_constraint_limits_dates_used(self) -> None:
         """Solver uses at most home_dates_used.maximum home dates for a club.
 
         Club "A" has two teams in a division with six other teams (one each from
@@ -357,7 +358,7 @@ class TestHomeDatesUsed(unittest.TestCase):
         unused_a_dates = set(a_home_dates) - a_dates_used
         self.assertGreaterEqual(len(unused_a_dates), 4)
 
-    def test_min_constraint_spreads_dates_used(self):
+    def test_min_constraint_spreads_dates_used(self) -> None:
         """Solver uses at least home_dates_used.minimum home dates for a club.
 
         Same shape as test_constraint_limits_dates_used: club "A" has two teams
@@ -397,7 +398,7 @@ class TestHomeDatesUsed(unittest.TestCase):
         a_dates_used = {sf.date for sf in fixtures if sf.fixture.home_team.club == "A"}
         self.assertGreaterEqual(len(a_dates_used), 10)
 
-    def test_min_constraint_enforced_strictly(self):
+    def test_min_constraint_enforced_strictly(self) -> None:
         """A club whose schedule can't reach home_dates_used.minimum is infeasible."""
         # A's single team plays one home match, so at most one home date can ever be
         # used; requiring a minimum of 2 is impossible.
@@ -423,7 +424,7 @@ class TestHomeDatesUsed(unittest.TestCase):
         with self.assertRaises(ValueError):
             fmodel.solve(params)
 
-    def test_constraint_enforced_strictly(self):
+    def test_constraint_enforced_strictly(self) -> None:
         """A club with two teams needs two home dates; a limit of 1 makes it infeasible."""
         # A has two teams in the same division, requiring 2 home matches on different dates
         # (min_gap_days=7 forces different dates). But home_dates_used.maximum=1 for A
@@ -458,7 +459,7 @@ class TestHomeDatesUsed(unittest.TestCase):
 class TestFixedFixtures(unittest.TestCase):
     """Test cases for the fixed_fixtures constraint."""
 
-    def _params(self, **kwargs):
+    def _params(self, **kwargs: Any) -> fmodel.Parameters:
         teams = [
             fmodel.Team(division=1, club="A", index=1),
             fmodel.Team(division=1, club="A", index=2),
@@ -488,7 +489,7 @@ class TestFixedFixtures(unittest.TestCase):
             **kwargs,
         )
 
-    def test_fixed_fixture_is_scheduled_on_given_date(self):
+    def test_fixed_fixture_is_scheduled_on_given_date(self) -> None:
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=1, club="A", index=2)
         fixed = fmodel.ScheduledFixture(
@@ -498,7 +499,7 @@ class TestFixedFixtures(unittest.TestCase):
         fixtures = list(fmodel.solve(params))
         self.assertIn(fixed, fixtures)
 
-    def test_fixed_fixture_on_non_home_date_rejected(self):
+    def test_fixed_fixture_on_non_home_date_rejected(self) -> None:
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=1, club="A", index=2)
         fixed = fmodel.ScheduledFixture(
@@ -509,7 +510,7 @@ class TestFixedFixtures(unittest.TestCase):
         with self.assertRaises(ValueError):
             fmodel.solve(params)
 
-    def test_fixed_fixture_forces_other_fixtures_off_that_date(self):
+    def test_fixed_fixture_forces_other_fixtures_off_that_date(self) -> None:
         """Pinning A1 v A2 to a date means A1 and A2 are both unavailable that date,
         so the reverse fixture (which involves both of the same teams) must land
         elsewhere."""
@@ -528,7 +529,7 @@ class TestFixedFixtures(unittest.TestCase):
         )
         self.assertNotEqual(reverse.date, date(2025, 1, 1))
 
-    def test_reverse_fixture_exactly_min_gap_days_apart_is_allowed(self):
+    def test_reverse_fixture_exactly_min_gap_days_apart_is_allowed(self) -> None:
         """Regression test: a gap of exactly min_gap_days satisfies a *minimum*
         gap of min_gap_days, so two fixed fixtures for the same pair of teams
         that many days apart must be schedulable, not rejected as too close."""
@@ -557,7 +558,7 @@ class TestFixedFixtures(unittest.TestCase):
         fixtures = list(fmodel.solve(params))
         self.assertCountEqual(fixtures, fixed)
 
-    def test_reverse_fixture_one_day_inside_min_gap_days_is_rejected(self):
+    def test_reverse_fixture_one_day_inside_min_gap_days_is_rejected(self) -> None:
         """A gap one day short of min_gap_days must still be rejected."""
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=1, club="A", index=2)
@@ -588,7 +589,7 @@ class TestFixedFixtures(unittest.TestCase):
 class TestLatestInternalMatchDate(unittest.TestCase):
     """Test cases for the latest_internal_match_date constraint."""
 
-    def _params(self, **kwargs):
+    def _params(self, **kwargs: Any) -> fmodel.Parameters:
         teams = [
             fmodel.Team(division=1, club="A", index=1),
             fmodel.Team(division=1, club="A", index=2),
@@ -615,7 +616,7 @@ class TestLatestInternalMatchDate(unittest.TestCase):
             **kwargs,
         )
 
-    def test_internal_matches_respect_the_cutoff(self):
+    def test_internal_matches_respect_the_cutoff(self) -> None:
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=1, club="A", index=2)
         params = self._params(latest_internal_match_date=date(2025, 2, 15))
@@ -629,7 +630,7 @@ class TestLatestInternalMatchDate(unittest.TestCase):
         for sf in internal:
             self.assertLessEqual(sf.date, date(2025, 2, 15))
 
-    def test_non_internal_matches_unaffected(self):
+    def test_non_internal_matches_unaffected(self) -> None:
         """A cross-club fixture (different clubs) may still use a late home date."""
         a1 = fmodel.Team(division=1, club="A", index=1)
         b1 = fmodel.Team(division=1, club="B", index=1)
@@ -642,7 +643,7 @@ class TestLatestInternalMatchDate(unittest.TestCase):
         )
         self.assertGreater(cross_club.date, date(2025, 2, 15))
 
-    def test_cutoff_before_any_home_date_drops_the_internal_fixture(self):
+    def test_cutoff_before_any_home_date_drops_the_internal_fixture(self) -> None:
         """No A home date qualifies, so the internal fixture has zero candidate
         variables: consistent with how a fixture that unavailable_away_dates makes
         wholly unschedulable is silently omitted (see
@@ -661,7 +662,7 @@ class TestLatestInternalMatchDate(unittest.TestCase):
         self.assertEqual(internal, [])
         self.assertTrue(fixtures)  # the other (non-internal) fixtures still solve
 
-    def test_fixed_internal_fixture_after_cutoff_rejected(self):
+    def test_fixed_internal_fixture_after_cutoff_rejected(self) -> None:
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=1, club="A", index=2)
         fixed = fmodel.ScheduledFixture(
@@ -673,7 +674,7 @@ class TestLatestInternalMatchDate(unittest.TestCase):
         with self.assertRaises(ValueError):
             fmodel.solve(params)
 
-    def test_no_cutoff_by_default(self):
+    def test_no_cutoff_by_default(self) -> None:
         """Without latest_internal_match_date, internal matches can use any date."""
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=1, club="A", index=2)
@@ -699,7 +700,7 @@ class TestEarliestMatchDate(unittest.TestCase):
     leave room for a cutoff to remove some of them and still solve.
     """
 
-    def _params(self, **kwargs):
+    def _params(self, **kwargs: Any) -> fmodel.Parameters:
         teams = [
             fmodel.Team(division=1, club="A", index=1),
             fmodel.Team(division=1, club="A", index=2),
@@ -728,7 +729,7 @@ class TestEarliestMatchDate(unittest.TestCase):
             **kwargs,
         )
 
-    def test_new_fixtures_respect_the_cutoff(self):
+    def test_new_fixtures_respect_the_cutoff(self) -> None:
         """A cutoff that excludes some (but not all) of club A's dates still
         leaves enough of them (4, the minimum -- see class docstring) to solve."""
         params = self._params(earliest_match_date=date(2025, 2, 1))
@@ -737,7 +738,7 @@ class TestEarliestMatchDate(unittest.TestCase):
         for sf in fixtures:
             self.assertGreaterEqual(sf.date, date(2025, 2, 1))
 
-    def test_cutoff_after_all_of_a_clubs_home_dates_drops_its_fixtures(self):
+    def test_cutoff_after_all_of_a_clubs_home_dates_drops_its_fixtures(self) -> None:
         """A cutoff after all of club A's home dates (but before club B's) makes
         every A-hosted fixture unschedulable -- each has zero candidate
         variables, so (consistent with
@@ -750,7 +751,7 @@ class TestEarliestMatchDate(unittest.TestCase):
         self.assertFalse([sf for sf in fixtures if sf.fixture.home_team.club == "A"])
         self.assertTrue([sf for sf in fixtures if sf.fixture.home_team.club == "B"])
 
-    def test_fixed_fixture_before_cutoff_still_solves(self):
+    def test_fixed_fixture_before_cutoff_still_solves(self) -> None:
         """Unlike latest_internal_match_date, a fixed fixture dated before the cutoff
         is not rejected: fixed_fixtures represents matches that are already
         committed (possibly already played), so an old date there is expected --
@@ -768,7 +769,7 @@ class TestEarliestMatchDate(unittest.TestCase):
         fixtures = list(fmodel.solve(params))
         self.assertIn(fixed, fixtures)
 
-    def test_no_cutoff_by_default(self):
+    def test_no_cutoff_by_default(self) -> None:
         """Without earliest_match_date, all 6 fixtures solve as normal (the tight
         4-distinct-A-dates requirement from the class docstring, with no cutoff
         trimming club A's 6 candidate dates, is comfortably satisfiable)."""
@@ -780,7 +781,7 @@ class TestEarliestMatchDate(unittest.TestCase):
 class TestExcludedFixtures(unittest.TestCase):
     """Test cases for the excluded_fixtures parameter."""
 
-    def _params(self, **kwargs):
+    def _params(self, **kwargs: Any) -> fmodel.Parameters:
         teams = [
             fmodel.Team(division=1, club="A", index=1),
             fmodel.Team(division=1, club="A", index=2),
@@ -807,7 +808,7 @@ class TestExcludedFixtures(unittest.TestCase):
             **kwargs,
         )
 
-    def test_excluded_fixture_is_not_scheduled(self):
+    def test_excluded_fixture_is_not_scheduled(self) -> None:
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=1, club="A", index=2)
         excluded_fixture = fmodel.Fixture(home_team=a1, away_team=a2)
@@ -817,7 +818,7 @@ class TestExcludedFixtures(unittest.TestCase):
         # The other 5 fixtures in this 3-team division must still be scheduled
         self.assertEqual(len(fixtures), 5)
 
-    def test_exclusion_is_directional(self):
+    def test_exclusion_is_directional(self) -> None:
         """Excluding A1 v A2 must not also exclude the reverse fixture A2 v A1."""
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=1, club="A", index=2)
@@ -831,7 +832,7 @@ class TestExcludedFixtures(unittest.TestCase):
             )
         )
 
-    def test_fixed_and_excluded_conflict_rejected(self):
+    def test_fixed_and_excluded_conflict_rejected(self) -> None:
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=1, club="A", index=2)
         fixture = fmodel.Fixture(home_team=a1, away_team=a2)
@@ -872,7 +873,7 @@ class TestDivisionSchemes(unittest.TestCase):
     def _teams(clubs: str, division: int = 1) -> list[fmodel.Team]:
         return [fmodel.Team(division=division, club=c, index=1) for c in clubs]
 
-    def test_double_round_is_the_default_scheme(self):
+    def test_double_round_is_the_default_scheme(self) -> None:
         params = self._params(self._teams("ABCD"))
         fixtures = list(fmodel.solve(params))
         # 4 teams, home and away: 4 * 3 = 12 fixtures.
@@ -880,7 +881,7 @@ class TestDivisionSchemes(unittest.TestCase):
         self.assertEqual(1, len(params.divisions))
         self.assertEqual(fmodel.FixtureScheme.DOUBLE_ROUND, params.divisions[0].scheme)
 
-    def test_single_round_plays_each_pair_once(self):
+    def test_single_round_plays_each_pair_once(self) -> None:
         params = self._params(
             self._teams("ABCD"),
             division_schemes={1: fmodel.FixtureScheme.SINGLE_ROUND},
@@ -892,7 +893,7 @@ class TestDivisionSchemes(unittest.TestCase):
         }
         self.assertEqual(6, len(unordered))
 
-    def test_single_round_home_away_follows_the_berger_table(self):
+    def test_single_round_home_away_follows_the_berger_table(self) -> None:
         teams = self._teams("ABCD")
         params = self._params(
             teams, division_schemes={1: fmodel.FixtureScheme.SINGLE_ROUND}
@@ -906,7 +907,7 @@ class TestDivisionSchemes(unittest.TestCase):
         }
         self.assertEqual(expected, got)
 
-    def test_single_round_draw_order_comes_from_parameters_teams(self):
+    def test_single_round_draw_order_comes_from_parameters_teams(self) -> None:
         # teams order D, C, B, A: the Berger draw, and every H/A, follows it.
         teams = self._teams("DCBA")
         params = self._params(
@@ -924,7 +925,7 @@ class TestDivisionSchemes(unittest.TestCase):
         # here that's D (first in teams) hosting A (last in teams).
         self.assertIn(("D", "A"), got)
 
-    def test_schemes_are_per_division(self):
+    def test_schemes_are_per_division(self) -> None:
         teams = self._teams("ABCD", division=1) + self._teams("EFGH", division=2)
         params = self._params(
             teams, division_schemes={1: fmodel.FixtureScheme.SINGLE_ROUND}
@@ -936,7 +937,7 @@ class TestDivisionSchemes(unittest.TestCase):
         self.assertEqual(6, by_division[1])  # single round
         self.assertEqual(12, by_division[2])  # double round (the default)
 
-    def test_scheme_for_division_with_no_teams_is_rejected(self):
+    def test_scheme_for_division_with_no_teams_is_rejected(self) -> None:
         with self.assertRaisesRegex(ValueError, "division.*9.*no teams"):
             self._params(
                 self._teams("ABCD"),
@@ -950,7 +951,7 @@ class TestTeamConstraints(unittest.TestCase):
     whose teams don't all share the same availability.
     """
 
-    def test_team_home_dates_override_restricts_that_team_only(self):
+    def test_team_home_dates_override_restricts_that_team_only(self) -> None:
         """A1 has a narrower home_dates override than club A; A2 (no override) can
         still use A's full home_dates list."""
         a1 = fmodel.Team(division=1, club="A", index=1)
@@ -974,7 +975,7 @@ class TestTeamConstraints(unittest.TestCase):
         self.assertTrue(a2_home_dates_used.issubset(set(a_home_dates)))
         self.assertTrue(a2_home_dates_used - {date(2025, 1, 1)})
 
-    def test_team_unavailable_away_dates_is_additive(self):
+    def test_team_unavailable_away_dates_is_additive(self) -> None:
         """A1's team-specific unavailable_away_dates blocks it from playing away on
         B's home date, even though club A has no such club-wide restriction."""
         a1 = fmodel.Team(division=1, club="A", index=1)
@@ -1007,7 +1008,7 @@ class TestTeamConstraints(unittest.TestCase):
             )
         )
 
-    def test_team_without_override_falls_back_to_club(self):
+    def test_team_without_override_falls_back_to_club(self) -> None:
         a1 = fmodel.Team(division=1, club="A", index=1)
         params = fmodel.Parameters(
             teams=[a1],
@@ -1028,14 +1029,14 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
     a given set of teams may be scheduled within any window of within_days days.
     """
 
-    def test_within_days_defaults_to_zero(self):
+    def test_within_days_defaults_to_zero(self) -> None:
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=2, club="A", index=2)
         self.assertEqual(
             fmodel.AvoidCoschedulingConstraint(teams=[a1, a2]).within_days, 0
         )
 
-    def test_applies_to_defaults_to_both(self):
+    def test_applies_to_defaults_to_both(self) -> None:
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=2, club="A", index=2)
         self.assertEqual(
@@ -1043,7 +1044,7 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
             fmodel.CoschedulingScope.BOTH,
         )
 
-    def test_forces_different_dates_for_constrained_teams(self):
+    def test_forces_different_dates_for_constrained_teams(self) -> None:
         """A1 and A2 are in different divisions (so have no fixture between them
         directly forcing a gap) and could otherwise both be scheduled at home on the
         same one of A's two shared home dates; the coscheduling constraint forces
@@ -1076,7 +1077,7 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
         a2_home_date = next(sf.date for sf in fixtures if sf.fixture.home_team == a2)
         self.assertNotEqual(a1_home_date, a2_home_date)
 
-    def test_also_applies_to_away_matches(self):
+    def test_also_applies_to_away_matches(self) -> None:
         """The constraint covers every match involving a constrained team, not just
         its home ones -- so if X only has one home date, A1 and A2 can't both play
         their away leg there, even though neither is hosting."""
@@ -1103,7 +1104,7 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
         with self.assertRaises(ValueError):
             fmodel.solve(params)
 
-    def test_infeasible_when_only_one_shared_date_available(self):
+    def test_infeasible_when_only_one_shared_date_available(self) -> None:
         """Same setup as test_forces_different_dates_for_constrained_teams, but A
         only has one home date -- both A1 and A2 need it for their home leg, and the
         coscheduling constraint forbids them sharing it. (X still gets two dates, to
@@ -1132,7 +1133,7 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
         with self.assertRaises(ValueError):
             fmodel.solve(params)
 
-    def test_within_days_window_enforced(self):
+    def test_within_days_window_enforced(self) -> None:
         """With within_days=3, A1 and A2's home matches must land on dates more than
         3 days apart -- of A's three candidate dates (Jan 1, 3, 10), only pairings
         involving Jan 10 satisfy that, so the solver must pick one of those. (X's two
@@ -1163,7 +1164,7 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
         a2_home_date = next(sf.date for sf in fixtures if sf.fixture.home_team == a2)
         self.assertGreater(abs((a1_home_date - a2_home_date).days), 3)
 
-    def test_direct_fixture_between_constrained_teams_not_double_counted(self):
+    def test_direct_fixture_between_constrained_teams_not_double_counted(self) -> None:
         """A single match between two constrained teams should count once towards
         the <=1 limit, not twice -- if the two teams' variables were combined
         naively (e.g. by concatenating each team's own match list) rather than by
@@ -1195,7 +1196,7 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
             ],
         )
 
-    def test_applies_to_away_allows_shared_home_date(self):
+    def test_applies_to_away_allows_shared_home_date(self) -> None:
         """With applies_to=AWAY the constraint ignores home matches: A1 and A2 may
         both host on A's single home date (which BOTH would forbid -- cf
         test_infeasible_when_only_one_shared_date_available), while X's two dates keep
@@ -1227,7 +1228,7 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
         a2_home_date = next(sf.date for sf in fixtures if sf.fixture.home_team == a2)
         self.assertEqual(a1_home_date, a2_home_date)
 
-    def test_applies_to_away_still_separates_away_legs(self):
+    def test_applies_to_away_still_separates_away_legs(self) -> None:
         """applies_to=AWAY still constrains away matches: with only one X home date,
         A1 and A2 can't both play their away leg there."""
         a1 = fmodel.Team(division=1, club="A", index=1)
@@ -1255,7 +1256,7 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
         with self.assertRaises(ValueError):
             fmodel.solve(params)
 
-    def test_applies_to_home_ignores_away_collision(self):
+    def test_applies_to_home_ignores_away_collision(self) -> None:
         """With applies_to=HOME the constraint ignores away matches: A1 and A2 may
         both play their away leg on X's single home date, while A's two dates keep
         their home legs apart."""
@@ -1286,7 +1287,7 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
         a2_away_date = next(sf.date for sf in fixtures if sf.fixture.away_team == a2)
         self.assertEqual(a1_away_date, a2_away_date)
 
-    def test_applies_to_home_still_separates_home_legs(self):
+    def test_applies_to_home_still_separates_home_legs(self) -> None:
         """applies_to=HOME still constrains home matches: with only one A home date,
         A1 and A2 can't both host there."""
         a1 = fmodel.Team(division=1, club="A", index=1)
@@ -1320,7 +1321,7 @@ class TestMaxConcurrentHomeMatchesUnlimited(unittest.TestCase):
     limit imposed by this mechanism, as opposed to a finite one.
     """
 
-    def test_finite_default_makes_it_infeasible(self):
+    def test_finite_default_makes_it_infeasible(self) -> None:
         """A has two teams (different divisions, so no direct fixture forces them
         apart) but only one home date; with a limit of 1, both teams needing to host
         on that one date is infeasible."""
@@ -1344,7 +1345,7 @@ class TestMaxConcurrentHomeMatchesUnlimited(unittest.TestCase):
         with self.assertRaises(ValueError):
             fmodel.solve(params)
 
-    def test_none_default_lifts_the_limit(self):
+    def test_none_default_lifts_the_limit(self) -> None:
         """Same setup, but A's default is None -- both A1 and A2 can now host on
         their one shared date."""
         a1 = fmodel.Team(division=1, club="A", index=1)
@@ -1370,7 +1371,7 @@ class TestMaxConcurrentHomeMatchesUnlimited(unittest.TestCase):
         self.assertEqual(a1_home_date, date(2025, 1, 1))
         self.assertEqual(a2_home_date, date(2025, 1, 1))
 
-    def test_none_override_lifts_the_limit_for_one_date_only(self):
+    def test_none_override_lifts_the_limit_for_one_date_only(self) -> None:
         """A's default limit of 1 applies generally, but is overridden to None (no
         limit) specifically on 2025-01-01 -- so both A1 and A2 can host there, even
         though a finite default of 1 would otherwise forbid it."""
@@ -1404,7 +1405,7 @@ class TestDuplicateRejection(unittest.TestCase):
     """Parameters construction relies on each (Fixture, date) pair mapping to at most
     one solver variable; these are the two ways it could otherwise be violated."""
 
-    def test_duplicate_team_rejected(self):
+    def test_duplicate_team_rejected(self) -> None:
         teams = [
             fmodel.Team(division=1, club="A", index=1),
             fmodel.Team(division=1, club="A", index=1),  # duplicate
@@ -1421,7 +1422,7 @@ class TestDuplicateRejection(unittest.TestCase):
                 },
             )
 
-    def test_duplicate_home_date_rejected(self):
+    def test_duplicate_home_date_rejected(self) -> None:
         teams = [
             fmodel.Team(division=1, club="A", index=1),
             fmodel.Team(division=1, club="B", index=1),
@@ -1440,7 +1441,7 @@ class TestDuplicateRejection(unittest.TestCase):
                 },
             )
 
-    def test_duplicate_team_home_date_rejected(self):
+    def test_duplicate_team_home_date_rejected(self) -> None:
         a1 = fmodel.Team(division=1, club="A", index=1)
         b1 = fmodel.Team(division=1, club="B", index=1)
         with self.assertRaisesRegex(ValueError, "Duplicate home date"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,10 +91,9 @@ show_error_codes = true
 show_column_numbers = true
 pretty = true
 
-# Allow some flexibility for existing code
-disallow_untyped_defs = false  # Too strict for test files initially
-disallow_incomplete_defs = false
-no_implicit_optional = false
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+no_implicit_optional = true
 
 # No type stubs published for this package
 [[tool.mypy.overrides]]

--- a/report_test.py
+++ b/report_test.py
@@ -62,7 +62,7 @@ club_constraints:
 
 
 class TestReport(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self._tmpdir = tempfile.TemporaryDirectory()
         self.addCleanup(self._tmpdir.cleanup)
@@ -72,28 +72,28 @@ class TestReport(unittest.TestCase):
         self.output_dir = self.dir / "out"
         self.solution_path = solve.solve(self.spec_path, self.output_dir)
 
-    def test_regenerates_report_from_solution_alone(self):
+    def test_regenerates_report_from_solution_alone(self) -> None:
         index_path = report.report(self.spec_path, self.solution_path, self.output_dir)
 
         self.assertTrue(index_path.exists())
         self.assertTrue((self.output_dir / "all-matches.html").exists())
         self.assertIn("Test Season", (self.output_dir / "all-matches.html").read_text())
 
-    def test_also_writes_csv_exports(self):
+    def test_also_writes_csv_exports(self) -> None:
         report.report(self.spec_path, self.solution_path, self.output_dir)
 
         for name in ("all-matches.csv", "all-matches-by-team.csv"):
             self.assertTrue((self.output_dir / name).exists(), f"{name} not written")
         self.assertIn("Albany 1", (self.output_dir / "all-matches.csv").read_text())
 
-    def test_run_index_links_to_the_csv_exports(self):
+    def test_run_index_links_to_the_csv_exports(self) -> None:
         report.report(self.spec_path, self.solution_path, self.output_dir)
 
         index = (self.output_dir / "index.html").read_text()
         self.assertIn('href="all-matches.csv"', index)
         self.assertIn('href="all-matches-by-team.csv"', index)
 
-    def test_does_not_require_resolving(self):
+    def test_does_not_require_resolving(self) -> None:
         """Deleting nothing but the intermediate solving step should still work:
         report.py only reads solution.yaml, never calls fmodel.solve()."""
         original_contents = self.solution_path.read_text()

--- a/reportdata_test.py
+++ b/reportdata_test.py
@@ -38,7 +38,7 @@ def _club(name: str) -> fmodel.Club:
 
 
 class ReportDataTest(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         # Club id "z-club" deliberately sorts after "a-club" by id but its
         # display name "Aardvark" sorts first, so tests can tell which key wins.
@@ -53,13 +53,13 @@ class ReportDataTest(unittest.TestCase):
             division=1, club="z-club", index=2, name_override="Aardvark Nomads"
         )
 
-    def test_team_name_falls_back_to_club_name_and_index(self):
+    def test_team_name_falls_back_to_club_name_and_index(self) -> None:
         self.assertEqual(reportdata.team_name(self.barnet1, self.clubs), "Barnet 1")
 
-    def test_team_name_prefers_override(self):
+    def test_team_name_prefers_override(self) -> None:
         self.assertEqual(reportdata.team_name(self.nick, self.clubs), "Aardvark Nomads")
 
-    def test_team_sort_key_is_club_display_name_then_index(self):
+    def test_team_sort_key_is_club_display_name_then_index(self) -> None:
         self.assertEqual(
             reportdata.team_sort_key(self.aardvark1, self.clubs), ("Aardvark", 1)
         )
@@ -68,7 +68,7 @@ class ReportDataTest(unittest.TestCase):
             reportdata.team_sort_key(self.barnet1, self.clubs),
         )
 
-    def test_by_date_home_away_orders_by_date_then_home_then_away(self):
+    def test_by_date_home_away_orders_by_date_then_home_then_away(self) -> None:
         later = _sf(self.barnet1, self.aardvark1, date(2025, 10, 1))
         early_b = _sf(self.barnet1, self.aardvark1, date(2025, 9, 1))
         early_a = _sf(self.aardvark1, self.barnet1, date(2025, 9, 1))
@@ -79,7 +79,7 @@ class ReportDataTest(unittest.TestCase):
         # Same date: home team "Aardvark 1" sorts before "Barnet 1"; later date last.
         self.assertEqual(ordered, [early_a, early_b, later])
 
-    def test_by_date_opponent_orders_by_date_then_opponent(self):
+    def test_by_date_opponent_orders_by_date_then_opponent(self) -> None:
         vs_nick = _sf(self.aardvark1, self.nick, date(2025, 9, 1))
         vs_barnet2 = _sf(self.barnet2, self.aardvark1, date(2025, 9, 1))
         later = _sf(self.aardvark1, self.barnet1, date(2025, 9, 20))
@@ -90,7 +90,7 @@ class ReportDataTest(unittest.TestCase):
         # Same date: opponent "Aardvark Nomads" before "Barnet 2"; later date last.
         self.assertEqual(ordered, [vs_nick, vs_barnet2, later])
 
-    def test_by_home_away_orders_without_dates(self):
+    def test_by_home_away_orders_without_dates(self) -> None:
         f1 = fmodel.Fixture(home_team=self.barnet1, away_team=self.aardvark1)
         f2 = fmodel.Fixture(home_team=self.aardvark1, away_team=self.barnet1)
 

--- a/solve_test.py
+++ b/solve_test.py
@@ -62,7 +62,7 @@ club_constraints:
 
 
 class TestSolve(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self._tmpdir = tempfile.TemporaryDirectory()
         self.addCleanup(self._tmpdir.cleanup)
@@ -70,7 +70,7 @@ class TestSolve(unittest.TestCase):
         self.spec_path = self.dir / "spec.yaml"
         self.spec_path.write_text(_MINIMAL_SPEC)
 
-    def test_writes_solution_yaml(self):
+    def test_writes_solution_yaml(self) -> None:
         output_dir = self.dir / "out"
         solution_path = solve.solve(self.spec_path, output_dir)
 
@@ -88,12 +88,12 @@ class TestSolve(unittest.TestCase):
         self.assertEqual(len(loaded), 2)  # Albany v Hackney and Hackney v Albany
         self.assertIn("home: albany-1", solution_path.read_text())
 
-    def test_creates_output_dir(self):
+    def test_creates_output_dir(self) -> None:
         output_dir = self.dir / "nested" / "out"
         solution_path = solve.solve(self.spec_path, output_dir)
         self.assertTrue(solution_path.exists())
 
-    def test_overwrites_existing_solution(self):
+    def test_overwrites_existing_solution(self) -> None:
         output_dir = self.dir / "out"
         output_dir.mkdir()
         (output_dir / "solution.yaml").write_text("stale: true\n")
@@ -102,7 +102,7 @@ class TestSolve(unittest.TestCase):
 
         self.assertIn("fixtures:", (output_dir / "solution.yaml").read_text())
 
-    def test_earliest_match_date_excludes_earlier_home_dates(self):
+    def test_earliest_match_date_excludes_earlier_home_dates(self) -> None:
         """Albany has two candidate home dates (2025-09-01 and 2025-09-29); a cutoff
         that excludes the earlier one should still solve, using the later one."""
         output_dir = self.dir / "out"
@@ -120,7 +120,7 @@ class TestSolve(unittest.TestCase):
         for sf in loaded:
             self.assertGreaterEqual(sf.date, date(2025, 9, 2))
 
-    def test_no_cutoff_by_default(self):
+    def test_no_cutoff_by_default(self) -> None:
         output_dir = self.dir / "out"
         solution_path = solve.solve(self.spec_path, output_dir)
         self.assertTrue(solution_path.exists())

--- a/spec_schema_test.py
+++ b/spec_schema_test.py
@@ -133,14 +133,14 @@ def _stringify_dates(value: Any) -> Any:
 
 
 class SpecSchemaTest(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         with _SCHEMA_PATH.open() as f:
             self.schema = json.load(f)
 
-    def test_schema_itself_is_valid(self):
+    def test_schema_itself_is_valid(self) -> None:
         jsonschema.Draft202012Validator.check_schema(self.schema)
 
-    def _assert_valid(self, yaml_text: str):
+    def _assert_valid(self, yaml_text: str) -> None:
         data = _stringify_dates(yaml.safe_load(yaml_text))
         validator = jsonschema.Draft202012Validator(
             self.schema, format_checker=jsonschema.FormatChecker()
@@ -148,10 +148,10 @@ class SpecSchemaTest(unittest.TestCase):
         errors = sorted(validator.iter_errors(data), key=str)
         self.assertEqual([], errors)
 
-    def test_full_example_is_valid(self):
+    def test_full_example_is_valid(self) -> None:
         self._assert_valid(_FULL_EXAMPLE)
 
-    def test_committed_example_run_is_valid(self):
+    def test_committed_example_run_is_valid(self) -> None:
         spec_path = Path(__file__).parent / "runs" / "example" / "spec.yaml"
         self._assert_valid(spec_path.read_text())
 
@@ -168,11 +168,11 @@ class SchemaAcceptsEveryValidFixtureSpecTest(unittest.TestCase):
     covers, gets the same protection without that risk.
     """
 
-    def test_schema_accepts_every_spec_fixturespec_test_considers_valid(self):
+    def test_schema_accepts_every_spec_fixturespec_test_considers_valid(self) -> None:
         collected: list[tuple[str, Any]] = []
         real_load_spec = fixturespec.load_spec
 
-        def recording_load_spec(spec_path):
+        def recording_load_spec(spec_path: str | Path) -> fixturespec.Spec:
             spec = real_load_spec(
                 spec_path
             )  # raises if fixturespec_test.py expects failure


### PR DESCRIPTION
…licit_optional

Removes the three strictness relaxations from [tool.mypy] in pyproject.toml and turns the checks on explicitly.

Code changes to satisfy them:
- Annotate _NoDuplicateKeysSafeLoader.construct_mapping and _NoAliasDumper.ignore_aliases.
- Annotate the Hypothesis property tests in helpers_test.py, the _params helpers in model_test.py, and the inner recording_load_spec in spec_schema_test.py.
- Add "-> None" to the ~315 test methods that lacked a return annotation.


Claude-Session: https://claude.ai/code/session_015ehvobaeV44skPhdBXZA8h