### PR TITLE
Move json-schema-for-humans to a docs group; build Pages on PRs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,25 +1,24 @@
-name: Deploy Pages
+name: Pages
 
 on:
   push:
+    branches: [main]
+  pull_request:
     branches: [main]
   workflow_dispatch:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
-  group: pages
+  # Per-ref: main deploys still serialise (same group, no cancel), while each
+  # PR builds in its own group and doesn't queue behind main or other PRs.
+  group: pages-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v7
 
@@ -31,19 +30,49 @@ jobs:
           python-version: "3.14"
 
       - name: Install dependencies
-        run: uv sync --dev --locked
+        # The Pages build only needs the core deps plus the docs group
+        # (json-schema-for-humans); it does not need the dev toolchain.
+        run: uv sync --no-default-groups --group docs --locked
+
+      - name: Activate the virtualenv for subsequent steps
+        # Put uv's .venv on PATH so later steps can run `python3 foo.py`
+        # directly, without a `uv run` prefix (and without uv re-syncing the
+        # default dependency groups on each invocation).
+        run: echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Build run reports into _site (HTML pages, CSV exports, index)
-        run: uv run python3 build_site.py
+        run: python3 build_site.py
 
       - name: Build schema reference page into _site
-        run: uv run python3 build_schema_docs.py
+        run: python3 build_schema_docs.py
 
       - name: Upload pages artifact
         uses: actions/upload-pages-artifact@v5
         with:
           path: _site
 
+      - name: Upload _site for PR preview download
+        # A plain, easily downloadable copy of the built site so a reviewer can
+        # inspect what a PR would publish before it's merged.
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: _site
+          path: _site
+          retention-days: 14
+
+  deploy:
+    # Only the real branch/dispatch runs deploy; PRs stop after build.
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5

--- a/README.md
+++ b/README.md
@@ -228,9 +228,17 @@ not source -- gitignored, and regenerated before every deploy from whatever
   `_site/schema-docs/`; it needs `json-schema-for-humans`.
 
 Both write straight into `_site/`, so the workflow uploads that directory
-as-is -- there's no separate copy/assemble step. It installs the dev
-dependencies first, so both scripts can run. Run them locally any time you
-want a preview that exactly matches what gets deployed:
+as-is -- there's no separate copy/assemble step. It installs the core
+dependencies plus the `docs` dependency group (`json-schema-for-humans`) --
+but not the dev toolchain -- so both scripts can run.
+
+Pull requests targeting `main` run the same `build` job but stop short of
+deploying: the built site is attached to the run as a downloadable `_site`
+artifact, so a reviewer can check what a PR would publish before it's merged.
+Only pushes to `main` (and manual `workflow_dispatch` runs) go on to deploy.
+
+Run the build locally any time you want a preview that exactly matches what
+gets deployed:
 
 ```bash
 uv run python3 build_site.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,11 @@ dev = [
     "types-pyyaml",
     "jsonschema",
     "types-jsonschema",
+    { include-group = "docs" },
+]
+# Only needed to build the schema reference page (build_schema_docs.py) for the
+# GitHub Pages site; not a runtime dependency of the fixture generator itself.
+docs = [
     "json-schema-for-humans",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -248,6 +248,9 @@ dev = [
     { name = "types-jsonschema" },
     { name = "types-pyyaml" },
 ]
+docs = [
+    { name = "json-schema-for-humans" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -265,6 +268,7 @@ dev = [
     { name = "types-jsonschema" },
     { name = "types-pyyaml" },
 ]
+docs = [{ name = "json-schema-for-humans" }]
 
 [[package]]
 name = "hypothesis"


### PR DESCRIPTION
json-schema-for-humans was in the dev group only so the Pages workflow's `uv sync --dev` would pick it up, even though it's a build-time dependency of build_schema_docs.py, not a dev tool. Split it into its own `docs` dependency group (dev pulls it in via include-group, so CI is unchanged).

The Pages workflow now installs just the core deps plus the docs group, not the dev toolchain, and activates uv's .venv on PATH so the build steps can call python3 directly instead of `uv run --group ...`.

Split the workflow into build + deploy jobs: build runs on pushes to main, PRs targeting main, and workflow_dispatch; deploy is skipped on PRs. PR builds attach the assembled _site as a downloadable artifact so a reviewer can check what would be published before merging. Pages write scopes are now scoped to the deploy job, and the concurrency group is per-ref so PR builds don't serialise against main.


Claude-Session: https://claude.ai/code/session_014e1UWpKoE7xTxvHUvK2ciX