### PR TITLE
Generalise max_concurrent_home_matches to max_concurrent_matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,15 +93,16 @@ divisions:                       # each team's division: the only place it's giv
 club_constraints:
   albany:
     home_dates: [2025-09-01, 2025-09-15, 2025-09-29]
-    max_concurrent_home_matches: 2
+    max_concurrent_matches: { home: 2 }
   hackney:
     home_dates: [2025-09-08, 2025-09-22]
-    max_concurrent_home_matches: 2
+    max_concurrent_matches: { home: 2 }
 ```
 
 That's only a fraction of what the format supports -- per-club/per-team date
-exclusions, concurrency limits with per-date overrides, pinned and withheld
-fixtures, and more. For the full field-by-field reference, see:
+exclusions, per-scope (home/away/any) concurrency limits with per-date
+overrides, pinned and withheld fixtures, and more. For the full field-by-field
+reference, see:
 
 - **[spec-schema.json](spec-schema.json)**, the JSON Schema every field is
   defined in (rendered to a browsable reference page at

--- a/build_site_test.py
+++ b/build_site_test.py
@@ -55,7 +55,8 @@ divisions:
 
 club_constraints:
   defaults:
-    max_concurrent_home_matches: 1
+    max_concurrent_matches:
+      home: 1
   albany:
     home_dates: [2025-09-01, 2025-09-29]
   hackney:

--- a/csvreport_test.py
+++ b/csvreport_test.py
@@ -47,7 +47,6 @@ def _generate_csv(
         teams=list(teams),
         home_dates={},
         unavailable_away_dates={},
-        max_concurrent_home_matches={},
         excluded_fixtures=excluded_fixtures,
     )
     spec = fixturespec.Spec(parameters=parameters, clubs=clubs)

--- a/fixturespec.py
+++ b/fixturespec.py
@@ -310,16 +310,15 @@ def _parse_divisions(
     )
 
 
-def _parse_max_concurrent_home_matches_value(
-    value: Any, context: str
-) -> fmodel.MaxConcurrentHomeMatches:
-    """A club's max_concurrent_home_matches value: either a plain integer, null (no
-    limit from this mechanism -- see fmodel.MaxConcurrentHomeMatches), or a mapping
-    with 'default' (an integer or null) and optionally 'overrides' (a date-keyed
-    mapping of integer-or-null overrides of that default).
+def _parse_concurrency_limit_value(value: Any, context: str) -> fmodel.ConcurrencyLimit:
+    """One ConcurrencyScope's limit within a max_concurrent_matches entry: either a
+    plain integer, null (no limit from this mechanism -- see
+    fmodel.ConcurrencyLimit), or a mapping with 'default' (an integer or null) and
+    optionally 'overrides' (a date-keyed mapping of integer-or-null overrides of
+    that default).
     """
     if value is None or (isinstance(value, int) and not isinstance(value, bool)):
-        return fmodel.MaxConcurrentHomeMatches(default=value)
+        return fmodel.ConcurrencyLimit(default=value)
     if isinstance(value, dict):
         unsupported = value.keys() - {"default", "overrides"}
         if unsupported:
@@ -338,11 +337,46 @@ def _parse_max_concurrent_home_matches_value(
                 overrides[override_date] = _require_int_or_none(
                     count, f"{context}.overrides[{date_key!r}]"
                 )
-        return fmodel.MaxConcurrentHomeMatches(default=default, overrides=overrides)
+        return fmodel.ConcurrencyLimit(default=default, overrides=overrides)
     raise SpecError(
         f"{context}: expected an integer, null (unlimited), or a mapping with "
         f"'default' and optionally 'overrides', got {value!r}"
     )
+
+
+_CONCURRENCY_SCOPES_BY_KEY = {s.value: s for s in fmodel.ConcurrencyScope}
+
+
+def _parse_max_concurrent_matches_by_scope(
+    value: Any, context: str
+) -> dict[fmodel.ConcurrencyScope, fmodel.ConcurrencyLimit]:
+    """A max_concurrent_matches entry: a mapping keyed by ConcurrencyScope value
+    ('home', 'away', 'any'), each value a per-scope limit (see
+    _parse_concurrency_limit_value). At least one scope must be given. Returns the
+    parsed limits keyed by scope, for merging with any club_constraints.defaults
+    entry by the caller.
+    """
+    if not isinstance(value, dict):
+        raise SpecError(
+            f"{context}: expected a mapping keyed by "
+            f"{sorted(_CONCURRENCY_SCOPES_BY_KEY)}, got {value!r}"
+        )
+    unsupported = value.keys() - _CONCURRENCY_SCOPES_BY_KEY.keys()
+    if unsupported:
+        raise SpecError(
+            f"{context}: unsupported scope(s) {sorted(unsupported)} "
+            f"(only {sorted(_CONCURRENCY_SCOPES_BY_KEY)} are)"
+        )
+    if not value:
+        raise SpecError(
+            f"{context}: needs at least one of {sorted(_CONCURRENCY_SCOPES_BY_KEY)}"
+        )
+    return {
+        _CONCURRENCY_SCOPES_BY_KEY[key]: _parse_concurrency_limit_value(
+            scope_value, f"{context}.{key}"
+        )
+        for key, scope_value in value.items()
+    }
 
 
 def _parse_home_dates_used_value(
@@ -383,7 +417,7 @@ def _parse_home_dates_used_value(
 _CLUB_CONSTRAINT_FIELD_KEYS = {
     "home_dates",
     "unavailable_away_dates",
-    "max_concurrent_home_matches",
+    "max_concurrent_matches",
     "home_dates_used",
     "teams",
     "avoid_coscheduling_teams",
@@ -399,14 +433,14 @@ _HOME_DATES_USED_FIELD_KEYS = {"min", "max"}
 # types (home_dates, unavailable_away_dates, home_dates_used, teams,
 # avoid_coscheduling_teams) have no meaningful spec-wide default, so aren't accepted
 # under 'defaults'.
-_CLUB_CONSTRAINT_DEFAULTS_KEYS = {"max_concurrent_home_matches"}
+_CLUB_CONSTRAINT_DEFAULTS_KEYS = {"max_concurrent_matches"}
 
 
 @dataclasses.dataclass(frozen=True)
 class _ClubConstraints:
     home_dates: dict[str, list[date]]
     unavailable_away_dates: dict[str, list[date]]
-    max_concurrent_home_matches: dict[str, fmodel.MaxConcurrentHomeMatches]
+    max_concurrent_matches: dict[str, fmodel.MaxConcurrentMatches]
     home_dates_used: dict[str, fmodel.HomeDatesUsedBounds]
     team_home_dates: dict[fmodel.Team, list[date]]
     team_unavailable_away_dates: dict[fmodel.Team, list[date]]
@@ -420,14 +454,15 @@ def _parse_club_constraints(
     path: Path,
 ) -> _ClubConstraints:
     """Parse the 'club_constraints' section: per-club home_dates, unavailable_away_dates,
-    max_concurrent_home_matches, home_dates_used, teams and
+    max_concurrent_matches, home_dates_used, teams and
     avoid_coscheduling_teams, keyed directly by club ID.
 
-    An optional 'defaults' entry (a sibling of the club entries) supplies a spec-wide
-    default for constraint types that support one (currently just
-    max_concurrent_home_matches); a club's own entry, if present, always takes
-    precedence over 'defaults'. If 'defaults.max_concurrent_home_matches' is omitted,
-    every club must have its own max_concurrent_home_matches entry.
+    An optional 'defaults' entry (a sibling of the club entries) supplies spec-wide
+    defaults for constraint types that support one (currently just
+    max_concurrent_matches). Its max_concurrent_matches is merged with a club's own
+    entry per scope: a club that sets only 'any' still inherits the default 'home'
+    limit, and its own value wins for any scope it does set. Every scope is optional
+    -- a club (and the spec as a whole) may have no concurrency limits at all.
 
     A club's optional 'teams' entry holds per-team exclusions, for clubs whose teams
     don't all share the same availability. Home dates are always specified at the club
@@ -452,11 +487,13 @@ def _parse_club_constraints(
             f"{path}: {section_name}.defaults.{sorted(unsupported_defaults)} not "
             f"supported (only {sorted(_CLUB_CONSTRAINT_DEFAULTS_KEYS)} are)"
         )
-    default_max_concurrent_home_matches = None
-    if "max_concurrent_home_matches" in defaults_spec:
-        default_max_concurrent_home_matches = _parse_max_concurrent_home_matches_value(
-            defaults_spec["max_concurrent_home_matches"],
-            f"{path}: {section_name}.defaults.max_concurrent_home_matches",
+    default_concurrency_by_scope: dict[
+        fmodel.ConcurrencyScope, fmodel.ConcurrencyLimit
+    ] = {}
+    if "max_concurrent_matches" in defaults_spec:
+        default_concurrency_by_scope = _parse_max_concurrent_matches_by_scope(
+            defaults_spec["max_concurrent_matches"],
+            f"{path}: {section_name}.defaults.max_concurrent_matches",
         )
 
     unknown_clubs = section_spec.keys() - clubs.keys() - {"defaults"}
@@ -467,12 +504,11 @@ def _parse_club_constraints(
 
     home_dates: dict[str, list[date]] = {}
     unavailable_away_dates: dict[str, list[date]] = {}
-    max_concurrent_home_matches: dict[str, fmodel.MaxConcurrentHomeMatches] = {}
+    max_concurrent_matches: dict[str, fmodel.MaxConcurrentMatches] = {}
     home_dates_used: dict[str, fmodel.HomeDatesUsedBounds] = {}
     team_home_dates: dict[fmodel.Team, list[date]] = {}
     team_unavailable_away_dates: dict[fmodel.Team, list[date]] = {}
     avoid_coscheduling_teams: list[fmodel.AvoidCoschedulingConstraint] = []
-    missing_max_concurrent: list[str] = []
 
     for club_id in clubs:
         club_spec = section_spec.get(club_id, {})
@@ -494,17 +530,18 @@ def _parse_club_constraints(
             f"{path}: {section_name}[{club_id!r}].unavailable_away_dates",
         )
 
-        if "max_concurrent_home_matches" in club_spec:
-            max_concurrent_home_matches[club_id] = (
-                _parse_max_concurrent_home_matches_value(
-                    club_spec["max_concurrent_home_matches"],
-                    f"{path}: {section_name}[{club_id!r}].max_concurrent_home_matches",
+        club_concurrency_by_scope = dict(default_concurrency_by_scope)
+        if "max_concurrent_matches" in club_spec:
+            club_concurrency_by_scope.update(
+                _parse_max_concurrent_matches_by_scope(
+                    club_spec["max_concurrent_matches"],
+                    f"{path}: {section_name}[{club_id!r}].max_concurrent_matches",
                 )
             )
-        elif default_max_concurrent_home_matches is not None:
-            max_concurrent_home_matches[club_id] = default_max_concurrent_home_matches
-        else:
-            missing_max_concurrent.append(club_id)
+        if club_concurrency_by_scope:
+            max_concurrent_matches[club_id] = fmodel.MaxConcurrentMatches(
+                by_scope=club_concurrency_by_scope
+            )
 
         if "home_dates_used" in club_spec:
             home_dates_used[club_id] = _parse_home_dates_used_value(
@@ -533,17 +570,10 @@ def _parse_club_constraints(
             )
         )
 
-    if missing_max_concurrent:
-        raise SpecError(
-            f"{path}: {section_name} missing max_concurrent_home_matches for "
-            f"club(s) {sorted(missing_max_concurrent)} (no "
-            f"{section_name}.defaults.max_concurrent_home_matches set)"
-        )
-
     return _ClubConstraints(
         home_dates=home_dates,
         unavailable_away_dates=unavailable_away_dates,
-        max_concurrent_home_matches=max_concurrent_home_matches,
+        max_concurrent_matches=max_concurrent_matches,
         home_dates_used=home_dates_used,
         team_home_dates=team_home_dates,
         team_unavailable_away_dates=team_unavailable_away_dates,
@@ -952,13 +982,14 @@ def load_spec(spec_path: str | Path) -> Spec:
         club_id: sorted(set(dates) | set(avoid_dates))
         for club_id, dates in club_constraints.unavailable_away_dates.items()
     }
-    max_concurrent_home_matches = club_constraints.max_concurrent_home_matches
     team_home_dates = club_constraints.team_home_dates
     team_unavailable_away_dates = club_constraints.team_unavailable_away_dates
 
     kwargs: dict[str, Any] = {}
     if "min_gap_days" in data:
         kwargs["min_gap_days"] = data["min_gap_days"]
+    if club_constraints.max_concurrent_matches:
+        kwargs["max_concurrent_matches"] = club_constraints.max_concurrent_matches
     if club_constraints.home_dates_used:
         kwargs["home_dates_used"] = club_constraints.home_dates_used
     if team_home_dates:
@@ -1008,7 +1039,6 @@ def load_spec(spec_path: str | Path) -> Spec:
         teams=list(teams.values()),
         home_dates=home_dates,
         unavailable_away_dates=unavailable_away_dates,
-        max_concurrent_home_matches=max_concurrent_home_matches,
         division_schemes=divisions.schemes,
         **kwargs,
     )

--- a/fixturespec_test.py
+++ b/fixturespec_test.py
@@ -22,6 +22,17 @@ from pathlib import Path
 import fixturespec
 import fmodel
 
+
+def _mcm(**scopes: fmodel.ConcurrencyLimit) -> fmodel.MaxConcurrentMatches:
+    """Terse fmodel.MaxConcurrentMatches builder for tests: keyword args are
+    ConcurrencyScope names, e.g. _mcm(home=fmodel.ConcurrencyLimit(2))."""
+    return fmodel.MaxConcurrentMatches(
+        by_scope={
+            fmodel.ConcurrencyScope(name): limit for name, limit in scopes.items()
+        }
+    )
+
+
 # Clubs/teams/divisions boilerplate, minus 'club_constraints', for tests that need to
 # supply their own version of that section (concatenating a second copy on top of an
 # existing one would create a duplicate top-level YAML key, which PyYAML resolves by
@@ -55,10 +66,11 @@ divisions:
     teams: [albany-1, hackney-1]
 """
 
-# A valid spec minus 'club_constraints.defaults' (so every club still needs its own
-# max_concurrent_home_matches entry to be valid), for tests that need to append their
-# own version of that piece.
-_MINIMAL_SPEC_NO_MCHM = (
+# A valid spec with no concurrency limits at all (no 'club_constraints.defaults'
+# and no per-club max_concurrent_matches), for tests that need to append their own
+# version of that piece. Concurrency limits are entirely optional, so this is valid
+# as-is too.
+_MINIMAL_SPEC_NO_CONCURRENCY = (
     _BOILERPLATE
     + """
 club_constraints:
@@ -71,7 +83,8 @@ club_constraints:
 )
 
 _MINIMAL_SPEC = (
-    _MINIMAL_SPEC_NO_MCHM + "  defaults:\n    max_concurrent_home_matches: 1\n"
+    _MINIMAL_SPEC_NO_CONCURRENCY
+    + "  defaults:\n    max_concurrent_matches:\n      home: 1\n"
 )
 
 # A three-team spec (two Albany teams plus Hackney) for exclude_fixtures tests, which
@@ -109,7 +122,8 @@ divisions:
 
 club_constraints:
   defaults:
-    max_concurrent_home_matches: 2
+    max_concurrent_matches:
+      home: 2
   albany:
     home_dates: [2025-09-01, 2025-10-01, 2025-11-01, 2025-12-01]
   hackney:
@@ -164,14 +178,14 @@ class TestLoadSpec(unittest.TestCase):
         self.assertEqual(spec.parameters.unavailable_away_dates["hackney"], [])
         self.assertEqual(spec.parameters.min_gap_days, 7)
         # Neither club has its own entry, so both inherit _MINIMAL_SPEC's
-        # club_constraints.defaults.max_concurrent_home_matches (1).
+        # club_constraints.defaults.max_concurrent_matches (home: 1).
         self.assertEqual(
-            spec.parameters.max_concurrent_home_matches["albany"],
-            fmodel.MaxConcurrentHomeMatches(default=1),
+            spec.parameters.max_concurrent_matches["albany"],
+            _mcm(home=fmodel.ConcurrencyLimit(1)),
         )
         self.assertEqual(
-            spec.parameters.max_concurrent_home_matches["hackney"],
-            fmodel.MaxConcurrentHomeMatches(default=1),
+            spec.parameters.max_concurrent_matches["hackney"],
+            _mcm(home=fmodel.ConcurrencyLimit(1)),
         )
         self.assertEqual(spec.name, "")
         self.assertFalse(spec.draft)
@@ -282,7 +296,7 @@ class TestLoadSpec(unittest.TestCase):
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
-            "    max_concurrent_home_matches: 1\n"
+            "    max_concurrent_matches:\n      home: 1\n"
             "  albany:\n"
             "    home_dates: [2025-09-01]\n"
             "  albany:\n"
@@ -291,121 +305,203 @@ class TestLoadSpec(unittest.TestCase):
         with self.assertRaisesRegex(fixturespec.SpecError, "duplicate key"):
             fixturespec.load_spec(path)
 
-    # These tests write standalone specs rather than extending _MINIMAL_SPEC_NO_MCHM,
-    # since appending a second 'club_constraints' section (or a second entry for a
-    # club already present) would create a duplicate YAML key, which PyYAML resolves
-    # by silently letting the later one clobber the earlier one.
+    # These tests write standalone specs rather than extending
+    # _MINIMAL_SPEC_NO_CONCURRENCY, since appending a second 'club_constraints'
+    # section (or a second entry for a club already present) would create a
+    # duplicate YAML key, which PyYAML resolves by silently letting the later one
+    # clobber the earlier one.
 
-    def test_max_concurrent_home_matches_shorthand_int(self) -> None:
+    def test_max_concurrent_matches_home_shorthand_int(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
-            "    max_concurrent_home_matches: 1\n"
+            "    max_concurrent_matches:\n"
+            "      home: 1\n"
             "  albany:\n"
-            "    max_concurrent_home_matches: 3\n"
+            "    max_concurrent_matches:\n"
+            "      home: 3\n"
         )
         spec = fixturespec.load_spec(path)
         self.assertEqual(
-            spec.parameters.max_concurrent_home_matches["albany"],
-            fmodel.MaxConcurrentHomeMatches(default=3),
+            spec.parameters.max_concurrent_matches["albany"],
+            _mcm(home=fmodel.ConcurrencyLimit(3)),
         )
         # hackney wasn't given its own entry, so it inherits club_constraints.defaults
         self.assertEqual(
-            spec.parameters.max_concurrent_home_matches["hackney"],
-            fmodel.MaxConcurrentHomeMatches(default=1),
+            spec.parameters.max_concurrent_matches["hackney"],
+            _mcm(home=fmodel.ConcurrencyLimit(1)),
         )
 
-    def test_max_concurrent_home_matches_default_and_overrides(self) -> None:
+    def test_max_concurrent_matches_default_and_overrides(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
-            "    max_concurrent_home_matches:\n"
-            "      default: 2\n"
-            "      overrides:\n"
-            "        2025-09-01: 3\n"
-            "  hackney:\n"
-            "    max_concurrent_home_matches: 1\n"
+            "    max_concurrent_matches:\n"
+            "      home:\n"
+            "        default: 2\n"
+            "        overrides:\n"
+            "          2025-09-01: 3\n"
         )
         spec = fixturespec.load_spec(path)
         self.assertEqual(
-            spec.parameters.max_concurrent_home_matches["albany"],
-            fmodel.MaxConcurrentHomeMatches(default=2, overrides={date(2025, 9, 1): 3}),
+            spec.parameters.max_concurrent_matches["albany"],
+            _mcm(home=fmodel.ConcurrencyLimit(2, {date(2025, 9, 1): 3})),
         )
 
-    def test_max_concurrent_home_matches_null_shorthand(self) -> None:
+    def test_max_concurrent_matches_null_shorthand(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
-            "    max_concurrent_home_matches: null\n"
-            "  hackney:\n"
-            "    max_concurrent_home_matches: 1\n"
+            "    max_concurrent_matches:\n"
+            "      home: null\n"
         )
         spec = fixturespec.load_spec(path)
         self.assertEqual(
-            spec.parameters.max_concurrent_home_matches["albany"],
-            fmodel.MaxConcurrentHomeMatches(default=None),
+            spec.parameters.max_concurrent_matches["albany"],
+            _mcm(home=fmodel.ConcurrencyLimit(None)),
         )
 
-    def test_max_concurrent_home_matches_null_default_with_override(self) -> None:
+    def test_max_concurrent_matches_null_default_with_override(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
-            "    max_concurrent_home_matches:\n"
-            "      default: null\n"
-            "      overrides:\n"
-            "        2025-09-01: 3\n"
-            "  hackney:\n"
-            "    max_concurrent_home_matches: 1\n"
+            "    max_concurrent_matches:\n"
+            "      home:\n"
+            "        default: null\n"
+            "        overrides:\n"
+            "          2025-09-01: 3\n"
         )
         spec = fixturespec.load_spec(path)
         self.assertEqual(
-            spec.parameters.max_concurrent_home_matches["albany"],
-            fmodel.MaxConcurrentHomeMatches(
-                default=None, overrides={date(2025, 9, 1): 3}
+            spec.parameters.max_concurrent_matches["albany"],
+            _mcm(home=fmodel.ConcurrencyLimit(None, {date(2025, 9, 1): 3})),
+        )
+
+    def test_max_concurrent_matches_missing_default(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    max_concurrent_matches:\n"
+            "      home:\n"
+            "        overrides:\n"
+            "          2025-09-01: 3\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "default"):
+            fixturespec.load_spec(path)
+
+    def test_max_concurrent_matches_away_and_any_scopes(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    max_concurrent_matches:\n"
+            "      away: 2\n"
+            "      any:\n"
+            "        default: null\n"
+            "        overrides:\n"
+            "          2025-09-01: 1\n"
+        )
+        spec = fixturespec.load_spec(path)
+        self.assertEqual(
+            spec.parameters.max_concurrent_matches["albany"],
+            _mcm(
+                away=fmodel.ConcurrencyLimit(2),
+                any=fmodel.ConcurrencyLimit(None, {date(2025, 9, 1): 1}),
             ),
         )
 
-    def test_max_concurrent_home_matches_missing_default(self) -> None:
+    def test_max_concurrent_matches_defaults_merge_per_scope(self) -> None:
+        # defaults set only 'home'; albany sets only 'any'. albany should end up
+        # with both (its own 'any', the inherited default 'home'); hackney, with no
+        # entry of its own, gets just the default 'home'.
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  defaults:\n"
+            "    max_concurrent_matches:\n"
+            "      home: 1\n"
+            "  albany:\n"
+            "    max_concurrent_matches:\n"
+            "      any: 1\n"
+        )
+        spec = fixturespec.load_spec(path)
+        self.assertEqual(
+            spec.parameters.max_concurrent_matches["albany"],
+            _mcm(
+                home=fmodel.ConcurrencyLimit(1),
+                any=fmodel.ConcurrencyLimit(1),
+            ),
+        )
+        self.assertEqual(
+            spec.parameters.max_concurrent_matches["hackney"],
+            _mcm(home=fmodel.ConcurrencyLimit(1)),
+        )
+
+    def test_max_concurrent_matches_club_scope_overrides_default_scope(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  defaults:\n"
+            "    max_concurrent_matches:\n"
+            "      home: 1\n"
+            "  albany:\n"
+            "    max_concurrent_matches:\n"
+            "      home: 3\n"
+        )
+        spec = fixturespec.load_spec(path)
+        self.assertEqual(
+            spec.parameters.max_concurrent_matches["albany"],
+            _mcm(home=fmodel.ConcurrencyLimit(3)),
+        )
+
+    def test_max_concurrent_matches_unknown_scope_rejected(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
-            "    max_concurrent_home_matches:\n"
-            "      overrides:\n"
-            "        2025-09-01: 3\n"
-            "  hackney:\n"
-            "    max_concurrent_home_matches: 1\n"
+            "    max_concurrent_matches:\n"
+            "      sideways: 1\n"
         )
-        with self.assertRaisesRegex(fixturespec.SpecError, "default"):
+        with self.assertRaisesRegex(fixturespec.SpecError, "sideways"):
+            fixturespec.load_spec(path)
+
+    def test_max_concurrent_matches_empty_mapping_rejected(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    max_concurrent_matches: {}\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "at least one"):
             fixturespec.load_spec(path)
 
     def test_club_constraints_unknown_club(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
-            "    max_concurrent_home_matches: 1\n"
-            "  hackney:\n"
-            "    max_concurrent_home_matches: 1\n"
+            "    home_dates: [2025-09-01]\n"
             "  nonexistent:\n"
-            "    max_concurrent_home_matches: 3\n"
+            "    home_dates: [2025-09-01]\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "nonexistent"):
             fixturespec.load_spec(path)
 
-    def test_max_concurrent_home_matches_missing_club_without_section_default(
-        self,
-    ) -> None:
+    def test_max_concurrent_matches_absent_for_a_club_is_allowed(self) -> None:
+        # No defaults, and only albany has an entry: hackney simply has no
+        # concurrency limits (nothing is required).
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
-            "    max_concurrent_home_matches: 1\n"
+            "    max_concurrent_matches:\n"
+            "      home: 1\n"
         )
-        with self.assertRaisesRegex(fixturespec.SpecError, "hackney"):
-            fixturespec.load_spec(path)
+        spec = fixturespec.load_spec(path)
+        self.assertEqual(
+            spec.parameters.max_concurrent_matches,
+            {"albany": _mcm(home=fmodel.ConcurrencyLimit(1))},
+        )
 
-    def test_max_concurrent_home_matches_section_omitted_entirely(self) -> None:
-        path = self._write(_BOILERPLATE)
-        with self.assertRaisesRegex(fixturespec.SpecError, "albany.*hackney"):
-            fixturespec.load_spec(path)
+    def test_max_concurrent_matches_omitted_everywhere_is_allowed(self) -> None:
+        # No club_constraints.defaults and no per-club max_concurrent_matches:
+        # concurrency limits are entirely optional.
+        path = self._write(_MINIMAL_SPEC_NO_CONCURRENCY)
+        spec = fixturespec.load_spec(path)
+        self.assertEqual(spec.parameters.max_concurrent_matches, {})
 
     def test_club_constraints_defaults_unsupported_field(self) -> None:
         path = self._write(
@@ -601,7 +697,7 @@ divisions:
     # to load successfully (the failure-path tests don't get this far).
     _SCHEME_SPEC_TAIL = (
         "club_constraints:\n"
-        "  defaults:\n    max_concurrent_home_matches: 1\n"
+        "  defaults:\n    max_concurrent_matches:\n      home: 1\n"
         "  albany:\n    home_dates: [2025-09-01, 2025-09-08, 2025-09-15]\n"
     )
 
@@ -687,7 +783,8 @@ divisions:
     teams: [albany-1, albany-2, albany-3]
 club_constraints:
   defaults:
-    max_concurrent_home_matches: 1
+    max_concurrent_matches:
+      home: 1
   albany:
     home_dates: [2025-09-01, 2025-09-08, 2025-09-15]
 """)
@@ -803,7 +900,7 @@ club_constraints:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
-            "    max_concurrent_home_matches: 1\n"
+            "    max_concurrent_matches:\n      home: 1\n"
             "  albany:\n"
             "    home_dates_used:\n"
             "      max: 1\n"
@@ -826,7 +923,7 @@ club_constraints:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
-            "    max_concurrent_home_matches: 1\n"
+            "    max_concurrent_matches:\n      home: 1\n"
             "  albany:\n"
             "    home_dates_used:\n"
             "      min: 3\n"
@@ -846,7 +943,7 @@ club_constraints:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
-            "    max_concurrent_home_matches: 1\n"
+            "    max_concurrent_matches:\n      home: 1\n"
             "  unknown-club:\n"
             "    home_dates_used:\n"
             "      max: 1\n"
@@ -858,7 +955,7 @@ club_constraints:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
-            "    max_concurrent_home_matches: 1\n"
+            "    max_concurrent_matches:\n      home: 1\n"
             "  albany:\n"
             "    home_dates_used:\n"
             "      max: not-an-int\n"
@@ -870,7 +967,7 @@ club_constraints:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
-            "    max_concurrent_home_matches: 1\n"
+            "    max_concurrent_matches:\n      home: 1\n"
             "  albany:\n"
             "    home_dates_used: 1\n"
         )
@@ -881,7 +978,7 @@ club_constraints:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
-            "    max_concurrent_home_matches: 1\n"
+            "    max_concurrent_matches:\n      home: 1\n"
             "  albany:\n"
             "    home_dates_used: {}\n"
         )
@@ -892,7 +989,7 @@ club_constraints:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
-            "    max_concurrent_home_matches: 1\n"
+            "    max_concurrent_matches:\n      home: 1\n"
             "  albany:\n"
             "    home_dates_used:\n"
             "      minimum: 2\n"
@@ -904,7 +1001,7 @@ club_constraints:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
-            "    max_concurrent_home_matches: 1\n"
+            "    max_concurrent_matches:\n      home: 1\n"
             "  albany:\n"
             "    home_dates_used:\n"
             "      min: 0\n"
@@ -916,7 +1013,7 @@ club_constraints:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
-            "    max_concurrent_home_matches: 1\n"
+            "    max_concurrent_matches:\n      home: 1\n"
             "  albany:\n"
             "    home_dates_used:\n"
             "      min: 5\n"
@@ -1118,7 +1215,7 @@ club_constraints:
     def test_team_constraints_unsupported_field(self) -> None:
         path = self._write(
             self._with_albany_teams(
-                "    teams:\n      albany-1:\n        max_concurrent_home_matches: 2\n"
+                "    teams:\n      albany-1:\n        max_concurrent_matches:\n          home: 2\n"
             )
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "not supported"):

--- a/fmodel.py
+++ b/fmodel.py
@@ -76,11 +76,25 @@ class Club:
     home_time_limit: str  # chess time control, e.g. "75+15" for 75 min + 15 sec/move
 
 
+class ConcurrencyScope(enum.Enum):
+    """Which of a club's matches on a date a MaxConcurrentMatches limit counts:
+    HOME only its home matches, AWAY only its away matches, ANY every match its
+    teams play (an internal match -- both teams the club's -- counted once).
+
+    Parallel to CoschedulingScope but kept separate: that one's third value is
+    BOTH ("home") and it names a different feature.
+    """
+
+    HOME = "home"
+    AWAY = "away"
+    ANY = "any"
+
+
 @dataclasses.dataclass(frozen=True)
-class MaxConcurrentHomeMatches:
-    """A club's home-match concurrency limit: a default, overridable for specific
-    dates. A value of None (for the default or an override) means no limit is
-    imposed by this mechanism -- e.g. for a club whose concurrency is already
+class ConcurrencyLimit:
+    """A match-count limit for one ConcurrencyScope: a default, overridable for
+    specific dates. A value of None (for the default or an override) means no limit
+    is imposed by this mechanism -- e.g. for a club whose concurrency is already
     bounded by another constraint (such as avoid_coscheduling_teams), where adding
     an explicit number here would just be a redundant, easy-to-forget-to-update
     restatement of that bound.
@@ -91,6 +105,23 @@ class MaxConcurrentHomeMatches:
 
     def for_date(self, d: date) -> int | None:
         return self.overrides.get(d, self.default)
+
+
+@dataclasses.dataclass(frozen=True)
+class MaxConcurrentMatches:
+    """A club's per-scope limits on how many matches its teams may play on the same
+    date. Each ConcurrencyScope present in `by_scope` has its own ConcurrencyLimit;
+    a scope with no entry imposes no limit. See ConcurrencyScope for what each
+    scope counts.
+    """
+
+    by_scope: Mapping[ConcurrencyScope, ConcurrencyLimit] = dataclasses.field(
+        default_factory=dict
+    )
+
+    def for_date(self, scope: ConcurrencyScope, d: date) -> int | None:
+        limit = self.by_scope.get(scope)
+        return None if limit is None else limit.for_date(d)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -223,8 +254,10 @@ class Parameters:
     teams: Collection[Team]
     home_dates: Mapping[ClubT, list[date]]
     unavailable_away_dates: Mapping[ClubT, list[date]]
-    max_concurrent_home_matches: Mapping[ClubT, MaxConcurrentHomeMatches]
     min_gap_days: int = 7
+    max_concurrent_matches: Mapping[ClubT, MaxConcurrentMatches] = dataclasses.field(
+        default_factory=dict
+    )
     home_dates_used: Mapping[ClubT, HomeDatesUsedBounds] = dataclasses.field(
         default_factory=dict
     )
@@ -289,14 +322,20 @@ class Parameters:
     def _teams_per_club(self) -> Mapping[ClubT, int]:
         return collections.Counter(team.club for team in self.teams)
 
-    def max_concurrent_home_matches_for(self, club: ClubT, d: date) -> int | None:
-        """The most home matches `club` may host on date `d`, or None if unlimited.
+    def max_concurrent_matches_for(
+        self, club: ClubT, scope: ConcurrencyScope, d: date
+    ) -> int | None:
+        """The most matches of `scope` (see ConcurrencyScope) `club` may play on
+        date `d`, or None if unlimited.
 
         A configured limit that is >= the club's own number of teams is reported as
-        unlimited too: the club can never field more simultaneous home matches than
-        it has teams, so such a limit could never actually bind.
+        unlimited too: the club can never play more simultaneous matches (of any
+        scope) than it has teams, so such a limit could never actually bind.
         """
-        limit = self.max_concurrent_home_matches[club].for_date(d)
+        entry = self.max_concurrent_matches.get(club)
+        if entry is None:
+            return None
+        limit = entry.for_date(scope, d)
         if limit is not None and limit >= self._teams_per_club[club]:
             return None
         return limit
@@ -443,6 +482,15 @@ def solve(params: Parameters) -> Collection[ScheduledFixture]:
     vars_by_club_home_date: MutableMapping[tuple[str, date], list[cp_model.IntVar]] = (
         collections.defaultdict(list)
     )
+    vars_by_club_away_date: MutableMapping[tuple[str, date], list[cp_model.IntVar]] = (
+        collections.defaultdict(list)
+    )
+    # Every match either club's teams play on a date (an internal match, both teams
+    # the same club's, appears once): the ConcurrencyScope.ANY counterpart of the
+    # home/away maps above.
+    vars_by_club_any_date: MutableMapping[tuple[str, date], list[cp_model.IntVar]] = (
+        collections.defaultdict(list)
+    )
 
     excluded = set(params.excluded_fixtures)
     fixed_fixture_keys = {(sf.fixture, sf.date) for sf in params.fixed_fixtures}
@@ -483,6 +531,10 @@ def solve(params: Parameters) -> Collection[ScheduledFixture]:
                 vars_by_team_date[home_team][match_date].append(var)
                 vars_by_team_date[away_team][match_date].append(var)
                 vars_by_club_home_date[(home_team.club, match_date)].append(var)
+                vars_by_club_away_date[(away_team.club, match_date)].append(var)
+                vars_by_club_any_date[(home_team.club, match_date)].append(var)
+                if away_team.club != home_team.club:
+                    vars_by_club_any_date[(away_team.club, match_date)].append(var)
 
     for fixture_vars in vars_by_fixture.values():
         # Each fixture must be scheduled exactly once
@@ -497,12 +549,17 @@ def solve(params: Parameters) -> Collection[ScheduledFixture]:
             window_vars = [v for d in window for v in team_vars_by_date[d]]
             model.add(cp_model.LinearExpr.Sum(window_vars) <= 1)
 
-    for (club, match_date), club_home_date_vars in vars_by_club_home_date.items():
-        # Each club can host at most max_concurrent_home_matches matches per date
-        # (None means unlimited: no constraint to add).
-        max_matches = params.max_concurrent_home_matches_for(club, match_date)
-        if max_matches is not None:
-            model.add(cp_model.LinearExpr.Sum(club_home_date_vars) <= max_matches)
+    for scope, vars_by_club_date in (
+        (ConcurrencyScope.HOME, vars_by_club_home_date),
+        (ConcurrencyScope.AWAY, vars_by_club_away_date),
+        (ConcurrencyScope.ANY, vars_by_club_any_date),
+    ):
+        for (club, match_date), club_date_vars in vars_by_club_date.items():
+            # Each club may play at most max_concurrent_matches matches of this
+            # scope per date (None means unlimited: no constraint to add).
+            max_matches = params.max_concurrent_matches_for(club, scope, match_date)
+            if max_matches is not None:
+                model.add(cp_model.LinearExpr.Sum(club_date_vars) <= max_matches)
 
     _add_home_dates_used_constraints(
         model, params.home_dates_used, vars_by_club_home_date

--- a/genfixtures.py
+++ b/genfixtures.py
@@ -153,8 +153,11 @@ _UNAVAILABLE_AWAY_DATES = {
     ),
 }
 
-_MAX_CONCURRENT_HOME_MATCHES = {
-    club: fmodel.MaxConcurrentHomeMatches(default=2) for club in _HOME_DATES
+_MAX_CONCURRENT_MATCHES = {
+    club: fmodel.MaxConcurrentMatches(
+        by_scope={fmodel.ConcurrencyScope.HOME: fmodel.ConcurrencyLimit(default=2)}
+    )
+    for club in _HOME_DATES
 }
 _MIN_MATCH_GAP_DAYS = 7
 
@@ -220,7 +223,7 @@ def build_params() -> fmodel.Parameters:
         home_dates=_HOME_DATES,
         unavailable_away_dates=_UNAVAILABLE_AWAY_DATES,
         min_gap_days=_MIN_MATCH_GAP_DAYS,
-        max_concurrent_home_matches=_MAX_CONCURRENT_HOME_MATCHES,
+        max_concurrent_matches=_MAX_CONCURRENT_MATCHES,
     )
 
 

--- a/htmlreport_test.py
+++ b/htmlreport_test.py
@@ -50,7 +50,6 @@ def _generate(
         teams=list(teams),
         home_dates={},
         unavailable_away_dates={},
-        max_concurrent_home_matches={},
         excluded_fixtures=excluded_fixtures,
         division_schemes=division_schemes or {},
     )

--- a/model_test.py
+++ b/model_test.py
@@ -25,6 +25,14 @@ import fmodel
 import genfixtures
 
 
+def _home_limit(n: int | None) -> fmodel.MaxConcurrentMatches:
+    """A club's MaxConcurrentMatches carrying just a HOME-scope limit with default
+    n (no per-date overrides) -- the shape most of these tests need."""
+    return fmodel.MaxConcurrentMatches(
+        by_scope={fmodel.ConcurrencyScope.HOME: fmodel.ConcurrencyLimit(default=n)}
+    )
+
+
 class TestSolve(unittest.TestCase):
     """Test cases for the solve() function."""
 
@@ -108,10 +116,12 @@ class TestSolve(unittest.TestCase):
             home_fixtures_by_club_date[key] += 1
 
         for (club, fixture_date), count in home_fixtures_by_club_date.items():
-            limit = self.params.max_concurrent_home_matches_for(club, fixture_date)
+            limit = self.params.max_concurrent_matches_for(
+                club, fmodel.ConcurrencyScope.HOME, fixture_date
+            )
             # None means unlimited -- including a configured limit that's >= the
             # club's number of teams, which can never actually bind (see
-            # TestMaxConcurrentHomeMatchesFor) -- so there's nothing to check.
+            # TestMaxConcurrentMatchesFor) -- so there's nothing to check.
             if limit is None:
                 continue
             self.assertLessEqual(
@@ -235,9 +245,9 @@ class TestSolve(unittest.TestCase):
                 ],  # B can't play away on Jan 1 (when A is home)
             },
             min_gap_days=7,
-            max_concurrent_home_matches={
-                "Test Club A": fmodel.MaxConcurrentHomeMatches(default=1),
-                "Test Club B": fmodel.MaxConcurrentHomeMatches(default=1),
+            max_concurrent_matches={
+                "Test Club A": _home_limit(1),
+                "Test Club B": _home_limit(1),
             },
         )
 
@@ -252,10 +262,10 @@ class TestSolve(unittest.TestCase):
         )
 
 
-class TestMaxConcurrentHomeMatchesFor(unittest.TestCase):
-    """A configured max_concurrent_home_matches limit that is >= a club's number of
-    teams can never actually restrict anything (the club can never field more
-    simultaneous home matches than it has teams), so max_concurrent_home_matches_for()
+class TestMaxConcurrentMatchesFor(unittest.TestCase):
+    """A configured max_concurrent_matches limit that is >= a club's number of
+    teams can never actually restrict anything (the club can never play more
+    simultaneous matches than it has teams), so max_concurrent_matches_for()
     should report it as unlimited (None) too. See issue #22.
     """
 
@@ -267,28 +277,61 @@ class TestMaxConcurrentHomeMatchesFor(unittest.TestCase):
             teams=teams,
             home_dates={"A": [date(2025, 1, 1)]},
             unavailable_away_dates={"A": []},
-            max_concurrent_home_matches={
-                "A": fmodel.MaxConcurrentHomeMatches(default=limit),
+            max_concurrent_matches={
+                "A": _home_limit(limit),
             },
         )
 
     def test_limit_below_team_count_is_kept(self) -> None:
         params = self._params(num_teams=3, limit=2)
         self.assertEqual(
-            params.max_concurrent_home_matches_for("A", date(2025, 1, 1)), 2
+            params.max_concurrent_matches_for(
+                "A", fmodel.ConcurrencyScope.HOME, date(2025, 1, 1)
+            ),
+            2,
         )
 
     def test_limit_equal_to_team_count_is_reported_as_unlimited(self) -> None:
         params = self._params(num_teams=2, limit=2)
-        self.assertIsNone(params.max_concurrent_home_matches_for("A", date(2025, 1, 1)))
+        self.assertIsNone(
+            params.max_concurrent_matches_for(
+                "A", fmodel.ConcurrencyScope.HOME, date(2025, 1, 1)
+            )
+        )
 
     def test_limit_above_team_count_is_reported_as_unlimited(self) -> None:
         params = self._params(num_teams=2, limit=5)
-        self.assertIsNone(params.max_concurrent_home_matches_for("A", date(2025, 1, 1)))
+        self.assertIsNone(
+            params.max_concurrent_matches_for(
+                "A", fmodel.ConcurrencyScope.HOME, date(2025, 1, 1)
+            )
+        )
 
     def test_explicit_unlimited_stays_unlimited(self) -> None:
         params = self._params(num_teams=2, limit=None)
-        self.assertIsNone(params.max_concurrent_home_matches_for("A", date(2025, 1, 1)))
+        self.assertIsNone(
+            params.max_concurrent_matches_for(
+                "A", fmodel.ConcurrencyScope.HOME, date(2025, 1, 1)
+            )
+        )
+
+    def test_club_with_no_entry_is_unlimited(self) -> None:
+        params = self._params(num_teams=3, limit=2)
+        # "B" isn't in max_concurrent_matches at all.
+        self.assertIsNone(
+            params.max_concurrent_matches_for(
+                "B", fmodel.ConcurrencyScope.HOME, date(2025, 1, 1)
+            )
+        )
+
+    def test_scope_with_no_entry_is_unlimited(self) -> None:
+        params = self._params(num_teams=3, limit=2)
+        # Only the HOME scope is configured; AWAY/ANY have no limit.
+        self.assertIsNone(
+            params.max_concurrent_matches_for(
+                "A", fmodel.ConcurrencyScope.AWAY, date(2025, 1, 1)
+            )
+        )
 
 
 class TestHomeDatesUsedBounds(unittest.TestCase):
@@ -317,7 +360,7 @@ class TestHomeDatesUsed(unittest.TestCase):
         clubs B-G).  Each A team plays seven home matches (one vs each of the
         other seven teams, including the intra-club match).  A has twelve weekly
         home dates available but home_dates_used.maximum is set to 8.  With
-        max_concurrent_home_matches=2, the solver can pack two home matches per
+        max_concurrent_matches home: 2, the solver can pack two home matches per
         date, so 14 total A home matches fit in 8 dates (capacity 16).  This
         leaves at least four of A's twelve available home dates completely unused.
         """
@@ -344,9 +387,9 @@ class TestHomeDatesUsed(unittest.TestCase):
             teams=teams,
             home_dates=home_dates,
             unavailable_away_dates={c: [] for c in all_clubs},
-            max_concurrent_home_matches={
-                "A": fmodel.MaxConcurrentHomeMatches(default=2),
-                **{c: fmodel.MaxConcurrentHomeMatches(default=1) for c in other_clubs},
+            max_concurrent_matches={
+                "A": _home_limit(2),
+                **{c: _home_limit(1) for c in other_clubs},
             },
             min_gap_days=0,
             home_dates_used={"A": fmodel.HomeDatesUsedBounds(maximum=8)},
@@ -363,7 +406,7 @@ class TestHomeDatesUsed(unittest.TestCase):
 
         Same shape as test_constraint_limits_dates_used: club "A" has two teams
         playing 14 home matches between them, 12 weekly home dates available, and
-        max_concurrent_home_matches=2 -- so absent any spread constraint the solver
+        max_concurrent_matches home: 2 -- so absent any spread constraint the solver
         could pack them onto as few as 7 dates.  home_dates_used.minimum=10 forces
         it to use at least 10 distinct dates instead.
         """
@@ -386,9 +429,9 @@ class TestHomeDatesUsed(unittest.TestCase):
             teams=teams,
             home_dates=home_dates,
             unavailable_away_dates={c: [] for c in all_clubs},
-            max_concurrent_home_matches={
-                "A": fmodel.MaxConcurrentHomeMatches(default=2),
-                **{c: fmodel.MaxConcurrentHomeMatches(default=1) for c in other_clubs},
+            max_concurrent_matches={
+                "A": _home_limit(2),
+                **{c: _home_limit(1) for c in other_clubs},
             },
             min_gap_days=0,
             home_dates_used={"A": fmodel.HomeDatesUsedBounds(minimum=10)},
@@ -414,9 +457,9 @@ class TestHomeDatesUsed(unittest.TestCase):
             teams=teams,
             home_dates=home_dates,
             unavailable_away_dates={"A": [], "B": []},
-            max_concurrent_home_matches={
-                "A": fmodel.MaxConcurrentHomeMatches(default=1),
-                "B": fmodel.MaxConcurrentHomeMatches(default=1),
+            max_concurrent_matches={
+                "A": _home_limit(1),
+                "B": _home_limit(1),
             },
             min_gap_days=7,
             home_dates_used={"A": fmodel.HomeDatesUsedBounds(minimum=2)},
@@ -442,9 +485,9 @@ class TestHomeDatesUsed(unittest.TestCase):
             teams=teams,
             home_dates=home_dates,
             unavailable_away_dates={"A": [], "B": []},
-            max_concurrent_home_matches={
-                "A": fmodel.MaxConcurrentHomeMatches(default=1),
-                "B": fmodel.MaxConcurrentHomeMatches(default=2),
+            max_concurrent_matches={
+                "A": _home_limit(1),
+                "B": _home_limit(2),
             },
             min_gap_days=7,
             home_dates_used={
@@ -481,9 +524,9 @@ class TestFixedFixtures(unittest.TestCase):
             teams=teams,
             home_dates=home_dates,
             unavailable_away_dates={"A": [], "B": []},
-            max_concurrent_home_matches={
-                "A": fmodel.MaxConcurrentHomeMatches(default=2),
-                "B": fmodel.MaxConcurrentHomeMatches(default=1),
+            max_concurrent_matches={
+                "A": _home_limit(2),
+                "B": _home_limit(1),
             },
             min_gap_days=7,
             **kwargs,
@@ -549,9 +592,7 @@ class TestFixedFixtures(unittest.TestCase):
             teams=[a1, a2],
             home_dates={"A": [date(2025, 1, 1), date(2025, 1, 8)]},
             unavailable_away_dates={"A": []},
-            max_concurrent_home_matches={
-                "A": fmodel.MaxConcurrentHomeMatches(default=None)
-            },
+            max_concurrent_matches={"A": _home_limit(None)},
             min_gap_days=7,
             fixed_fixtures=fixed,
         )
@@ -576,9 +617,7 @@ class TestFixedFixtures(unittest.TestCase):
             teams=[a1, a2],
             home_dates={"A": [date(2025, 1, 1), date(2025, 1, 7)]},
             unavailable_away_dates={"A": []},
-            max_concurrent_home_matches={
-                "A": fmodel.MaxConcurrentHomeMatches(default=None)
-            },
+            max_concurrent_matches={"A": _home_limit(None)},
             min_gap_days=7,
             fixed_fixtures=fixed,
         )
@@ -608,9 +647,9 @@ class TestLatestInternalMatchDate(unittest.TestCase):
             teams=teams,
             home_dates=home_dates,
             unavailable_away_dates={"A": [], "B": []},
-            max_concurrent_home_matches={
-                "A": fmodel.MaxConcurrentHomeMatches(default=2),
-                "B": fmodel.MaxConcurrentHomeMatches(default=1),
+            max_concurrent_matches={
+                "A": _home_limit(2),
+                "B": _home_limit(1),
             },
             min_gap_days=7,
             **kwargs,
@@ -695,7 +734,7 @@ class TestEarliestMatchDate(unittest.TestCase):
     fixtures that club A hosts (A1 v A2, A2 v A1, A1 v B1, A2 v B1) shares a
     team -- with only 3 teams to draw from, any two of those 4 fixtures must
     involve at least one of the same two teams. That means all 4 need distinct
-    dates regardless of max_concurrent_home_matches, so club A's home_dates
+    dates regardless of max_concurrent_matches, so club A's home_dates
     below deliberately has some slack (6 dates) beyond that minimum of 4, to
     leave room for a cutoff to remove some of them and still solve.
     """
@@ -721,9 +760,9 @@ class TestEarliestMatchDate(unittest.TestCase):
             teams=teams,
             home_dates=home_dates,
             unavailable_away_dates={"A": [], "B": []},
-            max_concurrent_home_matches={
-                "A": fmodel.MaxConcurrentHomeMatches(default=2),
-                "B": fmodel.MaxConcurrentHomeMatches(default=1),
+            max_concurrent_matches={
+                "A": _home_limit(2),
+                "B": _home_limit(1),
             },
             min_gap_days=7,
             **kwargs,
@@ -800,9 +839,9 @@ class TestExcludedFixtures(unittest.TestCase):
             teams=teams,
             home_dates=home_dates,
             unavailable_away_dates={"A": [], "B": []},
-            max_concurrent_home_matches={
-                "A": fmodel.MaxConcurrentHomeMatches(default=2),
-                "B": fmodel.MaxConcurrentHomeMatches(default=1),
+            max_concurrent_matches={
+                "A": _home_limit(2),
+                "B": _home_limit(1),
             },
             min_gap_days=7,
             **kwargs,
@@ -862,9 +901,7 @@ class TestDivisionSchemes(unittest.TestCase):
             teams=teams,
             home_dates={c: list(dates) for c in clubs},
             unavailable_away_dates={c: [] for c in clubs},
-            max_concurrent_home_matches={
-                c: fmodel.MaxConcurrentHomeMatches(default=1) for c in clubs
-            },
+            max_concurrent_matches={c: _home_limit(1) for c in clubs},
             min_gap_days=7,
             division_schemes=division_schemes or {},
         )
@@ -961,8 +998,8 @@ class TestTeamConstraints(unittest.TestCase):
             teams=[a1, a2],
             home_dates={"A": a_home_dates},
             unavailable_away_dates={"A": []},
-            max_concurrent_home_matches={
-                "A": fmodel.MaxConcurrentHomeMatches(default=1),
+            max_concurrent_matches={
+                "A": _home_limit(1),
             },
             min_gap_days=7,
             # A1 can only host on Jan 1; A2 keeps A's full home_dates.
@@ -984,9 +1021,9 @@ class TestTeamConstraints(unittest.TestCase):
             teams=[a1, b1],
             home_dates={"A": [date(2025, 1, 1)], "B": [date(2025, 2, 1)]},
             unavailable_away_dates={"A": [], "B": []},
-            max_concurrent_home_matches={
-                "A": fmodel.MaxConcurrentHomeMatches(default=1),
-                "B": fmodel.MaxConcurrentHomeMatches(default=1),
+            max_concurrent_matches={
+                "A": _home_limit(1),
+                "B": _home_limit(1),
             },
             min_gap_days=7,
             team_unavailable_away_dates={a1: [date(2025, 2, 1)]},
@@ -1014,9 +1051,7 @@ class TestTeamConstraints(unittest.TestCase):
             teams=[a1],
             home_dates={"A": [date(2025, 1, 1), date(2025, 2, 1)]},
             unavailable_away_dates={"A": []},
-            max_concurrent_home_matches={
-                "A": fmodel.MaxConcurrentHomeMatches(default=1)
-            },
+            max_concurrent_matches={"A": _home_limit(1)},
         )
         self.assertEqual(
             params.home_dates_for(a1), [date(2025, 1, 1), date(2025, 2, 1)]
@@ -1063,9 +1098,9 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
                 "X": [date(2025, 3, 1), date(2025, 3, 8)],
             },
             unavailable_away_dates={"A": [], "X": []},
-            max_concurrent_home_matches={
-                "A": fmodel.MaxConcurrentHomeMatches(default=2),
-                "X": fmodel.MaxConcurrentHomeMatches(default=2),
+            max_concurrent_matches={
+                "A": _home_limit(2),
+                "X": _home_limit(2),
             },
             min_gap_days=7,
             avoid_coscheduling_teams=[
@@ -1092,9 +1127,9 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
                 "X": [date(2025, 3, 1)],
             },
             unavailable_away_dates={"A": [], "X": []},
-            max_concurrent_home_matches={
-                "A": fmodel.MaxConcurrentHomeMatches(default=2),
-                "X": fmodel.MaxConcurrentHomeMatches(default=2),
+            max_concurrent_matches={
+                "A": _home_limit(2),
+                "X": _home_limit(2),
             },
             min_gap_days=7,
             avoid_coscheduling_teams=[
@@ -1121,9 +1156,9 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
                 "X": [date(2025, 3, 1), date(2025, 3, 8)],
             },
             unavailable_away_dates={"A": [], "X": []},
-            max_concurrent_home_matches={
-                "A": fmodel.MaxConcurrentHomeMatches(default=2),
-                "X": fmodel.MaxConcurrentHomeMatches(default=2),
+            max_concurrent_matches={
+                "A": _home_limit(2),
+                "X": _home_limit(2),
             },
             min_gap_days=7,
             avoid_coscheduling_teams=[
@@ -1150,9 +1185,9 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
                 "X": [date(2025, 3, 1), date(2025, 3, 8)],
             },
             unavailable_away_dates={"A": [], "X": []},
-            max_concurrent_home_matches={
-                "A": fmodel.MaxConcurrentHomeMatches(default=2),
-                "X": fmodel.MaxConcurrentHomeMatches(default=2),
+            max_concurrent_matches={
+                "A": _home_limit(2),
+                "X": _home_limit(2),
             },
             min_gap_days=7,
             avoid_coscheduling_teams=[
@@ -1176,9 +1211,7 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
             teams=[a1, a2],
             home_dates={"A": [date(2025, 1, 1)]},
             unavailable_away_dates={"A": []},
-            max_concurrent_home_matches={
-                "A": fmodel.MaxConcurrentHomeMatches(default=1)
-            },
+            max_concurrent_matches={"A": _home_limit(1)},
             min_gap_days=7,
             excluded_fixtures=[fmodel.Fixture(home_team=a2, away_team=a1)],
             avoid_coscheduling_teams=[
@@ -1212,9 +1245,9 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
                 "X": [date(2025, 3, 1), date(2025, 3, 8)],
             },
             unavailable_away_dates={"A": [], "X": []},
-            max_concurrent_home_matches={
-                "A": fmodel.MaxConcurrentHomeMatches(default=2),
-                "X": fmodel.MaxConcurrentHomeMatches(default=2),
+            max_concurrent_matches={
+                "A": _home_limit(2),
+                "X": _home_limit(2),
             },
             min_gap_days=7,
             avoid_coscheduling_teams=[
@@ -1242,9 +1275,9 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
                 "X": [date(2025, 3, 1)],
             },
             unavailable_away_dates={"A": [], "X": []},
-            max_concurrent_home_matches={
-                "A": fmodel.MaxConcurrentHomeMatches(default=2),
-                "X": fmodel.MaxConcurrentHomeMatches(default=2),
+            max_concurrent_matches={
+                "A": _home_limit(2),
+                "X": _home_limit(2),
             },
             min_gap_days=7,
             avoid_coscheduling_teams=[
@@ -1271,9 +1304,9 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
                 "X": [date(2025, 3, 1)],
             },
             unavailable_away_dates={"A": [], "X": []},
-            max_concurrent_home_matches={
-                "A": fmodel.MaxConcurrentHomeMatches(default=2),
-                "X": fmodel.MaxConcurrentHomeMatches(default=2),
+            max_concurrent_matches={
+                "A": _home_limit(2),
+                "X": _home_limit(2),
             },
             min_gap_days=7,
             avoid_coscheduling_teams=[
@@ -1301,9 +1334,9 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
                 "X": [date(2025, 3, 1), date(2025, 3, 8)],
             },
             unavailable_away_dates={"A": [], "X": []},
-            max_concurrent_home_matches={
-                "A": fmodel.MaxConcurrentHomeMatches(default=2),
-                "X": fmodel.MaxConcurrentHomeMatches(default=2),
+            max_concurrent_matches={
+                "A": _home_limit(2),
+                "X": _home_limit(2),
             },
             min_gap_days=7,
             avoid_coscheduling_teams=[
@@ -1316,8 +1349,8 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
             fmodel.solve(params)
 
 
-class TestMaxConcurrentHomeMatchesUnlimited(unittest.TestCase):
-    """Test cases for MaxConcurrentHomeMatches(default=None) / overrides=None: no
+class TestMaxConcurrentMatchesUnlimited(unittest.TestCase):
+    """Test cases for ConcurrencyLimit(default=None) / overrides=None: no
     limit imposed by this mechanism, as opposed to a finite one.
     """
 
@@ -1336,9 +1369,9 @@ class TestMaxConcurrentHomeMatchesUnlimited(unittest.TestCase):
                 "X": [date(2025, 3, 1), date(2025, 3, 8)],
             },
             unavailable_away_dates={"A": [], "X": []},
-            max_concurrent_home_matches={
-                "A": fmodel.MaxConcurrentHomeMatches(default=1),
-                "X": fmodel.MaxConcurrentHomeMatches(default=2),
+            max_concurrent_matches={
+                "A": _home_limit(1),
+                "X": _home_limit(2),
             },
             min_gap_days=7,
         )
@@ -1359,9 +1392,9 @@ class TestMaxConcurrentHomeMatchesUnlimited(unittest.TestCase):
                 "X": [date(2025, 3, 1), date(2025, 3, 8)],
             },
             unavailable_away_dates={"A": [], "X": []},
-            max_concurrent_home_matches={
-                "A": fmodel.MaxConcurrentHomeMatches(default=None),
-                "X": fmodel.MaxConcurrentHomeMatches(default=2),
+            max_concurrent_matches={
+                "A": _home_limit(None),
+                "X": _home_limit(2),
             },
             min_gap_days=7,
         )
@@ -1386,11 +1419,15 @@ class TestMaxConcurrentHomeMatchesUnlimited(unittest.TestCase):
                 "X": [date(2025, 3, 1), date(2025, 3, 8)],
             },
             unavailable_away_dates={"A": [], "X": []},
-            max_concurrent_home_matches={
-                "A": fmodel.MaxConcurrentHomeMatches(
-                    default=1, overrides={date(2025, 1, 1): None}
+            max_concurrent_matches={
+                "A": fmodel.MaxConcurrentMatches(
+                    by_scope={
+                        fmodel.ConcurrencyScope.HOME: fmodel.ConcurrencyLimit(
+                            default=1, overrides={date(2025, 1, 1): None}
+                        )
+                    }
                 ),
-                "X": fmodel.MaxConcurrentHomeMatches(default=2),
+                "X": _home_limit(2),
             },
             min_gap_days=7,
         )
@@ -1399,6 +1436,74 @@ class TestMaxConcurrentHomeMatchesUnlimited(unittest.TestCase):
         a2_home_date = next(sf.date for sf in fixtures if sf.fixture.home_team == a2)
         self.assertEqual(a1_home_date, date(2025, 1, 1))
         self.assertEqual(a2_home_date, date(2025, 1, 1))
+
+
+class TestMaxConcurrentMatchesScopes(unittest.TestCase):
+    """The AWAY and ANY ConcurrencyScopes at the solve() level (HOME is covered by
+    the classes above). Scenario: club A's two teams (different divisions, so no
+    direct fixture) play their away legs at club X, whose single home date forces
+    both onto the same night unless something says otherwise.
+    """
+
+    def _params(
+        self,
+        a_limits: fmodel.MaxConcurrentMatches,
+        *,
+        x_home_dates: list[date],
+    ) -> fmodel.Parameters:
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        a2 = fmodel.Team(division=2, club="A", index=2)
+        x1 = fmodel.Team(division=1, club="X", index=1)
+        x2 = fmodel.Team(division=2, club="X", index=2)
+        return fmodel.Parameters(
+            teams=[a1, a2, x1, x2],
+            home_dates={"A": [date(2025, 3, 1)], "X": x_home_dates},
+            unavailable_away_dates={"A": [], "X": []},
+            # X can host both its teams' matches whenever it has the dates for them.
+            max_concurrent_matches={"A": a_limits},
+            min_gap_days=7,
+        )
+
+    def _any(self, limit: int | None) -> fmodel.MaxConcurrentMatches:
+        return fmodel.MaxConcurrentMatches(
+            by_scope={fmodel.ConcurrencyScope.ANY: fmodel.ConcurrencyLimit(limit)}
+        )
+
+    def _away(self, limit: int | None) -> fmodel.MaxConcurrentMatches:
+        return fmodel.MaxConcurrentMatches(
+            by_scope={fmodel.ConcurrencyScope.AWAY: fmodel.ConcurrencyLimit(limit)}
+        )
+
+    def test_any_scope_limit_blocks_two_matches_on_one_date(self) -> None:
+        # X has one home date, so A1 and A2 must both play away that night; an ANY
+        # limit of 1 forbids A playing two matches (home or away) on a date.
+        params = self._params(self._any(1), x_home_dates=[date(2025, 1, 1)])
+        with self.assertRaises(ValueError):
+            fmodel.solve(params)
+
+    def test_any_scope_limit_allows_up_to_the_limit(self) -> None:
+        params = self._params(self._any(2), x_home_dates=[date(2025, 1, 1)])
+        fixtures = list(fmodel.solve(params))
+        away = sorted(sf.date for sf in fixtures if sf.fixture.away_team.club == "A")
+        self.assertEqual(away, [date(2025, 1, 1), date(2025, 1, 1)])
+
+    def test_away_scope_limit_blocks_two_away_matches_on_one_date(self) -> None:
+        params = self._params(self._away(1), x_home_dates=[date(2025, 1, 1)])
+        with self.assertRaises(ValueError):
+            fmodel.solve(params)
+
+    def test_away_scope_does_not_restrict_home_matches(self) -> None:
+        # With two X home dates the away legs fall on separate nights, satisfying
+        # away: 1; A's own two home matches still share A's single home date,
+        # because the AWAY scope doesn't count home matches.
+        params = self._params(
+            self._away(1), x_home_dates=[date(2025, 1, 1), date(2025, 1, 8)]
+        )
+        fixtures = list(fmodel.solve(params))
+        home = sorted(sf.date for sf in fixtures if sf.fixture.home_team.club == "A")
+        self.assertEqual(home, [date(2025, 3, 1), date(2025, 3, 1)])
+        away = sorted(sf.date for sf in fixtures if sf.fixture.away_team.club == "A")
+        self.assertEqual(away, [date(2025, 1, 1), date(2025, 1, 8)])
 
 
 class TestDuplicateRejection(unittest.TestCase):
@@ -1416,9 +1521,9 @@ class TestDuplicateRejection(unittest.TestCase):
                 teams=teams,
                 home_dates={"A": [date(2025, 1, 1)], "B": [date(2025, 2, 1)]},
                 unavailable_away_dates={"A": [], "B": []},
-                max_concurrent_home_matches={
-                    "A": fmodel.MaxConcurrentHomeMatches(default=1),
-                    "B": fmodel.MaxConcurrentHomeMatches(default=1),
+                max_concurrent_matches={
+                    "A": _home_limit(1),
+                    "B": _home_limit(1),
                 },
             )
 
@@ -1435,9 +1540,9 @@ class TestDuplicateRejection(unittest.TestCase):
                     "B": [date(2025, 2, 1)],
                 },
                 unavailable_away_dates={"A": [], "B": []},
-                max_concurrent_home_matches={
-                    "A": fmodel.MaxConcurrentHomeMatches(default=1),
-                    "B": fmodel.MaxConcurrentHomeMatches(default=1),
+                max_concurrent_matches={
+                    "A": _home_limit(1),
+                    "B": _home_limit(1),
                 },
             )
 
@@ -1452,9 +1557,9 @@ class TestDuplicateRejection(unittest.TestCase):
                     "B": [date(2025, 2, 1)],
                 },
                 unavailable_away_dates={"A": [], "B": []},
-                max_concurrent_home_matches={
-                    "A": fmodel.MaxConcurrentHomeMatches(default=1),
-                    "B": fmodel.MaxConcurrentHomeMatches(default=1),
+                max_concurrent_matches={
+                    "A": _home_limit(1),
+                    "B": _home_limit(1),
                 },
                 team_home_dates={
                     a1: [date(2025, 1, 1), date(2025, 1, 1)]  # duplicate

--- a/report_test.py
+++ b/report_test.py
@@ -53,7 +53,8 @@ divisions:
 
 club_constraints:
   defaults:
-    max_concurrent_home_matches: 1
+    max_concurrent_matches:
+      home: 1
   albany:
     home_dates: [2025-09-01, 2025-09-29]
   hackney:

--- a/runs/example/spec.yaml
+++ b/runs/example/spec.yaml
@@ -190,7 +190,8 @@ divisions:
     - potters-bar-1
 club_constraints:
   defaults:
-    max_concurrent_home_matches: 2
+    max_concurrent_matches:
+      home: 2
   albany:
     home_dates:
     - '2025-09-01'
@@ -355,10 +356,11 @@ club_constraints:
     - '2026-04-23'
     - '2026-04-30'
     - '2026-05-28'
-    max_concurrent_home_matches:
-      default: 2
-      overrides:
-        '2025-11-13': 3
+    max_concurrent_matches:
+      home:
+        default: 2
+        overrides:
+          '2025-11-13': 3
   harrow:
     home_dates:
     - '2025-09-11'

--- a/solve_test.py
+++ b/solve_test.py
@@ -53,7 +53,8 @@ divisions:
 
 club_constraints:
   defaults:
-    max_concurrent_home_matches: 1
+    max_concurrent_matches:
+      home: 1
   albany:
     home_dates: [2025-09-01, 2025-09-29]
   hackney:

--- a/spec-schema.json
+++ b/spec-schema.json
@@ -80,15 +80,15 @@
     },
     "club_constraints": {
       "type": "object",
-      "description": "Every constraint that can vary by club -- home_dates, unavailable_away_dates, max_concurrent_home_matches, home_dates_used, teams and avoid_coscheduling_teams -- keyed by that club's own ID, alongside an optional 'defaults' entry.",
+      "description": "Every constraint that can vary by club -- home_dates, unavailable_away_dates, max_concurrent_matches, home_dates_used, teams and avoid_coscheduling_teams -- keyed by that club's own ID, alongside an optional 'defaults' entry.",
       "additionalProperties": { "$ref": "#/$defs/club_constraints_entry" },
       "properties": {
         "defaults": {
           "type": "object",
           "additionalProperties": false,
-          "description": "Spec-wide defaults for constraint types that support one, overridable per club. Today that's just max_concurrent_home_matches: if defaults.max_concurrent_home_matches is omitted, every club must have its own max_concurrent_home_matches entry -- there's no built-in fallback value.",
+          "description": "Spec-wide defaults for constraint types that support one, merged with each club's own entry. Today that's just max_concurrent_matches, merged per scope (see its definition). All of it is optional -- there is no requirement that any club have a concurrency limit.",
           "properties": {
-            "max_concurrent_home_matches": { "$ref": "#/$defs/max_concurrent_home_matches" }
+            "max_concurrent_matches": { "$ref": "#/$defs/max_concurrent_matches" }
           }
         }
       }
@@ -180,8 +180,8 @@
         }
       }
     },
-    "max_concurrent_home_matches": {
-      "description": "How many home matches a club may host on the same date. Either a plain integer, null (no limit imposed by this mechanism -- e.g. for a club whose concurrency is already bounded by another constraint, such as a full set of avoid_coscheduling_teams pairings across its teams, where restating that bound as a number here would be redundant and easy to leave stale), or a mapping giving a default plus per-date overrides. A value that's simply set high enough to never bind -- i.e. >= the club's number of teams -- needs no special-casing: the solver recognises this case itself and skips adding a constraint for it.",
+    "concurrency_limit": {
+      "description": "A limit on how many matches of one scope (see max_concurrent_matches) a club may play on the same date. Either a plain integer, null (no limit imposed by this mechanism -- e.g. for a club whose concurrency is already bounded by another constraint, such as a full set of avoid_coscheduling_teams pairings across its teams, where restating that bound as a number here would be redundant and easy to leave stale), or a mapping giving a default plus per-date overrides. A value that's simply set high enough to never bind -- i.e. >= the club's number of teams -- needs no special-casing: the solver recognises this case itself and skips adding a constraint for it.",
       "oneOf": [
         { "type": "integer" },
         { "type": "null" },
@@ -205,6 +205,26 @@
         }
       ]
     },
+    "max_concurrent_matches": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "description": "Per-scope limits on how many matches a club's teams may play on the same date. Give any of 'home', 'away', 'any' (at least one). Each is a concurrency_limit (an integer, null, or a default plus per-date overrides). Under club_constraints.defaults it sets spec-wide defaults; a club's own entry is merged with those per scope (its value wins for the scopes it sets, the default applies to the rest). Every scope is optional -- a club, and the spec as a whole, may set no concurrency limits at all.",
+      "properties": {
+        "home": {
+          "description": "Counts only the club's home matches on a date.",
+          "$ref": "#/$defs/concurrency_limit"
+        },
+        "away": {
+          "description": "Counts only the club's away matches on a date.",
+          "$ref": "#/$defs/concurrency_limit"
+        },
+        "any": {
+          "description": "Counts every match the club's teams play on a date (an internal match, both teams the club's, counted once).",
+          "$ref": "#/$defs/concurrency_limit"
+        }
+      }
+    },
     "club_constraints_entry": {
       "type": "object",
       "additionalProperties": false,
@@ -224,7 +244,7 @@
           "items": { "$ref": "#/$defs/date" },
           "uniqueItems": true
         },
-        "max_concurrent_home_matches": { "$ref": "#/$defs/max_concurrent_home_matches" },
+        "max_concurrent_matches": { "$ref": "#/$defs/max_concurrent_matches" },
         "home_dates_used": {
           "type": "object",
           "additionalProperties": false,

--- a/spec_schema_test.py
+++ b/spec_schema_test.py
@@ -79,19 +79,27 @@ divisions:
 
 club_constraints:
   defaults:
-    max_concurrent_home_matches: 2
+    max_concurrent_matches:
+      home: 2
 
   albany:
     home_dates: [2025-09-01, 2025-09-15, 2025-09-29]
     unavailable_away_dates: [2025-12-25]
-    max_concurrent_home_matches: 3
+    max_concurrent_matches:
+      home: 3
 
   hackney:
     home_dates: [2025-09-08, 2025-09-22]
-    max_concurrent_home_matches:
-      default: 2
-      overrides:
-        2025-09-08: 3
+    max_concurrent_matches:
+      home:
+        default: 2
+        overrides:
+          2025-09-08: 3
+      away: null
+      any:
+        default: null
+        overrides:
+          2025-09-22: 1
     home_dates_used:
       min: 1
       max: 2


### PR DESCRIPTION
Replace the home-only concurrency cap with a per-scope max_concurrent_matches: a club may now limit its home matches, its away matches, or any match its teams play on a given date, each limit being a plain int, null (no limit), or a {default, overrides} mapping with per-date overrides -- the same shape as before, now available per scope.

- fmodel: ConcurrencyScope (HOME/AWAY/ANY) + ConcurrencyLimit + MaxConcurrentMatches replace MaxConcurrentHomeMatches; Parameters.max_concurrent_matches is now optional; solve() adds a per-scope Sum <= limit constraint (an internal match counts once for ANY). The ">= team count => unlimited" reduction applies to every scope.
- fixturespec / spec-schema: club_constraints[*].max_concurrent_matches and club_constraints.defaults.max_concurrent_matches, merged per scope (a club setting only 'any' still inherits the default 'home'). All scopes are optional now -- the old "every club must declare a limit" error is gone.
- Migrate runs/example/spec.yaml and genfixtures.py to the new key; update tests, including new solve()-level coverage of the AWAY and ANY scopes.


Claude-Session: https://claude.ai/code/session_016R2nTVDkrMKVqLi1xC74Mb