### PR TITLE
Show distinct match-date counts under each club's consolidated table …

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ The report build writes, for each run, into `_site/runs/<run path>/`:
   with its own venues list covering just that division's home clubs
 - `club-<id>.html` — one page per club, headed by that club's full venue
   name and address, with a consolidated table of all the club's matches
-  followed by one table per team
+  (followed by a count of the distinct dates the club is in action on,
+  split into total / home / away) followed by one table per team
 - `all-matches.csv` — one row per match, `home_team` vs `away_team`, with
   `date` (ISO `yyyy-mm-dd`), `division`, and the home club's `venue`,
   `venue_address`, `start_time` and `time_limit`

--- a/htmlreport.py
+++ b/htmlreport.py
@@ -57,6 +57,7 @@ _STYLE = """
     nav li { margin-bottom: 0.3rem; }
     nav ul ul { padding-left: 1.2rem; margin-top: 0.3rem; }
     .venue { margin-top: -0.5rem; margin-bottom: 1.5rem; color: #333; }
+    .date-summary { margin-top: -1.5rem; margin-bottom: 2rem; color: #333; }
     ul.venues { padding-left: 1.2rem; }
     ul.venues li { margin-bottom: 0.3rem; }
     .anchor-link { margin-left: 0.4rem; font-size: 0.8em; text-decoration: none;
@@ -340,6 +341,20 @@ def _venue_header(club: fmodel.Club) -> str:
     )
 
 
+def _club_date_summary(
+    club_id: str, fixtures: Collection[fmodel.ScheduledFixture]
+) -> str:
+    """A one-line count of the distinct dates a club is in action on, shown under
+    its consolidated table. Excluded (TBC) fixtures have no date and don't count."""
+    counts = reportdata.club_date_counts(club_id, fixtures)
+    return (
+        '<p class="date-summary">Distinct match dates: '
+        f"<strong>{counts.total}</strong> total "
+        f"(<strong>{counts.home}</strong> home, "
+        f"<strong>{counts.away}</strong> away)</p>\n"
+    )
+
+
 def _venues_section(club_ids: Collection[str], clubs: Mapping[str, fmodel.Club]) -> str:
     if not club_ids:
         return ""
@@ -484,10 +499,16 @@ def generate_report(
     # One page per club: venue header, consolidated table, then one table per team
     for club_id in sorted(teams_by_club):
         club_name = clubs[club_id].name
-        body = _venue_header(clubs[club_id]) + _table(
-            _MATCH_HEADERS_WITH_DIVISION,
-            _rows_with_division(fixtures_by_club.get(club_id, []), clubs)
-            + _excluded_rows_with_division(excluded_by_club.get(club_id, []), clubs),
+        body = (
+            _venue_header(clubs[club_id])
+            + _table(
+                _MATCH_HEADERS_WITH_DIVISION,
+                _rows_with_division(fixtures_by_club.get(club_id, []), clubs)
+                + _excluded_rows_with_division(
+                    excluded_by_club.get(club_id, []), clubs
+                ),
+            )
+            + _club_date_summary(club_id, fixtures_by_club.get(club_id, []))
         )
         for team in sorted(teams_by_club[club_id], key=lambda t: t.index):
             team_fixtures = [

--- a/htmlreport_test.py
+++ b/htmlreport_test.py
@@ -286,6 +286,18 @@ class TestGenerateReport(unittest.TestCase):
         self.assertIn("Harrow Leisure Centre", header_part)
         self.assertIn("1 Harrow Road, London", header_part)
 
+    def test_club_page_shows_distinct_date_counts_under_consolidated_table(
+        self,
+    ) -> None:
+        harrow_page = (self.output_dir / "club-harrow.html").read_text()
+        # Harrow: home 1 Sep + 15 Sep (derby); away 8 Sep + 15 Sep (derby).
+        # Distinct overall: 1, 8, 15 Sep -> 3 total, 2 home, 2 away.
+        summary = harrow_page.split("</table>")[1].split("<h2")[0]
+        self.assertIn('<p class="date-summary">', summary)
+        self.assertIn("3</strong> total", summary)
+        self.assertIn("2</strong> home", summary)
+        self.assertIn("2</strong> away", summary)
+
     def test_ampersand_club_name_slugified_and_escaped(self) -> None:
         path = self.output_dir / "club-willesden-brent.html"
         self.assertTrue(path.exists())

--- a/reportdata.py
+++ b/reportdata.py
@@ -22,7 +22,9 @@ or produces any markup.
 
 from __future__ import annotations
 
+import dataclasses
 from collections.abc import Collection, Mapping
+from datetime import date
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -90,3 +92,36 @@ def by_home_away(
         )
 
     return sorted(fixtures, key=key)
+
+
+@dataclasses.dataclass(frozen=True)
+class ClubDateCounts:
+    """How many distinct calendar dates a club is in action on: `total` across all
+    its matches, `home` across the ones it hosts, `away` across the ones it visits.
+    A date carrying both a home and an away match for the club (two of its teams
+    out the same night, or an internal derby) counts once in `total` but in both
+    `home` and `away`, so `total` can be less than `home + away`."""
+
+    total: int
+    home: int
+    away: int
+
+
+def club_date_counts(
+    club_id: str, fixtures: Collection[fmodel.ScheduledFixture]
+) -> ClubDateCounts:
+    """Count club_id's distinct match dates over the given scheduled fixtures
+    (which may be the whole season or any subset; fixtures not involving club_id
+    are ignored)."""
+    home_dates: set[date] = set()
+    away_dates: set[date] = set()
+    for sf in fixtures:
+        if sf.fixture.home_team.club == club_id:
+            home_dates.add(sf.date)
+        if sf.fixture.away_team.club == club_id:
+            away_dates.add(sf.date)
+    return ClubDateCounts(
+        total=len(home_dates | away_dates),
+        home=len(home_dates),
+        away=len(away_dates),
+    )

--- a/reportdata_test.py
+++ b/reportdata_test.py
@@ -97,6 +97,39 @@ class ReportDataTest(unittest.TestCase):
         ordered = reportdata.by_home_away([f1, f2], self.clubs, with_division=False)
         self.assertEqual(ordered, [f2, f1])
 
+    def test_club_date_counts_splits_home_away_and_total(self) -> None:
+        fixtures = [
+            _sf(self.barnet1, self.aardvark1, date(2025, 9, 1)),
+            _sf(self.barnet2, self.aardvark1, date(2025, 9, 15)),
+            _sf(self.aardvark1, self.barnet1, date(2025, 10, 6)),
+        ]
+        self.assertEqual(
+            reportdata.club_date_counts("a-club", fixtures),
+            reportdata.ClubDateCounts(total=3, home=2, away=1),
+        )
+
+    def test_club_date_counts_dedupes_dates_and_ignores_other_clubs(self) -> None:
+        fixtures = [
+            # Two Barnet teams both at home the same night: one home date, not two.
+            _sf(self.barnet1, self.aardvark1, date(2025, 9, 1)),
+            _sf(self.barnet2, self.aardvark1, date(2025, 9, 1)),
+            # An internal derby: same date counts as both a home and an away date.
+            _sf(self.barnet1, self.barnet2, date(2025, 9, 8)),
+            # Not involving a-club at all.
+            _sf(self.aardvark1, self.nick, date(2025, 9, 22)),
+        ]
+        self.assertEqual(
+            reportdata.club_date_counts("a-club", fixtures),
+            reportdata.ClubDateCounts(total=2, home=2, away=1),
+        )
+
+    def test_club_date_counts_zero_when_club_absent(self) -> None:
+        fixtures = [_sf(self.aardvark1, self.nick, date(2025, 9, 1))]
+        self.assertEqual(
+            reportdata.club_date_counts("a-club", fixtures),
+            reportdata.ClubDateCounts(total=0, home=0, away=0),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
…(closes #67)

Adds reportdata.club_date_counts(), which counts a club's distinct match dates split into total / home / away, and renders it as a one-line summary directly beneath the consolidated table on every club-<id>.html page. A date with both a home and an away match for the club (two teams out the same night, or an internal derby) counts once in the total but in both home and away.


Claude-Session: https://claude.ai/code/session_01AKn1GvKvarzWLG8ZjPwQ1Z