### PR TITLE
Give report pages meaningful head-titles; build run indexes from data

### DIFF
--- a/htmlreport.py
+++ b/htmlreport.py
@@ -14,10 +14,11 @@
 
 """Render a solved fixture list as a set of linked HTML pages.
 
-The index-building helpers here (build_run_index and write_runs_index) derive
-the per-run and top-level index.html pages purely from the report files present
-on disk, without needing the original fixtures/teams data. build_site.py calls
-them after re-rendering the report pages during a GitHub Pages deploy.
+generate_report writes each run's report pages plus that run's own index.html,
+all from the spec + solved fixtures it is handed. write_runs_index then derives
+the single top-level index.html from the run directories present on disk (their
+folder layout is the only input it needs). build_site.py drives both during a
+GitHub Pages deploy.
 """
 
 from __future__ import annotations
@@ -70,11 +71,6 @@ _STYLE = """
     }
 """
 
-_TITLE_RE = re.compile(r"<title>(.*?)</title>", re.DOTALL)
-_RUN_NAME_RE = re.compile(r'<span class="run-name">(.*?)</span>', re.DOTALL)
-_DESCRIPTION_RE = re.compile(r'<p class="description">(.*?)</p>', re.DOTALL)
-_DRAFT_MARKER = 'class="draft-label"'
-
 
 def slugify(value: str) -> str:
     """Turn a name into a filesystem/URL-safe slug, e.g. 'Willesden & Brent' -> 'willesden-brent'."""
@@ -86,12 +82,32 @@ def _fmt_date(d: date) -> str:
     return d.strftime("%a %d %b %Y")
 
 
+def _head_title(title: str, run_name: str, draft: bool, is_run_home: bool) -> str:
+    """The text for the page's <title> element.
+
+    A run's home page gets just the run name; every other page in the run gets
+    the run name followed by that page's own title (a club or division name, or
+    "All matches"). A trailing "(DRAFT)" is added whenever the run is a draft.
+    Pages with no run name (e.g. the top-level list of runs) fall back to their
+    own title alone.
+    """
+    if run_name and is_run_home:
+        text = run_name
+    elif run_name:
+        text = f"{run_name} – {title}"
+    else:
+        text = title
+    return f"{text} (DRAFT)" if draft else text
+
+
 def _page(
     title: str,
     body: str,
     run_name: str = "",
     draft: bool = False,
     description: str = "",
+    *,
+    is_run_home: bool = False,
 ) -> str:
     banner_html = ""
     if run_name or draft:
@@ -111,7 +127,7 @@ def _page(
         "<head>\n"
         '<meta charset="utf-8">\n'
         '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
-        f"<title>{html.escape(title)}</title>\n"
+        f"<title>{html.escape(_head_title(title, run_name, draft, is_run_home))}</title>\n"
         f"<style>{_STYLE}</style>\n"
         "</head>\n"
         "<body>\n"
@@ -122,29 +138,6 @@ def _page(
         "</body>\n"
         "</html>\n"
     )
-
-
-def _page_title(path: Path) -> str:
-    """Recover the display title of a page previously written by _page(), for nav links."""
-    match = _TITLE_RE.search(path.read_text())
-    return html.unescape(match.group(1)) if match else path.stem
-
-
-def _page_run_name(path: Path) -> str:
-    """Recover the run name banner text of a page previously written by _page(), if any."""
-    match = _RUN_NAME_RE.search(path.read_text())
-    return html.unescape(match.group(1)) if match else ""
-
-
-def _page_is_draft(path: Path) -> bool:
-    """Recover whether a page previously written by _page() carried a draft banner."""
-    return _DRAFT_MARKER in path.read_text()
-
-
-def _page_description(path: Path) -> str:
-    """Recover the description of a page previously written by _page(), if any."""
-    match = _DESCRIPTION_RE.search(path.read_text())
-    return html.unescape(match.group(1)) if match else ""
 
 
 def _table_cell(cell: str) -> str:
@@ -384,8 +377,21 @@ def _nav(links: list[tuple[str, str]]) -> str:
     return f"<nav><ul>\n{items}</ul></nav>\n"
 
 
-def _division_number(path: Path) -> int:
-    return int(path.stem.removeprefix("division-"))
+def _run_index_body(
+    all_matches_links: list[tuple[str, str]],
+    division_links: list[tuple[str, str]],
+    club_links: list[tuple[str, str]],
+) -> str:
+    """The body of a run's index.html: three lists of (href, label) links, one
+    per section, in the order they'll appear on the page."""
+    return (
+        "<h2>All matches</h2>\n"
+        + _nav(all_matches_links)
+        + "<h2>Divisions</h2>\n"
+        + _nav(division_links)
+        + "<h2>Clubs</h2>\n"
+        + _nav(club_links)
+    )
 
 
 _MATCH_HEADERS = ["Date", "Home", "Away", "Venue", "Start", "Time Limit"]
@@ -414,13 +420,18 @@ def generate_report(
     fixtures: Collection[fmodel.ScheduledFixture],
     output_dir: Path,
 ) -> Path:
-    """Write all HTML report pages for a solved fixture list into output_dir.
+    """Write a solved fixture list's report pages, plus the run's index.html
+    linking them, into output_dir.
 
     `spec` supplies everything about the season except the solved dates -- teams,
     clubs, the run name/draft/description banners, each division's fixture scheme,
     and any excluded_fixtures (withheld from scheduling entirely, to be arranged
     in a later run; these are appended to the bottom of every relevant table with
     "TBC" in place of a date). `fixtures` is the solved schedule for that spec.
+
+    The index links whichever all-matches.csv / all-matches-by-team.csv exports
+    are already present in output_dir (csvreport.generate_csv writes them), so
+    run that first if the index should link them.
 
     Returns the path to the run's index.html.
     """
@@ -474,8 +485,16 @@ def generate_report(
             description,
         )
     )
+    all_matches_links: list[tuple[str, str]] = [("all-matches.html", "All matches")]
+    for csv_name, csv_label in (
+        ("all-matches.csv", "CSV: one row per match"),
+        ("all-matches-by-team.csv", "CSV: two rows per match, one per team"),
+    ):
+        if (output_dir / csv_name).exists():
+            all_matches_links.append((csv_name, csv_label))
 
     # One page per division
+    division_links: list[tuple[str, str]] = []
     for division in sorted(set(fixtures_by_division) | set(excluded_by_division)):
         division_club_ids = _home_club_ids_scheduled(
             fixtures_by_division[division]
@@ -495,8 +514,10 @@ def generate_report(
                 description,
             )
         )
+        division_links.append((f"division-{division}.html", f"Division {division}"))
 
     # One page per club: venue header, consolidated table, then one table per team
+    club_links: list[tuple[str, str]] = []
     for club_id in sorted(teams_by_club):
         club_name = clubs[club_id].name
         body = (
@@ -530,48 +551,24 @@ def generate_report(
                 _team_rows(team, team_fixtures, clubs)
                 + _excluded_team_rows(team, team_excluded, clubs),
             )
-        (output_dir / f"club-{slugify(club_id)}.html").write_text(
+        club_slug = slugify(club_id)
+        (output_dir / f"club-{club_slug}.html").write_text(
             _page(club_name, body, name, draft, description)
         )
+        club_links.append((f"club-{club_slug}.html", club_name))
+    club_links.sort()
 
-    return build_run_index(output_dir)
-
-
-def build_run_index(run_dir: Path) -> Path:
-    """(Re)build a run's index.html purely from the report files present in run_dir."""
-    all_matches_path = run_dir / "all-matches.html"
-    division_paths = sorted(run_dir.glob("division-*.html"), key=_division_number)
-    club_paths = sorted(run_dir.glob("club-*.html"))
-
-    body = "<h2>All matches</h2>\n"
-    all_matches_links: list[tuple[str, str]] = []
-    if all_matches_path.exists():
-        all_matches_links.append(("all-matches.html", _page_title(all_matches_path)))
-    for csv_name, csv_label in (
-        ("all-matches.csv", "CSV: one row per match"),
-        ("all-matches-by-team.csv", "CSV: two rows per match, one per team"),
-    ):
-        if (run_dir / csv_name).exists():
-            all_matches_links.append((csv_name, csv_label))
-    if all_matches_links:
-        body += _nav(all_matches_links)
-    body += "<h2>Divisions</h2>\n"
-    body += _nav([(p.name, _page_title(p)) for p in division_paths])
-    body += "<h2>Clubs</h2>\n"
-    body += _nav([(p.name, _page_title(p)) for p in club_paths])
-
-    # Run name/draft status aren't known here (this can run standalone, from
-    # just the files on disk), so recover them from an already-written page.
-    reference_page = next(
-        (p for p in [all_matches_path, *division_paths, *club_paths] if p.exists()),
-        None,
+    index_path = output_dir / "index.html"
+    index_path.write_text(
+        _page(
+            "Fixtures",
+            _run_index_body(all_matches_links, division_links, club_links),
+            name,
+            draft,
+            description,
+            is_run_home=True,
+        )
     )
-    run_name = _page_run_name(reference_page) if reference_page else ""
-    draft = _page_is_draft(reference_page) if reference_page else False
-    description = _page_description(reference_page) if reference_page else ""
-
-    index_path = run_dir / "index.html"
-    index_path.write_text(_page("Fixtures", body, run_name, draft, description))
     return index_path
 
 

--- a/htmlreport_test.py
+++ b/htmlreport_test.py
@@ -311,15 +311,19 @@ class TestGenerateReport(unittest.TestCase):
         self.assertIn("division-2.html", content)
         self.assertIn("club-harrow.html", content)
         self.assertIn("club-willesden-brent.html", content)
-        # Titles recovered from the linked pages, not raw filenames
+        # Link labels are the pages' own titles, not raw filenames
         self.assertIn(">Division 1<", content)
         self.assertIn(">Willesden &amp; Brent<", content)
 
     def test_run_index_links_to_csv_exports_when_present(self) -> None:
+        # generate_report links whichever CSV exports it finds already written
+        # into the output dir (csvreport.generate_csv writes them in production).
         for name in ("all-matches.csv", "all-matches-by-team.csv"):
             (self.output_dir / name).write_text("date\n")
 
-        content = htmlreport.build_run_index(self.output_dir).read_text()
+        content = _generate(
+            self.fixtures, self.teams, self.clubs, self.output_dir
+        ).read_text()
 
         self.assertIn('href="all-matches.csv"', content)
         self.assertIn('href="all-matches-by-team.csv"', content)
@@ -332,24 +336,19 @@ class TestGenerateReport(unittest.TestCase):
         # setUp's _generate() writes HTML pages only, no CSV files.
         self.assertNotIn(".csv", self.index_path.read_text())
 
-    def test_build_run_index_is_rebuildable_from_disk_alone(self) -> None:
-        """Deleting index.html and rebuilding from the other report files must reproduce it."""
-        self.index_path.unlink()
-        rebuilt_path = htmlreport.build_run_index(self.output_dir)
-        self.assertEqual(rebuilt_path, self.index_path)
-        content = self.index_path.read_text()
-        self.assertIn("division-1.html", content)
-        self.assertIn("club-harrow.html", content)
-
     def test_division_numbers_sort_numerically_not_lexically(self) -> None:
-        out2 = Path(self._tmpdir.name) / "out3"
-        out2.mkdir()
-        for n in [1, 2, 10]:
-            (out2 / f"division-{n}.html").write_text(
-                htmlreport._page(f"Division {n}", "")
-            )
-        (out2 / "all-matches.html").write_text(htmlreport._page("All matches", ""))
-        content = htmlreport.build_run_index(out2).read_text()
+        clubs = {"c": _club("C"), "d": _club("D")}
+        teams: list[fmodel.Team] = []
+        fixtures: list[fmodel.ScheduledFixture] = []
+        for n in (1, 2, 10):
+            home = fmodel.Team(division=n, club="c", index=1)
+            away = fmodel.Team(division=n, club="d", index=1)
+            teams += [home, away]
+            fixtures.append(_sf(home, away, date(2025, 9, 1)))
+
+        out2 = Path(self._tmpdir.name) / "out-div-sort"
+        content = _generate(fixtures, teams, clubs, out2).read_text()
+
         self.assertLess(
             content.index("division-1.html"), content.index("division-2.html")
         )
@@ -399,19 +398,6 @@ class TestGenerateReport(unittest.TestCase):
             self.assertIn('<span class="draft-label">DRAFT</span>', content)
             self.assertIn('<span class="run-name">2025-26 Season</span>', content)
 
-    def test_index_recovers_name_and_draft_from_disk_alone(self) -> None:
-        """Rebuilding index.html from scratch must recover the run name/draft status
-        from the other report files, since build_run_index has no other source for them."""
-        out2 = Path(self._tmpdir.name) / "out-rebuilt"
-        index_path = _generate(
-            self.fixtures, self.teams, self.clubs, out2, name="Test Run", draft=True
-        )
-        index_path.unlink()
-        rebuilt_path = htmlreport.build_run_index(out2)
-        content = rebuilt_path.read_text()
-        self.assertIn('<span class="draft-label">DRAFT</span>', content)
-        self.assertIn('<span class="run-name">Test Run</span>', content)
-
     def test_description_shown_on_every_page(self) -> None:
         out2 = Path(self._tmpdir.name) / "out-described"
         index_path = _generate(
@@ -431,20 +417,71 @@ class TestGenerateReport(unittest.TestCase):
             self.assertIn('<p class="description">', content)
             self.assertIn("Final schedule", content)
 
-    def test_index_recovers_description_from_disk_alone(self) -> None:
-        """Rebuilding index.html must recover the description from the other report files."""
-        out2 = Path(self._tmpdir.name) / "out-desc-rebuilt"
+    def test_head_title_is_bare_page_title_without_a_run_name(self) -> None:
+        # setUp generates with no run name and draft=False.
+        self.assertIn(
+            "<title>All matches</title>",
+            (self.output_dir / "all-matches.html").read_text(),
+        )
+        self.assertIn(
+            "<title>Division 1</title>",
+            (self.output_dir / "division-1.html").read_text(),
+        )
+        self.assertIn(
+            "<title>Harrow</title>",
+            (self.output_dir / "club-harrow.html").read_text(),
+        )
+        self.assertIn("<title>Fixtures</title>", self.index_path.read_text())
+
+    def test_head_title_carries_run_name_club_or_division_and_draft(self) -> None:
+        out2 = Path(self._tmpdir.name) / "out-head-title"
         index_path = _generate(
             self.fixtures,
             self.teams,
             self.clubs,
             out2,
-            description="Test description.",
+            name="2025-26 Season",
+            draft=True,
         )
-        index_path.unlink()
-        rebuilt_path = htmlreport.build_run_index(out2)
-        content = rebuilt_path.read_text()
-        self.assertIn('<p class="description">Test description.</p>', content)
+        self.assertIn("<title>2025-26 Season (DRAFT)</title>", index_path.read_text())
+        self.assertIn(
+            "<title>2025-26 Season – All matches (DRAFT)</title>",
+            (out2 / "all-matches.html").read_text(),
+        )
+        self.assertIn(
+            "<title>2025-26 Season – Division 1 (DRAFT)</title>",
+            (out2 / "division-1.html").read_text(),
+        )
+        self.assertIn(
+            "<title>2025-26 Season – Harrow (DRAFT)</title>",
+            (out2 / "club-harrow.html").read_text(),
+        )
+
+    def test_head_title_omits_draft_marker_for_non_draft_runs(self) -> None:
+        out2 = Path(self._tmpdir.name) / "out-head-title-final"
+        index_path = _generate(
+            self.fixtures, self.teams, self.clubs, out2, name="2025-26 Season"
+        )
+        self.assertIn("<title>2025-26 Season</title>", index_path.read_text())
+        self.assertIn(
+            "<title>2025-26 Season – Division 1</title>",
+            (out2 / "division-1.html").read_text(),
+        )
+
+    def test_nav_link_labels_stay_bare_despite_richer_head_titles(self) -> None:
+        out2 = Path(self._tmpdir.name) / "out-nav-labels"
+        index_path = _generate(
+            self.fixtures,
+            self.teams,
+            self.clubs,
+            out2,
+            name="2025-26 Season",
+            draft=True,
+        )
+        content = index_path.read_text()
+        self.assertIn(">All matches</a>", content)
+        self.assertIn(">Division 1</a>", content)
+        self.assertNotIn("2025-26 Season – Division 1</a>", content)
 
 
 class TestExcludedFixturesInReport(unittest.TestCase):
@@ -550,6 +587,10 @@ class TestWriteRunsIndex(unittest.TestCase):
         htmlreport.write_runs_index(self.runs_dir, self.index_path)
         content = self.index_path.read_text()
         self.assertIn("No runs yet", content)
+
+    def test_head_title_of_top_level_index(self) -> None:
+        htmlreport.write_runs_index(self.runs_dir, self.index_path)
+        self.assertIn("<title>Fixture runs</title>", self.index_path.read_text())
 
     def test_lists_runs_with_report_only(self) -> None:
         for name in ["2024-25-season", "2025-26-season"]:


### PR DESCRIPTION
The <title> of every report page now carries the run name, then the club/division/section name (except on the run's own home page), then a "(DRAFT)" marker for draft runs, instead of a bare "Fixtures"/"Division 1". Any run description already showed on every page including the index.

While here, stop deriving each run's index.html by writing the report pages, globbing them back off disk and regex-parsing their HTML for the titles/run name/draft status. That round-trip was a leftover from when the report HTML was committed and the index had to be rebuildable standalone (removed in #46); every entrypoint now starts from spec + solution, so generate_report builds the index directly from the same data it renders the pages from. Removes build_run_index and the _page_* HTML scrapers; write_runs_index still derives the top-level index from the run folders on disk (folder layout is all it needs).

Verified the rendered runs/example is byte-identical to before apart from the intended <title> changes.


Claude-Session: https://claude.ai/code/session_01GzgEkKmeFwQCfEwgNpKhEw