### PR TITLE
Add per-club and per-team CSV exports, linked from club pages

### DIFF
--- a/csvreport.py
+++ b/csvreport.py
@@ -14,23 +14,31 @@
 
 """Render a solved fixture list as CSV, for importing into other tools.
 
-Two files are written, covering every division (there's a ``division`` column
-to filter on):
+Two whole-season files are written, covering every division (there's a
+``division`` column to filter on):
 
 * ``all-matches.csv`` -- one row per match, ``home_team`` vs ``away_team``.
 * ``all-matches-by-team.csv`` -- two rows per match, one from each team's point
   of view (``team``, ``opponent``, ``home_or_away``), so a club can pull just
   its own team's fixtures straight into a calendar.
 
-Each team is given as its display name, its club's name (``*_club``, e.g.
-``Albany``) and its index within that club (``*_index``, e.g. ``1``), so the
-club and team number are available directly even when the display name is a
-``name_override``.
+Then, for each team, ``team-<club-slug>-<index>.csv`` -- exactly the
+``all-matches-by-team.csv`` rows for that one team; and for each club,
+``club-<club-slug>-dates.csv`` -- one row per date the club is in action, holding
+that ``date`` and a comma-separated, home-team-order list of the club's matches
+(home and away) that day as ``home - away``, to join onto a calendar spreadsheet
+by date.
 
-Both files list withheld matches (a spec's ``exclude_fixtures``) too, with an
-empty ``date``, mirroring the HTML report's "TBC" rows. Dates are ISO
-``yyyy-mm-dd``; venue, start time and time limit are always the home team's
-club's, as in the HTML report.
+In the whole-season and per-team files each team is given as its display name,
+its club's name (``*_club``, e.g. ``Albany``) and its index within that club
+(``*_index``, e.g. ``1``), so the club and team number are available directly
+even when the display name is a ``name_override``.
+
+Every file lists withheld matches (a spec's ``exclude_fixtures``) too with an
+empty ``date`` -- one row each in the whole-season and per-team files, all
+together on a single trailing row in the per-club file -- mirroring the HTML
+report's "TBC" rows. Dates are ISO ``yyyy-mm-dd``; venue, start time and time
+limit are always the home team's club's, as in the HTML report.
 """
 
 from __future__ import annotations
@@ -50,6 +58,8 @@ if TYPE_CHECKING:
 
 ALL_MATCHES_FILENAME = "all-matches.csv"
 BY_TEAM_FILENAME = "all-matches-by-team.csv"
+
+_CLUB_BY_DATE_HEADER = ["date", "matches"]
 
 _ALL_MATCHES_HEADER = [
     "date",
@@ -155,6 +165,32 @@ def _all_matches_rows(
     return rows
 
 
+def _one_team_rows(
+    team: fmodel.Team,
+    fixtures: Collection[fmodel.ScheduledFixture],
+    excluded_fixtures: Collection[fmodel.Fixture],
+    clubs: Mapping[str, fmodel.Club],
+) -> list[list[str]]:
+    """The by-team rows for a single team: its scheduled matches by date then
+    opponent, then any withheld matches (empty date) by opponent."""
+    rows: list[list[str]] = []
+    team_fixtures = [
+        sf for sf in fixtures if team in (sf.fixture.home_team, sf.fixture.away_team)
+    ]
+    for sf in reportdata.by_date_opponent(team, team_fixtures, clubs):
+        rows.append(_team_row(team, sf.fixture, sf.date, clubs))
+
+    team_excluded = [f for f in excluded_fixtures if team in (f.home_team, f.away_team)]
+    for f in sorted(
+        team_excluded,
+        key=lambda f: reportdata.team_sort_key(
+            f.away_team if f.home_team == team else f.home_team, clubs
+        ),
+    ):
+        rows.append(_team_row(team, f, None, clubs))
+    return rows
+
+
 def _by_team_rows(
     teams: Collection[fmodel.Team],
     fixtures: Collection[fmodel.ScheduledFixture],
@@ -163,24 +199,50 @@ def _by_team_rows(
 ) -> list[list[str]]:
     rows: list[list[str]] = []
     for team in sorted(teams, key=lambda t: reportdata.team_sort_key(t, clubs)):
-        team_fixtures = [
-            sf
-            for sf in fixtures
-            if team in (sf.fixture.home_team, sf.fixture.away_team)
-        ]
-        for sf in reportdata.by_date_opponent(team, team_fixtures, clubs):
-            rows.append(_team_row(team, sf.fixture, sf.date, clubs))
+        rows += _one_team_rows(team, fixtures, excluded_fixtures, clubs)
+    return rows
 
-        team_excluded = [
-            f for f in excluded_fixtures if team in (f.home_team, f.away_team)
+
+def _match_description(
+    fixture: fmodel.Fixture, clubs: Mapping[str, fmodel.Club]
+) -> str:
+    """A match as one string for the per-club file's list, e.g. ``Harrow 1 - Ealing 1``
+    (home team first)."""
+    return (
+        f"{reportdata.team_name(fixture.home_team, clubs)} - "
+        f"{reportdata.team_name(fixture.away_team, clubs)}"
+    )
+
+
+def _club_by_date_rows(
+    club_id: str,
+    fixtures: Collection[fmodel.ScheduledFixture],
+    excluded_fixtures: Collection[fmodel.Fixture],
+    clubs: Mapping[str, fmodel.Club],
+) -> list[list[str]]:
+    """One row per date club_id is in action: the ISO date and a comma-separated,
+    home-team-order list of that club's matches (home and away) that day. Any
+    withheld matches are listed together on a single trailing empty-date row,
+    matching the other exports."""
+    club_fixtures = [
+        sf
+        for sf in fixtures
+        if club_id in (sf.fixture.home_team.club, sf.fixture.away_team.club)
+    ]
+    by_date: dict[date, list[str]] = {}
+    for sf in reportdata.by_date_home_away(club_fixtures, clubs, with_division=True):
+        by_date.setdefault(sf.date, []).append(_match_description(sf.fixture, clubs))
+    rows = [[_iso(d), ", ".join(matches)] for d, matches in sorted(by_date.items())]
+
+    club_excluded = [
+        f for f in excluded_fixtures if club_id in (f.home_team.club, f.away_team.club)
+    ]
+    if club_excluded:
+        descriptions = [
+            _match_description(f, clubs)
+            for f in reportdata.by_home_away(club_excluded, clubs, with_division=True)
         ]
-        for f in sorted(
-            team_excluded,
-            key=lambda f: reportdata.team_sort_key(
-                f.away_team if f.home_team == team else f.home_team, clubs
-            ),
-        ):
-            rows.append(_team_row(team, f, None, clubs))
+        rows.append(["", ", ".join(descriptions)])
     return rows
 
 
@@ -201,8 +263,9 @@ def generate_csv(
 
     `spec` supplies the teams, clubs and any excluded_fixtures (withheld matches,
     written with an empty date); `fixtures` is the solved schedule for it. See the
-    module docstring for the two files and their columns. Returns the paths
-    written, in the order (all-matches, all-matches-by-team).
+    module docstring for the files and their columns. Returns the paths written,
+    in the order: all-matches, all-matches-by-team, then one club-<slug>-dates.csv
+    per club and one team-<slug>.csv per team (each group in (club, index) order).
     """
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -210,12 +273,15 @@ def generate_csv(
     clubs = spec.clubs
     excluded_fixtures = spec.parameters.excluded_fixtures
 
+    paths: list[Path] = []
+
     all_matches_path = output_dir / ALL_MATCHES_FILENAME
     _write_csv(
         all_matches_path,
         _ALL_MATCHES_HEADER,
         _all_matches_rows(fixtures, excluded_fixtures, clubs),
     )
+    paths.append(all_matches_path)
 
     by_team_path = output_dir / BY_TEAM_FILENAME
     _write_csv(
@@ -223,5 +289,25 @@ def generate_csv(
         _BY_TEAM_HEADER,
         _by_team_rows(teams, fixtures, excluded_fixtures, clubs),
     )
+    paths.append(by_team_path)
 
-    return [all_matches_path, by_team_path]
+    club_ids = sorted({t.club for t in teams}, key=lambda cid: clubs[cid].name)
+    for club_id in club_ids:
+        path = output_dir / reportdata.club_dates_csv_filename(club_id)
+        _write_csv(
+            path,
+            _CLUB_BY_DATE_HEADER,
+            _club_by_date_rows(club_id, fixtures, excluded_fixtures, clubs),
+        )
+        paths.append(path)
+
+    for team in sorted(teams, key=lambda t: reportdata.team_sort_key(t, clubs)):
+        path = output_dir / reportdata.team_csv_filename(team)
+        _write_csv(
+            path,
+            _BY_TEAM_HEADER,
+            _one_team_rows(team, fixtures, excluded_fixtures, clubs),
+        )
+        paths.append(path)
+
+    return paths

--- a/csvreport_test.py
+++ b/csvreport_test.py
@@ -113,16 +113,27 @@ class CsvReportTest(unittest.TestCase):
         with (self.out / name).open(newline="") as f:
             return list(csv.DictReader(f))
 
-    def test_writes_both_files_and_returns_their_paths(self) -> None:
+    def test_writes_all_files_and_returns_their_paths(self) -> None:
         paths = _generate_csv(self.fixtures, self.teams, self.clubs, self.out)
         self.assertEqual(
-            paths,
+            [p.name for p in paths],
             [
-                self.out / "all-matches.csv",
-                self.out / "all-matches-by-team.csv",
+                "all-matches.csv",
+                "all-matches-by-team.csv",
+                # One per club, in club-name order.
+                "club-ealing-dates.csv",
+                "club-harrow-dates.csv",
+                "club-hendon-dates.csv",
+                # One per team, in (club, index) order.
+                "team-ealing-1.csv",
+                "team-harrow-1.csv",
+                "team-harrow-2.csv",
+                "team-hendon-1.csv",
+                "team-hendon-2.csv",
             ],
         )
         for p in paths:
+            self.assertEqual(p.parent, self.out)
             self.assertTrue(p.exists())
 
     def test_header_columns(self) -> None:
@@ -259,6 +270,91 @@ class CsvReportTest(unittest.TestCase):
         harrow1_rows = [r for r in team_rows if r["team"] == "Harrow 1"]
         self.assertEqual(harrow1_rows[-1]["date"], "")
         self.assertEqual(harrow1_rows[-1]["opponent"], "Harrow 2")
+
+    def test_per_team_file_is_the_by_team_rows_for_that_team(self) -> None:
+        _generate_csv(self.fixtures, self.teams, self.clubs, self.out)
+
+        def header(name: str) -> list[str]:
+            with (self.out / name).open(newline="") as f:
+                return next(csv.reader(f))
+
+        # Same columns as the whole-season by-team file.
+        self.assertEqual(header("team-harrow-1.csv"), header("all-matches-by-team.csv"))
+
+        team_rows = self._rows("team-harrow-1.csv")
+        self.assertEqual([r["team"] for r in team_rows], ["Harrow 1", "Harrow 1"])
+        self.assertEqual(
+            [(r["date"], r["opponent"], r["home_or_away"]) for r in team_rows],
+            [("2025-09-01", "Ealing 1", "home"), ("2025-09-08", "Ealing 1", "away")],
+        )
+        # It's exactly the all-matches-by-team.csv slice for this team.
+        by_team = [
+            r for r in self._rows("all-matches-by-team.csv") if r["team"] == "Harrow 1"
+        ]
+        self.assertEqual(team_rows, by_team)
+
+    def test_per_team_file_uses_name_override(self) -> None:
+        _generate_csv(self.fixtures, self.teams, self.clubs, self.out)
+        rows = self._rows("team-hendon-2.csv")
+        self.assertEqual([r["team"] for r in rows], ["Hendon Warriors"])
+        self.assertEqual(rows[0]["opponent"], "Hendon 1")
+
+    def test_per_club_file_one_row_per_date_listing_that_clubs_matches(self) -> None:
+        _generate_csv(self.fixtures, self.teams, self.clubs, self.out)
+
+        with (self.out / "club-harrow-dates.csv").open(newline="") as f:
+            self.assertEqual(next(csv.reader(f)), ["date", "matches"])
+
+        rows = self._rows("club-harrow-dates.csv")
+        self.assertEqual(
+            [(r["date"], r["matches"]) for r in rows],
+            [
+                ("2025-09-01", "Harrow 1 - Ealing 1"),
+                ("2025-09-08", "Ealing 1 - Harrow 1"),
+            ],
+        )
+        # Ealing's own file covers the same two matches (Ealing plays in both)...
+        self.assertEqual(len(self._rows("club-ealing-dates.csv")), 2)
+        # ...but Hendon's does not.
+        hendon = self._rows("club-hendon-dates.csv")
+        self.assertEqual([r["date"] for r in hendon], ["2025-09-03"])
+        self.assertEqual(hendon[0]["matches"], "Hendon 1 - Hendon Warriors")
+
+    def test_per_club_file_joins_same_day_matches_with_commas(self) -> None:
+        # Two Harrow teams both playing on 2025-09-01.
+        fixtures = [
+            _sf(self.harrow1, self.ealing1, date(2025, 9, 1)),
+            _sf(self.harrow2, self.hendon1, date(2025, 9, 1)),
+        ]
+        _generate_csv(fixtures, self.teams, self.clubs, self.out)
+
+        rows = self._rows("club-harrow-dates.csv")
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["date"], "2025-09-01")
+        self.assertEqual(rows[0]["matches"], "Harrow 1 - Ealing 1, Harrow 2 - Hendon 1")
+
+    def test_per_club_and_per_team_list_excluded_fixtures_with_empty_date(self) -> None:
+        excluded = [fmodel.Fixture(home_team=self.harrow1, away_team=self.harrow2)]
+        _generate_csv(
+            self.fixtures,
+            self.teams,
+            self.clubs,
+            self.out,
+            excluded_fixtures=excluded,
+        )
+
+        # Per-club: a single trailing empty-date row gathering the withheld matches.
+        club_rows = self._rows("club-harrow-dates.csv")
+        self.assertEqual(club_rows[-1]["date"], "")
+        self.assertEqual(club_rows[-1]["matches"], "Harrow 1 - Harrow 2")
+        self.assertTrue(all(r["date"] for r in club_rows[:-1]))
+        # A club not involved in the withheld match gets no empty-date row.
+        self.assertTrue(all(r["date"] for r in self._rows("club-hendon-dates.csv")))
+
+        # Per-team: an empty-date row at the end, as in all-matches-by-team.csv.
+        team_rows = self._rows("team-harrow-1.csv")
+        self.assertEqual(team_rows[-1]["date"], "")
+        self.assertEqual(team_rows[-1]["opponent"], "Harrow 2")
 
     def test_empty_fixture_list_writes_header_only(self) -> None:
         _generate_csv([], [], self.clubs, self.out)

--- a/htmlreport.py
+++ b/htmlreport.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import dataclasses
 import html
-import re
 from collections import defaultdict
 from collections.abc import Collection, Mapping
 from datetime import date
@@ -59,6 +58,7 @@ _STYLE = """
     nav ul ul { padding-left: 1.2rem; margin-top: 0.3rem; }
     .venue { margin-top: -0.5rem; margin-bottom: 1.5rem; color: #333; }
     .date-summary { margin-top: -1.5rem; margin-bottom: 2rem; color: #333; }
+    .export-link { margin-top: -1rem; margin-bottom: 2rem; }
     ul.venues { padding-left: 1.2rem; }
     ul.venues li { margin-bottom: 0.3rem; }
     .anchor-link { margin-left: 0.4rem; font-size: 0.8em; text-decoration: none;
@@ -70,12 +70,6 @@ _STYLE = """
         th, td { padding: 0.4rem 0.5rem; white-space: nowrap; }
     }
 """
-
-
-def slugify(value: str) -> str:
-    """Turn a name into a filesystem/URL-safe slug, e.g. 'Willesden & Brent' -> 'willesden-brent'."""
-    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
-    return slug or "unnamed"
 
 
 def _fmt_date(d: date) -> str:
@@ -327,6 +321,12 @@ def _scheme_label(
     return "Single-round all-play-all" if single else "Double-round all-play-all"
 
 
+def _csv_link(filename: str, label: str) -> str:
+    """A short paragraph linking a CSV export sitting next to the page, shown only
+    when csvreport.generate_csv has actually written that file."""
+    return f'<p class="export-link"><a href="{filename}">{html.escape(label)}</a></p>\n'
+
+
 def _venue_header(club: fmodel.Club) -> str:
     return (
         f'<p class="venue"><strong>{html.escape(club.home_venue_name)}</strong><br>\n'
@@ -429,9 +429,11 @@ def generate_report(
     in a later run; these are appended to the bottom of every relevant table with
     "TBC" in place of a date). `fixtures` is the solved schedule for that spec.
 
-    The index links whichever all-matches.csv / all-matches-by-team.csv exports
-    are already present in output_dir (csvreport.generate_csv writes them), so
-    run that first if the index should link them.
+    Wherever csvreport.generate_csv has already written its exports into
+    output_dir, they get linked too: all-matches.csv / all-matches-by-team.csv
+    from the run index, each club's club-<slug>-dates.csv from its club page, and
+    each team's team-<slug>.csv from that team's section. Run generate_csv first
+    if those links are wanted.
 
     Returns the path to the run's index.html.
     """
@@ -531,6 +533,9 @@ def generate_report(
             )
             + _club_date_summary(club_id, fixtures_by_club.get(club_id, []))
         )
+        club_csv = reportdata.club_dates_csv_filename(club_id)
+        if (output_dir / club_csv).exists():
+            body += _csv_link(club_csv, "Download CSV (one row per match date)")
         for team in sorted(teams_by_club[club_id], key=lambda t: t.index):
             team_fixtures = [
                 sf
@@ -543,7 +548,7 @@ def generate_report(
                 if f.home_team == team or f.away_team == team
             ]
             team_name = reportdata.team_name(team, clubs)
-            body += _anchored_heading(2, team_name, slugify(team_name))
+            body += _anchored_heading(2, team_name, reportdata.slugify(team_name))
             scheme_label = _scheme_label(schemes, team.division)
             body += f"<h3>Division {team.division} ({html.escape(scheme_label)})</h3>\n"
             body += _table(
@@ -551,7 +556,10 @@ def generate_report(
                 _team_rows(team, team_fixtures, clubs)
                 + _excluded_team_rows(team, team_excluded, clubs),
             )
-        club_slug = slugify(club_id)
+            team_csv = reportdata.team_csv_filename(team)
+            if (output_dir / team_csv).exists():
+                body += _csv_link(team_csv, "Download CSV")
+        club_slug = reportdata.slugify(club_id)
         (output_dir / f"club-{club_slug}.html").write_text(
             _page(club_name, body, name, draft, description)
         )

--- a/htmlreport_test.py
+++ b/htmlreport_test.py
@@ -79,20 +79,6 @@ def _club(
     )
 
 
-class TestSlugify(unittest.TestCase):
-    def test_simple(self) -> None:
-        self.assertEqual(htmlreport.slugify("Albany"), "albany")
-
-    def test_spaces_and_punctuation(self) -> None:
-        self.assertEqual(htmlreport.slugify("Willesden & Brent"), "willesden-brent")
-
-    def test_leading_trailing_punctuation(self) -> None:
-        self.assertEqual(htmlreport.slugify("  Kings Head!!"), "kings-head")
-
-    def test_empty(self) -> None:
-        self.assertEqual(htmlreport.slugify("---"), "unnamed")
-
-
 class TestGenerateReport(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -335,6 +321,38 @@ class TestGenerateReport(unittest.TestCase):
     def test_run_index_has_no_csv_links_when_exports_absent(self) -> None:
         # setUp's _generate() writes HTML pages only, no CSV files.
         self.assertNotIn(".csv", self.index_path.read_text())
+
+    def test_club_page_links_per_club_and_per_team_csv_when_present(self) -> None:
+        # generate_report links the per-club / per-team exports it finds already
+        # written into the output dir (csvreport.generate_csv writes them).
+        for name in ("club-harrow-dates.csv", "team-harrow-1.csv", "team-harrow-2.csv"):
+            (self.output_dir / name).write_text("date\n")
+
+        _generate(self.fixtures, self.teams, self.clubs, self.output_dir)
+        harrow_page = (self.output_dir / "club-harrow.html").read_text()
+
+        # Per-club link sits under the consolidated table, ahead of the first team.
+        self.assertIn(
+            '<p class="export-link"><a href="club-harrow-dates.csv">', harrow_page
+        )
+        self.assertLess(
+            harrow_page.index("club-harrow-dates.csv"),
+            harrow_page.index('<h2 id="harrow-1">'),
+        )
+        # Each team section links its own file, under that team's table.
+        h1_section = harrow_page.split('<h2 id="harrow-1">')[1].split("<h2")[0]
+        self.assertIn(
+            '<p class="export-link"><a href="team-harrow-1.csv">Download CSV</a></p>',
+            h1_section,
+        )
+        self.assertLess(
+            h1_section.index("</table>"), h1_section.index("team-harrow-1.csv")
+        )
+        self.assertNotIn("team-harrow-2.csv", h1_section)
+
+    def test_club_page_has_no_csv_links_when_exports_absent(self) -> None:
+        # setUp's _generate() writes HTML pages only, no CSV files.
+        self.assertNotIn(".csv", (self.output_dir / "club-harrow.html").read_text())
 
     def test_division_numbers_sort_numerically_not_lexically(self) -> None:
         clubs = {"c": _club("C"), "d": _club("D")}

--- a/report_test.py
+++ b/report_test.py
@@ -83,7 +83,14 @@ class TestReport(unittest.TestCase):
     def test_also_writes_csv_exports(self) -> None:
         report.report(self.spec_path, self.solution_path, self.output_dir)
 
-        for name in ("all-matches.csv", "all-matches-by-team.csv"):
+        for name in (
+            "all-matches.csv",
+            "all-matches-by-team.csv",
+            "club-albany-dates.csv",
+            "club-hackney-dates.csv",
+            "team-albany-1.csv",
+            "team-hackney-1.csv",
+        ):
             self.assertTrue((self.output_dir / name).exists(), f"{name} not written")
         self.assertIn("Albany 1", (self.output_dir / "all-matches.csv").read_text())
 
@@ -93,6 +100,13 @@ class TestReport(unittest.TestCase):
         index = (self.output_dir / "index.html").read_text()
         self.assertIn('href="all-matches.csv"', index)
         self.assertIn('href="all-matches-by-team.csv"', index)
+
+    def test_club_page_links_its_per_club_and_per_team_csv(self) -> None:
+        report.report(self.spec_path, self.solution_path, self.output_dir)
+
+        club_page = (self.output_dir / "club-albany.html").read_text()
+        self.assertIn('href="club-albany-dates.csv"', club_page)
+        self.assertIn('href="team-albany-1.csv"', club_page)
 
     def test_does_not_require_resolving(self) -> None:
         """Deleting nothing but the intermediate solving step should still work:

--- a/reportdata.py
+++ b/reportdata.py
@@ -23,12 +23,32 @@ or produces any markup.
 from __future__ import annotations
 
 import dataclasses
+import re
 from collections.abc import Collection, Mapping
 from datetime import date
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import fmodel
+
+
+def slugify(value: str) -> str:
+    """Turn a name into a filesystem/URL-safe slug, e.g. 'Willesden & Brent' -> 'willesden-brent'."""
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "unnamed"
+
+
+def club_dates_csv_filename(club_id: str) -> str:
+    """Filename of a club's by-date CSV export (one row per match date), a sibling
+    of its ``club-<slug>.html`` page. The ``-dates`` suffix leaves room for other
+    per-club CSVs alongside it later."""
+    return f"club-{slugify(club_id)}-dates.csv"
+
+
+def team_csv_filename(team: fmodel.Team) -> str:
+    """Filename of a single team's CSV export -- the by-team CSV filtered to that
+    team -- linked from the team's section of its club page."""
+    return f"team-{slugify(team.club)}-{team.index}.csv"
 
 
 def team_name(team: fmodel.Team, clubs: Mapping[str, fmodel.Club]) -> str:

--- a/reportdata_test.py
+++ b/reportdata_test.py
@@ -37,6 +37,40 @@ def _club(name: str) -> fmodel.Club:
     )
 
 
+class TestSlugify(unittest.TestCase):
+    def test_simple(self) -> None:
+        self.assertEqual(reportdata.slugify("Albany"), "albany")
+
+    def test_spaces_and_punctuation(self) -> None:
+        self.assertEqual(reportdata.slugify("Willesden & Brent"), "willesden-brent")
+
+    def test_leading_trailing_punctuation(self) -> None:
+        self.assertEqual(reportdata.slugify("  Kings Head!!"), "kings-head")
+
+    def test_empty(self) -> None:
+        self.assertEqual(reportdata.slugify("---"), "unnamed")
+
+
+class TestCsvFilenames(unittest.TestCase):
+    def test_club_dates_csv_filename_is_the_club_slug_with_a_dates_suffix(self) -> None:
+        self.assertEqual(
+            reportdata.club_dates_csv_filename("willesden-brent"),
+            "club-willesden-brent-dates.csv",
+        )
+
+    def test_team_csv_filename_is_club_slug_plus_index(self) -> None:
+        team = fmodel.Team(division=2, club="willesden-brent", index=3)
+        self.assertEqual(
+            reportdata.team_csv_filename(team), "team-willesden-brent-3.csv"
+        )
+
+    def test_team_csv_filename_ignores_name_override(self) -> None:
+        team = fmodel.Team(
+            division=1, club="hendon", index=2, name_override="Hendon Warriors"
+        )
+        self.assertEqual(reportdata.team_csv_filename(team), "team-hendon-2.csv")
+
+
 class ReportDataTest(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()


### PR DESCRIPTION
csvreport.generate_csv now also writes, for each run:

* team-<club-slug>-<index>.csv -- the all-matches-by-team.csv rows for that one team, linked under the team's table on its club page.
* club-<club-slug>-dates.csv -- one row per date the club is in action, holding the date and a comma-separated "home - away" list of the club's matches that day, for joining onto a calendar spreadsheet by date; linked under the club's consolidated table. The -dates suffix leaves room for other per-club CSVs later.

slugify moves to reportdata (shared by both renderers) alongside new club_dates_csv_filename / team_csv_filename helpers; htmlreport links each export only where generate_csv has actually written it, as it already did for the whole-season files.


Claude-Session: https://claude.ai/code/session_014xRoDLdVRiK8fMByxig45M