### PR TITLE
Carry the OR-Tools model/solver stats through to the report (closes #70)

### DIFF
--- a/fixturesolution.py
+++ b/fixturesolution.py
@@ -60,6 +60,17 @@ class _NoAliasDumper(yaml.SafeDumper):
         return True
 
 
+def _represent_str(dumper: yaml.SafeDumper, data: str) -> yaml.Node:
+    """Write any multi-line string (i.e. the stored stats blocks) as a literal
+    block scalar rather than PyYAML's default one-line double-quoted form with
+    escaped newlines, so the solution file stays readable and diffable."""
+    style = "|" if "\n" in data else None
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data, style=style)
+
+
+_NoAliasDumper.add_representer(str, _represent_str)
+
+
 def _team_id(
     team: fmodel.Team, ids_by_club_index: Mapping[tuple[str, int], str]
 ) -> str:
@@ -73,15 +84,20 @@ def _team_id(
 
 
 def save_solution(
-    fixtures: Collection[fmodel.ScheduledFixture],
+    result: fmodel.SolveResult,
     team_ids: Mapping[str, tuple[str, int]],
     path: Path,
 ) -> None:
-    """Write a solved fixture list to path in the canonical solution YAML format.
+    """Write a solve result to path in the canonical solution YAML format.
 
     team_ids maps each team ID in the spec that was solved to its (club, index)
     pair (see fixturespec.load_team_ids()) -- used to translate fmodel.Team,
     which doesn't carry a spec team ID, back into one.
+
+    result.model_stats/result.solve_stats, when non-empty, are written under a
+    trailing "stats" key so the OR-Tools summaries travel with the schedule to
+    the report; empty strings leave the key out entirely. load_solution()
+    reverses this exactly, back into an fmodel.SolveResult.
     """
     ids_by_club_index = {
         club_index: team_id for team_id, club_index in team_ids.items()
@@ -92,12 +108,16 @@ def save_solution(
             "away": _team_id(sf.fixture.away_team, ids_by_club_index),
             "date": sf.date,
         }
-        for sf in fixtures
+        for sf in result.fixtures
     ]
     entries.sort(key=lambda e: (e["date"], e["home"], e["away"]))
-    path.write_text(
-        yaml.dump({"fixtures": entries}, Dumper=_NoAliasDumper, sort_keys=False)
-    )
+    document: dict[str, Any] = {"fixtures": entries}
+    if result.model_stats or result.solve_stats:
+        document["stats"] = {
+            "model": result.model_stats,
+            "solve": result.solve_stats,
+        }
+    path.write_text(yaml.dump(document, Dumper=_NoAliasDumper, sort_keys=False))
 
 
 _REQUIRED_FIXTURE_FIELDS = {"home", "away", "date"}
@@ -115,15 +135,35 @@ def _resolve_team(
     return teams_by_id[team_id]
 
 
+def _load_stats(data: dict[str, Any], path: Path) -> tuple[str, str]:
+    """Pull the optional model/solve summary text out of a loaded solution
+    document. A file with no 'stats' key (one written before it was recorded)
+    yields two empty strings."""
+    stats = data.get("stats")
+    if stats is None:
+        return "", ""
+    if not isinstance(stats, dict):
+        raise SolutionError(f"{path}: 'stats' must be a mapping")
+    model_stats = stats.get("model", "")
+    solve_stats = stats.get("solve", "")
+    if not isinstance(model_stats, str) or not isinstance(solve_stats, str):
+        raise SolutionError(f"{path}: 'stats.model' and 'stats.solve' must be strings")
+    return model_stats, solve_stats
+
+
 def load_solution(
     path: Path,
     teams: Collection[fmodel.Team],
     team_ids: Mapping[str, tuple[str, int]],
-) -> list[fmodel.ScheduledFixture]:
-    """Load a solution YAML file, resolving each entry's home/away team ID via
-    team_ids and teams (normally fixturespec.load_team_ids() and
-    spec.parameters.teams from the spec the solution was solved from) to recover
-    full Team objects (division, name_override, etc.).
+) -> fmodel.SolveResult:
+    """Load a solution YAML file back into an fmodel.SolveResult, resolving each
+    entry's home/away team ID via team_ids and teams (normally
+    fixturespec.load_team_ids() and spec.parameters.teams from the spec the
+    solution was solved from) to recover full Team objects (division,
+    name_override, etc.).
+
+    Any model/solver summary text stored under the file's 'stats' key comes back
+    on the result too (empty strings if the file predates it).
     """
     with path.open() as f:
         data = yaml.safe_load(f)
@@ -134,6 +174,8 @@ def load_solution(
     fixtures_spec = data["fixtures"]
     if not isinstance(fixtures_spec, list):
         raise SolutionError(f"{path}: 'fixtures' must be a list")
+
+    model_stats, solve_stats = _load_stats(data, path)
 
     teams_by_club_index = {(t.club, t.index): t for t in teams}
     teams_by_id = {
@@ -176,4 +218,6 @@ def load_solution(
                 date=fixture_date,
             )
         )
-    return result
+    return fmodel.SolveResult(
+        fixtures=result, model_stats=model_stats, solve_stats=solve_stats
+    )

--- a/fixturesolution_test.py
+++ b/fixturesolution_test.py
@@ -53,29 +53,37 @@ class TestSaveAndLoadSolution(unittest.TestCase):
             _sf(_ALBANY_1, _HACKNEY_1, date(2025, 9, 1)),
             _sf(_HACKNEY_2, _ALBANY_1, date(2025, 9, 15)),
         ]
-        fixturesolution.save_solution(fixtures, _TEAM_IDS, self.path)
+        fixturesolution.save_solution(
+            fmodel.SolveResult(fixtures), _TEAM_IDS, self.path
+        )
 
         loaded = fixturesolution.load_solution(
             self.path, [_ALBANY_1, _HACKNEY_1, _HACKNEY_2], _TEAM_IDS
         )
-        self.assertCountEqual(loaded, fixtures)
+        self.assertCountEqual(loaded.fixtures, fixtures)
+        self.assertEqual(loaded.model_stats, "")
+        self.assertEqual(loaded.solve_stats, "")
 
     def test_load_recovers_division_and_name_override(self) -> None:
         """Loading resolves each entry against the given teams, so fields not stored
         in the solution file itself (division, name_override) come back correctly."""
         fixturesolution.save_solution(
-            [_sf(_HACKNEY_2, _ALBANY_1, date(2025, 9, 15))], _TEAM_IDS, self.path
+            fmodel.SolveResult([_sf(_HACKNEY_2, _ALBANY_1, date(2025, 9, 15))]),
+            _TEAM_IDS,
+            self.path,
         )
 
         [loaded] = fixturesolution.load_solution(
             self.path, [_ALBANY_1, _HACKNEY_1, _HACKNEY_2], _TEAM_IDS
-        )
+        ).fixtures
         self.assertEqual(loaded.fixture.home_team, _HACKNEY_2)
         self.assertEqual(loaded.fixture.home_team.name_override, "Hackney Herons")
 
     def test_written_format_uses_team_ids(self) -> None:
         fixturesolution.save_solution(
-            [_sf(_ALBANY_1, _HACKNEY_1, date(2025, 9, 1))], _TEAM_IDS, self.path
+            fmodel.SolveResult([_sf(_ALBANY_1, _HACKNEY_1, date(2025, 9, 1))]),
+            _TEAM_IDS,
+            self.path,
         )
         contents = self.path.read_text()
         self.assertIn("home: albany-1", contents)
@@ -92,7 +100,9 @@ class TestSaveAndLoadSolution(unittest.TestCase):
             _sf(_ALBANY_1, _HACKNEY_1, shared_date),
             _sf(_HACKNEY_2, _ALBANY_1, shared_date),
         ]
-        fixturesolution.save_solution(fixtures, _TEAM_IDS, self.path)
+        fixturesolution.save_solution(
+            fmodel.SolveResult(fixtures), _TEAM_IDS, self.path
+        )
         contents = self.path.read_text()
         self.assertNotIn("&id", contents)
         self.assertNotIn("*id", contents)
@@ -101,7 +111,7 @@ class TestSaveAndLoadSolution(unittest.TestCase):
     def test_save_unknown_team(self) -> None:
         with self.assertRaisesRegex(fixturesolution.SolutionError, "albany"):
             fixturesolution.save_solution(
-                [_sf(_ALBANY_1, _HACKNEY_1, date(2025, 9, 1))],
+                fmodel.SolveResult([_sf(_ALBANY_1, _HACKNEY_1, date(2025, 9, 1))]),
                 {"hackney-1": ("hackney", 1)},
                 self.path,
             )
@@ -136,11 +146,60 @@ class TestSaveAndLoadSolution(unittest.TestCase):
             fixturesolution.load_solution(self.path, [_ALBANY_1, _HACKNEY_1], _TEAM_IDS)
 
     def test_empty_fixtures_list(self) -> None:
-        fixturesolution.save_solution([], _TEAM_IDS, self.path)
+        fixturesolution.save_solution(fmodel.SolveResult([]), _TEAM_IDS, self.path)
         loaded = fixturesolution.load_solution(
             self.path, [_ALBANY_1, _HACKNEY_1], _TEAM_IDS
         )
-        self.assertEqual(loaded, [])
+        self.assertEqual(loaded.fixtures, [])
+
+    def test_stats_round_trip(self) -> None:
+        model_stats = "satisfaction model '':\n#Variables: 42\n"
+        solve_stats = "CpSolverResponse summary:\nstatus: OPTIMAL\n"
+        fixturesolution.save_solution(
+            fmodel.SolveResult(
+                [_sf(_ALBANY_1, _HACKNEY_1, date(2025, 9, 1))],
+                model_stats=model_stats,
+                solve_stats=solve_stats,
+            ),
+            _TEAM_IDS,
+            self.path,
+        )
+
+        loaded = fixturesolution.load_solution(
+            self.path, [_ALBANY_1, _HACKNEY_1], _TEAM_IDS
+        )
+        self.assertEqual(loaded.model_stats, model_stats)
+        self.assertEqual(loaded.solve_stats, solve_stats)
+
+    def test_stats_written_as_literal_block_scalars(self) -> None:
+        """The multi-line stats blocks should be written as readable YAML literal
+        blocks (|), not one-liners with escaped \\n."""
+        fixturesolution.save_solution(
+            fmodel.SolveResult(
+                [_sf(_ALBANY_1, _HACKNEY_1, date(2025, 9, 1))],
+                model_stats="line one\nline two\n",
+                solve_stats="status: OPTIMAL\n",
+            ),
+            _TEAM_IDS,
+            self.path,
+        )
+        contents = self.path.read_text()
+        self.assertIn("model: |", contents)
+        self.assertIn("    line one\n", contents)
+        self.assertNotIn("\\n", contents)
+
+    def test_stats_key_omitted_when_no_stats_given(self) -> None:
+        fixturesolution.save_solution(
+            fmodel.SolveResult([_sf(_ALBANY_1, _HACKNEY_1, date(2025, 9, 1))]),
+            _TEAM_IDS,
+            self.path,
+        )
+        self.assertNotIn("stats:", self.path.read_text())
+
+    def test_stats_not_a_mapping(self) -> None:
+        self.path.write_text("fixtures: []\nstats: nope\n")
+        with self.assertRaisesRegex(fixturesolution.SolutionError, "stats"):
+            fixturesolution.load_solution(self.path, [_ALBANY_1, _HACKNEY_1], _TEAM_IDS)
 
 
 if __name__ == "__main__":

--- a/fixturespec_test.py
+++ b/fixturespec_test.py
@@ -1554,7 +1554,7 @@ club_constraints:
             "      away: albany-2\n"
         )
         spec = fixturespec.load_spec(path)
-        fixtures = list(fmodel.solve(spec.parameters))
+        fixtures = list(fmodel.solve(spec.parameters).fixtures)
         albany1 = next(
             t for t in spec.parameters.teams if t.club == "albany" and t.index == 1
         )
@@ -1599,7 +1599,7 @@ club_constraints:
             _THREE_TEAM_SPEC + "latest_internal_match_date: 2025-10-15\n"
         )
         spec = fixturespec.load_spec(path)
-        fixtures = list(fmodel.solve(spec.parameters))
+        fixtures = list(fmodel.solve(spec.parameters).fixtures)
         albany1 = next(
             t for t in spec.parameters.teams if t.club == "albany" and t.index == 1
         )
@@ -1619,7 +1619,7 @@ club_constraints:
         """A loaded spec's Parameters should be usable directly with fmodel.solve()."""
         path = self._write(_MINIMAL_SPEC)
         spec = fixturespec.load_spec(path)
-        fixtures = list(fmodel.solve(spec.parameters))
+        fixtures = list(fmodel.solve(spec.parameters).fixtures)
         self.assertEqual(len(fixtures), 2)  # Albany v Hackney and Hackney v Albany
 
 

--- a/fmodel.py
+++ b/fmodel.py
@@ -19,7 +19,6 @@ import dataclasses
 import enum
 import functools
 import itertools
-import logging
 from collections.abc import Collection, Iterable, Mapping, MutableMapping
 from datetime import date
 from typing import Any
@@ -27,8 +26,6 @@ from typing import Any
 from ortools.sat.python import cp_model
 
 import berger
-
-logger = logging.getLogger(__name__)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -60,6 +57,25 @@ class Fixture:
 class ScheduledFixture:
     fixture: Fixture
     date: date
+
+
+@dataclasses.dataclass(frozen=True)
+class SolveResult:
+    """A solved schedule plus the OR-Tools model and solver summary text
+    (model.model_stats() and solver.response_stats()).
+
+    This is both what solve() returns and, via fixturesolution, exactly what a
+    solution.yaml round-trips to: save_solution() writes one out and
+    load_solution() reads one back, so the type is the single description of a
+    solution's on-disk contents. The stats are plain strings -- persisting and
+    rendering them (fixturesolution.save_solution into solution.yaml, the report's
+    "Solver diagnostics" section) needs no structure. They default to "" for a
+    solution file written before the text was recorded.
+    """
+
+    fixtures: list[ScheduledFixture]
+    model_stats: str = ""
+    solve_stats: str = ""
 
 
 ClubT = str
@@ -375,13 +391,81 @@ def date_windows(dates: Collection[date], window_days: int) -> list[frozenset[da
     return result
 
 
+class _FixtureVars:
+    """Every candidate (fixture, date) decision variable in the model, kept in the
+    several grouped forms the constraints read them back in.
+
+    _build_model calls register() once per candidate (fixture, date) as it creates
+    the variables; everything after that is read-only through the accessors. The
+    point is to keep the fan-out -- which groups a new variable belongs to -- in
+    one place, so _build_model and its constraint helpers read as constraints
+    rather than bookkeeping.
+    """
+
+    def __init__(self) -> None:
+        self._by_fixture_date: dict[tuple[Fixture, date], cp_model.IntVar] = {}
+        self._by_fixture: MutableMapping[Fixture, list[cp_model.IntVar]] = (
+            collections.defaultdict(list)
+        )
+        self._by_team_date: MutableMapping[
+            Team, MutableMapping[date, list[cp_model.IntVar]]
+        ] = collections.defaultdict(lambda: collections.defaultdict(list))
+        # One (club, date) -> vars map per ConcurrencyScope (see ConcurrencyScope
+        # for what each counts).
+        self._by_club_date: Mapping[
+            ConcurrencyScope, MutableMapping[tuple[ClubT, date], list[cp_model.IntVar]]
+        ] = {scope: collections.defaultdict(list) for scope in ConcurrencyScope}
+
+    def register(
+        self, fixture: Fixture, match_date: date, var: cp_model.IntVar
+    ) -> None:
+        """Record `var` as the decision variable for scheduling `fixture` on
+        `match_date`, adding it to each grouped view. Raises if that (fixture,
+        date) has already been registered (callers rely on the 1:1 mapping)."""
+        key = (fixture, match_date)
+        if key in self._by_fixture_date:
+            raise ValueError(
+                f"Duplicate variable for fixture {fixture.home_team.name} vs "
+                f"{fixture.away_team.name} on {match_date.isoformat()}"
+            )
+        home, away = fixture.home_team, fixture.away_team
+        self._by_fixture_date[key] = var
+        self._by_fixture[fixture].append(var)
+        self._by_team_date[home][match_date].append(var)
+        self._by_team_date[away][match_date].append(var)
+        self._by_club_date[ConcurrencyScope.HOME][home.club, match_date].append(var)
+        self._by_club_date[ConcurrencyScope.AWAY][away.club, match_date].append(var)
+        self._by_club_date[ConcurrencyScope.ANY][home.club, match_date].append(var)
+        if away.club != home.club:
+            self._by_club_date[ConcurrencyScope.ANY][away.club, match_date].append(var)
+
+    def fixture_date_vars(self) -> Mapping[tuple[Fixture, date], cp_model.IntVar]:
+        """The master map: the single bool var for each candidate (fixture, date)."""
+        return self._by_fixture_date
+
+    def per_fixture(self) -> Iterable[list[cp_model.IntVar]]:
+        """Each fixture's vars over all its candidate dates (exactly one is true)."""
+        return self._by_fixture.values()
+
+    def per_team_dates(self) -> Iterable[Mapping[date, list[cp_model.IntVar]]]:
+        """Per team, its vars grouped by date (for the min-gap window limit)."""
+        return self._by_team_date.values()
+
+    def by_club_date(
+        self, scope: ConcurrencyScope
+    ) -> Mapping[tuple[ClubT, date], list[cp_model.IntVar]]:
+        """Per (club, date), the vars counting towards `scope` (see ConcurrencyScope)."""
+        return self._by_club_date[scope]
+
+
 def _add_home_dates_used_constraints(
     model: cp_model.CpModel,
     home_dates_used: Mapping[ClubT, HomeDatesUsedBounds],
-    vars_by_club_home_date: Mapping[tuple[str, date], list[cp_model.IntVar]],
+    fixture_vars: _FixtureVars,
 ) -> None:
     """For each club in home_dates_used, bound the number of its home dates that
     end up hosting at least one match (below by `minimum`, above by `maximum`)."""
+    vars_by_club_home_date = fixture_vars.by_club_date(ConcurrencyScope.HOME)
     # Collect the set of home dates per club that appear in the variable map
     clubs_home_dates: MutableMapping[str, list[date]] = collections.defaultdict(list)
     for club, d in vars_by_club_home_date:
@@ -411,7 +495,7 @@ def _add_home_dates_used_constraints(
 def _add_avoid_coscheduling_constraints(
     model: cp_model.CpModel,
     constraints: Collection[AvoidCoschedulingConstraint],
-    vars_by_fixture_date: Mapping[tuple[Fixture, date], cp_model.IntVar],
+    fixture_vars: _FixtureVars,
 ) -> None:
     """For each AvoidCoschedulingConstraint, ensure at most one match involving any
     of its teams is scheduled within any window of within_days days. The constraint's
@@ -433,7 +517,7 @@ def _add_avoid_coscheduling_constraints(
         vars_by_date: MutableMapping[date, list[cp_model.IntVar]] = (
             collections.defaultdict(list)
         )
-        for (fixture, d), var in vars_by_fixture_date.items():
+        for (fixture, d), var in fixture_vars.fixture_date_vars().items():
             if (count_home and fixture.home_team in team_set) or (
                 count_away and fixture.away_team in team_set
             ):
@@ -448,9 +532,10 @@ def _add_avoid_coscheduling_constraints(
 def _add_fixed_fixtures_constraints(
     model: cp_model.CpModel,
     fixed_fixtures: Collection[ScheduledFixture],
-    vars_by_fixture_date: Mapping[tuple[Fixture, date], cp_model.IntVar],
+    fixture_vars: _FixtureVars,
 ) -> None:
     """Force each pre-specified fixture onto its given date."""
+    vars_by_fixture_date = fixture_vars.fixture_date_vars()
     for scheduled in fixed_fixtures:
         key = (scheduled.fixture, scheduled.date)
         var = vars_by_fixture_date.get(key)
@@ -469,28 +554,11 @@ def _add_fixed_fixtures_constraints(
         model.add(var == 1)
 
 
-def solve(params: Parameters) -> Collection[ScheduledFixture]:
+def _build_model(params: Parameters) -> tuple[cp_model.CpModel, _FixtureVars]:
+    """Build the CP-SAT model for params, returning it with the _FixtureVars the
+    schedule is read back off after solving."""
     model = cp_model.CpModel()
-
-    vars_by_fixture: MutableMapping[Fixture, list[cp_model.IntVar]] = (
-        collections.defaultdict(list)
-    )
-    vars_by_fixture_date: MutableMapping[tuple[Fixture, date], cp_model.IntVar] = {}
-    vars_by_team_date: MutableMapping[
-        Team, MutableMapping[date, list[cp_model.IntVar]]
-    ] = collections.defaultdict(lambda: collections.defaultdict(list))
-    vars_by_club_home_date: MutableMapping[tuple[str, date], list[cp_model.IntVar]] = (
-        collections.defaultdict(list)
-    )
-    vars_by_club_away_date: MutableMapping[tuple[str, date], list[cp_model.IntVar]] = (
-        collections.defaultdict(list)
-    )
-    # Every match either club's teams play on a date (an internal match, both teams
-    # the same club's, appears once): the ConcurrencyScope.ANY counterpart of the
-    # home/away maps above.
-    vars_by_club_any_date: MutableMapping[tuple[str, date], list[cp_model.IntVar]] = (
-        collections.defaultdict(list)
-    )
+    fixture_vars = _FixtureVars()
 
     excluded = set(params.excluded_fixtures)
     fixed_fixture_keys = {(sf.fixture, sf.date) for sf in params.fixed_fixtures}
@@ -520,74 +588,76 @@ def solve(params: Parameters) -> Collection[ScheduledFixture]:
                 var = model.new_bool_var(
                     f"{home_team.name}_vs_{away_team.name}_{match_date.isoformat()}"
                 )
-                key = (fixture, match_date)
-                if key in vars_by_fixture_date:
-                    raise ValueError(
-                        f"Duplicate variable for fixture {fixture.home_team.name} vs "
-                        f"{fixture.away_team.name} on {match_date.isoformat()}"
-                    )
-                vars_by_fixture[fixture].append(var)
-                vars_by_fixture_date[key] = var
-                vars_by_team_date[home_team][match_date].append(var)
-                vars_by_team_date[away_team][match_date].append(var)
-                vars_by_club_home_date[(home_team.club, match_date)].append(var)
-                vars_by_club_away_date[(away_team.club, match_date)].append(var)
-                vars_by_club_any_date[(home_team.club, match_date)].append(var)
-                if away_team.club != home_team.club:
-                    vars_by_club_any_date[(away_team.club, match_date)].append(var)
+                fixture_vars.register(fixture, match_date, var)
 
-    for fixture_vars in vars_by_fixture.values():
+    for scheduled_vars in fixture_vars.per_fixture():
         # Each fixture must be scheduled exactly once
-        model.add(cp_model.LinearExpr.Sum(fixture_vars) == 1)
+        model.add(cp_model.LinearExpr.Sum(scheduled_vars) == 1)
 
-    for team_vars_by_date in vars_by_team_date.values():
+    for team_date_vars in fixture_vars.per_team_dates():
         # Each team can play at most one match in each window. date_windows groups
         # dates up to and including window_days apart, so pass min_gap_days - 1: a
         # gap of exactly min_gap_days (e.g. two matches a week apart when
         # min_gap_days=7) must be allowed, not treated as a violation.
-        for window in date_windows(team_vars_by_date.keys(), params.min_gap_days - 1):
-            window_vars = [v for d in window for v in team_vars_by_date[d]]
+        for window in date_windows(team_date_vars.keys(), params.min_gap_days - 1):
+            window_vars = [v for d in window for v in team_date_vars[d]]
             model.add(cp_model.LinearExpr.Sum(window_vars) <= 1)
 
-    for scope, vars_by_club_date in (
-        (ConcurrencyScope.HOME, vars_by_club_home_date),
-        (ConcurrencyScope.AWAY, vars_by_club_away_date),
-        (ConcurrencyScope.ANY, vars_by_club_any_date),
-    ):
-        for (club, match_date), club_date_vars in vars_by_club_date.items():
+    for scope in ConcurrencyScope:
+        for (club, match_date), club_date_vars in fixture_vars.by_club_date(
+            scope
+        ).items():
             # Each club may play at most max_concurrent_matches matches of this
             # scope per date (None means unlimited: no constraint to add).
             max_matches = params.max_concurrent_matches_for(club, scope, match_date)
             if max_matches is not None:
                 model.add(cp_model.LinearExpr.Sum(club_date_vars) <= max_matches)
 
-    _add_home_dates_used_constraints(
-        model, params.home_dates_used, vars_by_club_home_date
-    )
+    _add_home_dates_used_constraints(model, params.home_dates_used, fixture_vars)
     _add_avoid_coscheduling_constraints(
-        model, params.avoid_coscheduling_teams, vars_by_fixture_date
+        model, params.avoid_coscheduling_teams, fixture_vars
     )
-    _add_fixed_fixtures_constraints(model, params.fixed_fixtures, vars_by_fixture_date)
+    _add_fixed_fixtures_constraints(model, params.fixed_fixtures, fixture_vars)
 
-    # Guarded by isEnabledFor, not just left to logger.info's own lazy %-formatting,
-    # since model_stats()/response_stats() themselves have a real (if modest) cost to
-    # compute -- not just to format -- and that argument is evaluated eagerly either way.
-    if logger.isEnabledFor(logging.INFO):
-        logger.info("Model stats:\n%s", model.model_stats())
+    return model, fixture_vars
+
+
+def _extract_fixtures(
+    solver: cp_model.CpSolver, fixture_vars: _FixtureVars
+) -> list[ScheduledFixture]:
+    """The scheduled fixtures of a solved model: every (fixture, date) whose
+    bool var the solver set to true."""
+    return [
+        ScheduledFixture(fixture=fixture, date=match_date)
+        for (fixture, match_date), var in fixture_vars.fixture_date_vars().items()
+        if solver.BooleanValue(var)
+    ]
+
+
+def solve(params: Parameters) -> SolveResult:
+    """Solve params, returning the scheduled fixtures together with the OR-Tools
+    model and solver summary text (see SolveResult). Raises ValueError if the
+    solver finds no feasible schedule.
+
+    The two stats blocks are always captured -- they're cheap next to solving
+    itself -- so callers can persist them next to the schedule
+    (fixturesolution.save_solution writes them into solution.yaml, and the report
+    shows them in its "Solver diagnostics" section).
+    """
+    model, fixture_vars = _build_model(params)
+    model_stats = model.model_stats()
 
     solver = cp_model.CpSolver()
     status = solver.Solve(model)
+    solve_stats = solver.response_stats()
 
-    if logger.isEnabledFor(logging.INFO):
-        logger.info("Solve stats:\n%s", solver.response_stats())
-
-    if status in [cp_model.OPTIMAL, cp_model.FEASIBLE]:
-        result = []
-        for (fixture, match_date), var in vars_by_fixture_date.items():
-            if solver.BooleanValue(var):
-                result.append(ScheduledFixture(fixture=fixture, date=match_date))
-        return result
-    else:
+    if status not in (cp_model.OPTIMAL, cp_model.FEASIBLE):
         raise ValueError(
             f"No solution found (solver status: {solver.StatusName(status)})"
         )
+
+    return SolveResult(
+        fixtures=_extract_fixtures(solver, fixture_vars),
+        model_stats=model_stats,
+        solve_stats=solve_stats,
+    )

--- a/genfixtures.py
+++ b/genfixtures.py
@@ -229,7 +229,7 @@ def build_params() -> fmodel.Parameters:
 
 def main() -> None:
     random.seed(0)
-    fixtures = fmodel.solve(build_params())
+    fixtures = fmodel.solve(build_params()).fixtures
     print_fixtures(fixtures)
 
 

--- a/htmlreport.py
+++ b/htmlreport.py
@@ -64,6 +64,12 @@ _STYLE = """
     .anchor-link { margin-left: 0.4rem; font-size: 0.8em; text-decoration: none;
                     color: #888; }
     .anchor-link:hover { color: #0645ad; }
+    .solver-diagnostics { margin-top: 2rem; color: #333; }
+    .solver-diagnostics summary { cursor: pointer; font-weight: 600; }
+    .solver-diagnostics h3 { margin-bottom: 0.3rem; }
+    .solver-diagnostics pre { overflow-x: auto; background: #f6f6f6;
+                              border: 1px solid #ddd; border-radius: 4px;
+                              padding: 0.6rem 0.8rem; font-size: 0.85rem; }
 
     @media (max-width: 40rem) {
         body { margin: 1rem; }
@@ -377,6 +383,26 @@ def _nav(links: list[tuple[str, str]]) -> str:
     return f"<nav><ul>\n{items}</ul></nav>\n"
 
 
+def _solver_diagnostics(model_stats: str, solve_stats: str) -> str:
+    """A collapsed <details> block carrying the OR-Tools model and solver summary
+    text recorded when this schedule was solved (fmodel.solve captures it and
+    solve.py stores it in solution.yaml). Empty when neither was recorded -- e.g.
+    a solution file written before that text was kept."""
+    sections = "".join(
+        f"<h3>{heading}</h3>\n<pre>{html.escape(text)}</pre>\n"
+        for heading, text in (("Model", model_stats), ("Solve", solve_stats))
+        if text
+    )
+    if not sections:
+        return ""
+    return (
+        '<details class="solver-diagnostics">\n'
+        "<summary>Solver diagnostics</summary>\n"
+        f"{sections}"
+        "</details>\n"
+    )
+
+
 def _run_index_body(
     all_matches_links: list[tuple[str, str]],
     division_links: list[tuple[str, str]],
@@ -417,17 +443,20 @@ _MATCH_HEADERS_WITH_DIVISION = [
 
 def generate_report(
     spec: fixturespec.Spec,
-    fixtures: Collection[fmodel.ScheduledFixture],
+    result: fmodel.SolveResult,
     output_dir: Path,
 ) -> Path:
-    """Write a solved fixture list's report pages, plus the run's index.html
-    linking them, into output_dir.
+    """Write a solve result's report pages, plus the run's index.html linking
+    them, into output_dir.
 
     `spec` supplies everything about the season except the solved dates -- teams,
     clubs, the run name/draft/description banners, each division's fixture scheme,
     and any excluded_fixtures (withheld from scheduling entirely, to be arranged
     in a later run; these are appended to the bottom of every relevant table with
-    "TBC" in place of a date). `fixtures` is the solved schedule for that spec.
+    "TBC" in place of a date). `result` is the solved schedule for that spec,
+    plus (if recorded) the OR-Tools model/solver summary text, which is shown in a
+    collapsed "Solver diagnostics" section at the foot of the run index -- absent
+    when result.model_stats/solve_stats are empty.
 
     Wherever csvreport.generate_csv has already written its exports into
     output_dir, they get linked too: all-matches.csv / all-matches-by-team.csv
@@ -437,6 +466,7 @@ def generate_report(
 
     Returns the path to the run's index.html.
     """
+    fixtures = result.fixtures
     output_dir.mkdir(parents=True, exist_ok=True)
 
     teams = spec.parameters.teams
@@ -570,7 +600,8 @@ def generate_report(
     index_path.write_text(
         _page(
             "Fixtures",
-            _run_index_body(all_matches_links, division_links, club_links),
+            _run_index_body(all_matches_links, division_links, club_links)
+            + _solver_diagnostics(result.model_stats, result.solve_stats),
             name,
             draft,
             description,

--- a/htmlreport_test.py
+++ b/htmlreport_test.py
@@ -32,7 +32,7 @@ def _sf(home: fmodel.Team, away: fmodel.Team, d: date) -> fmodel.ScheduledFixtur
 
 
 def _generate(
-    fixtures: Collection[fmodel.ScheduledFixture],
+    result: fmodel.SolveResult,
     teams: Collection[fmodel.Team],
     clubs: Mapping[str, fmodel.Club],
     output_dir: Path,
@@ -44,8 +44,8 @@ def _generate(
     division_schemes: Mapping[int, fmodel.FixtureScheme] | None = None,
 ) -> Path:
     """Assemble a minimal fixturespec.Spec from the loose pieces these tests work
-    with and render its HTML report, so the tests need not build a full
-    fmodel.Parameters just to exercise htmlreport.generate_report()."""
+    with and render `result` as its HTML report, so the tests need not build a
+    full fmodel.Parameters just to exercise htmlreport.generate_report()."""
     parameters = fmodel.Parameters(
         teams=list(teams),
         home_dates={},
@@ -60,7 +60,7 @@ def _generate(
         draft=draft,
         description=description,
     )
-    return htmlreport.generate_report(spec, fixtures, output_dir)
+    return htmlreport.generate_report(spec, result, output_dir)
 
 
 def _club(
@@ -137,7 +137,7 @@ class TestGenerateReport(unittest.TestCase):
         ]
 
         self.index_path = _generate(
-            self.fixtures, self.teams, self.clubs, self.output_dir
+            fmodel.SolveResult(self.fixtures), self.teams, self.clubs, self.output_dir
         )
 
     def test_returns_index_path(self) -> None:
@@ -221,7 +221,7 @@ class TestGenerateReport(unittest.TestCase):
     def test_single_round_division_scheme_shown_on_its_pages_only(self) -> None:
         out2 = Path(self._tmpdir.name) / "out-scheme"
         _generate(
-            self.fixtures,
+            fmodel.SolveResult(self.fixtures),
             self.teams,
             self.clubs,
             out2,
@@ -308,7 +308,7 @@ class TestGenerateReport(unittest.TestCase):
             (self.output_dir / name).write_text("date\n")
 
         content = _generate(
-            self.fixtures, self.teams, self.clubs, self.output_dir
+            fmodel.SolveResult(self.fixtures), self.teams, self.clubs, self.output_dir
         ).read_text()
 
         self.assertIn('href="all-matches.csv"', content)
@@ -322,13 +322,65 @@ class TestGenerateReport(unittest.TestCase):
         # setUp's _generate() writes HTML pages only, no CSV files.
         self.assertNotIn(".csv", self.index_path.read_text())
 
+    def test_run_index_shows_solver_diagnostics_when_stats_given(self) -> None:
+        content = _generate(
+            fmodel.SolveResult(
+                self.fixtures,
+                model_stats="satisfaction model '':\n#Variables: 42\n",
+                solve_stats="CpSolverResponse summary:\nstatus: OPTIMAL\n",
+            ),
+            self.teams,
+            self.clubs,
+            self.output_dir,
+        ).read_text()
+
+        self.assertIn(
+            '<details class="solver-diagnostics">\n'
+            "<summary>Solver diagnostics</summary>",
+            content,
+        )
+        self.assertIn("<h3>Model</h3>\n<pre>satisfaction model", content)
+        self.assertIn("<h3>Solve</h3>\n<pre>CpSolverResponse summary", content)
+        # Diagnostics sit below the run's navigation lists.
+        self.assertLess(
+            content.index("<h2>Clubs</h2>"),
+            content.index('<details class="solver-diagnostics">'),
+        )
+
+    def test_run_index_escapes_solver_diagnostics_text(self) -> None:
+        content = _generate(
+            fmodel.SolveResult(self.fixtures, model_stats="a <b> & c\n"),
+            self.teams,
+            self.clubs,
+            self.output_dir,
+        ).read_text()
+        self.assertIn("a &lt;b&gt; &amp; c", content)
+
+    def test_run_index_omits_a_missing_diagnostics_half(self) -> None:
+        content = _generate(
+            fmodel.SolveResult(self.fixtures, solve_stats="status: OPTIMAL\n"),
+            self.teams,
+            self.clubs,
+            self.output_dir,
+        ).read_text()
+        self.assertIn("<summary>Solver diagnostics</summary>", content)
+        self.assertIn("<h3>Solve</h3>", content)
+        self.assertNotIn("<h3>Model</h3>", content)
+
+    def test_run_index_has_no_solver_diagnostics_by_default(self) -> None:
+        self.assertNotIn(
+            '<details class="solver-diagnostics">', self.index_path.read_text()
+        )
+
     def test_club_page_links_per_club_and_per_team_csv_when_present(self) -> None:
         # generate_report links the per-club / per-team exports it finds already
         # written into the output dir (csvreport.generate_csv writes them).
         for name in ("club-harrow-dates.csv", "team-harrow-1.csv", "team-harrow-2.csv"):
             (self.output_dir / name).write_text("date\n")
 
-        _generate(self.fixtures, self.teams, self.clubs, self.output_dir)
+        _generate(
+            fmodel.SolveResult(self.fixtures), self.teams, self.clubs, self.output_dir
+        )
         harrow_page = (self.output_dir / "club-harrow.html").read_text()
 
         # Per-club link sits under the consolidated table, ahead of the first team.
@@ -365,7 +417,9 @@ class TestGenerateReport(unittest.TestCase):
             fixtures.append(_sf(home, away, date(2025, 9, 1)))
 
         out2 = Path(self._tmpdir.name) / "out-div-sort"
-        content = _generate(fixtures, teams, clubs, out2).read_text()
+        content = _generate(
+            fmodel.SolveResult(fixtures), teams, clubs, out2
+        ).read_text()
 
         self.assertLess(
             content.index("division-1.html"), content.index("division-2.html")
@@ -378,7 +432,7 @@ class TestGenerateReport(unittest.TestCase):
         lonely_clubs = {"lonely-fc": _club("Lonely FC")}
         lonely = fmodel.Team(division=3, club="lonely-fc", index=1)
         out2 = Path(self._tmpdir.name) / "out2"
-        _generate([], [lonely], lonely_clubs, out2)
+        _generate(fmodel.SolveResult([]), [lonely], lonely_clubs, out2)
         content = (out2 / "club-lonely-fc.html").read_text()
         self.assertIn("No matches", content)
 
@@ -398,7 +452,7 @@ class TestGenerateReport(unittest.TestCase):
     def test_run_name_and_draft_shown_on_every_page(self) -> None:
         out2 = Path(self._tmpdir.name) / "out-named"
         index_path = _generate(
-            self.fixtures,
+            fmodel.SolveResult(self.fixtures),
             self.teams,
             self.clubs,
             out2,
@@ -419,7 +473,7 @@ class TestGenerateReport(unittest.TestCase):
     def test_description_shown_on_every_page(self) -> None:
         out2 = Path(self._tmpdir.name) / "out-described"
         index_path = _generate(
-            self.fixtures,
+            fmodel.SolveResult(self.fixtures),
             self.teams,
             self.clubs,
             out2,
@@ -454,7 +508,7 @@ class TestGenerateReport(unittest.TestCase):
     def test_head_title_carries_run_name_club_or_division_and_draft(self) -> None:
         out2 = Path(self._tmpdir.name) / "out-head-title"
         index_path = _generate(
-            self.fixtures,
+            fmodel.SolveResult(self.fixtures),
             self.teams,
             self.clubs,
             out2,
@@ -478,7 +532,11 @@ class TestGenerateReport(unittest.TestCase):
     def test_head_title_omits_draft_marker_for_non_draft_runs(self) -> None:
         out2 = Path(self._tmpdir.name) / "out-head-title-final"
         index_path = _generate(
-            self.fixtures, self.teams, self.clubs, out2, name="2025-26 Season"
+            fmodel.SolveResult(self.fixtures),
+            self.teams,
+            self.clubs,
+            out2,
+            name="2025-26 Season",
         )
         self.assertIn("<title>2025-26 Season</title>", index_path.read_text())
         self.assertIn(
@@ -489,7 +547,7 @@ class TestGenerateReport(unittest.TestCase):
     def test_nav_link_labels_stay_bare_despite_richer_head_titles(self) -> None:
         out2 = Path(self._tmpdir.name) / "out-nav-labels"
         index_path = _generate(
-            self.fixtures,
+            fmodel.SolveResult(self.fixtures),
             self.teams,
             self.clubs,
             out2,
@@ -526,7 +584,7 @@ class TestExcludedFixturesInReport(unittest.TestCase):
         self.excluded = [fmodel.Fixture(home_team=self.harrow2, away_team=self.ealing1)]
 
         self.index_path = _generate(
-            self.fixtures,
+            fmodel.SolveResult(self.fixtures),
             self.teams,
             self.clubs,
             self.output_dir,
@@ -568,7 +626,7 @@ class TestExcludedFixturesInReport(unittest.TestCase):
 
     def test_no_excluded_fixtures_by_default(self) -> None:
         out2 = Path(self._tmpdir.name) / "out-no-excluded"
-        _generate(self.fixtures, self.teams, self.clubs, out2)
+        _generate(fmodel.SolveResult(self.fixtures), self.teams, self.clubs, out2)
         content = (out2 / "all-matches.html").read_text()
         self.assertNotIn("TBC", content)
 
@@ -585,7 +643,13 @@ class TestExcludedFixturesInReport(unittest.TestCase):
         ]
 
         out2 = Path(self._tmpdir.name) / "out-div2"
-        _generate(self.fixtures, teams, clubs, out2, excluded_fixtures=excluded)
+        _generate(
+            fmodel.SolveResult(self.fixtures),
+            teams,
+            clubs,
+            out2,
+            excluded_fixtures=excluded,
+        )
         div2 = (out2 / "division-2.html").read_text()
         self.assertIn("TBC", div2)
         self.assertIn("Hendon 1", div2)

--- a/model_test.py
+++ b/model_test.py
@@ -45,7 +45,7 @@ class TestSolve(unittest.TestCase):
         # Seed random number generator for reproducible test results
         random.seed(42)
         cls.params = genfixtures.build_params()
-        cls.fixtures = list(fmodel.solve(cls.params))
+        cls.fixtures = list(fmodel.solve(cls.params).fixtures)
 
     def test_basic_solve(self) -> None:
         """Test that solve produces fixtures with real parameters."""
@@ -252,7 +252,7 @@ class TestSolve(unittest.TestCase):
         )
 
         # This should be impossible to schedule any fixtures due to conflicting constraints
-        result = list(fmodel.solve(params))
+        result = list(fmodel.solve(params).fixtures)
         # Since constraints make it impossible to schedule required fixtures,
         # the solver returns an empty list (no feasible schedule)
         self.assertEqual(
@@ -260,6 +260,32 @@ class TestSolve(unittest.TestCase):
             0,
             "Expected no fixtures to be scheduled due to impossible constraints",
         )
+
+
+class TestSolveStats(unittest.TestCase):
+    """solve() returns the OR-Tools model/solver summary text alongside the
+    schedule, and raises when the model is genuinely unsatisfiable."""
+
+    def test_captures_model_and_solve_stats(self) -> None:
+        random.seed(42)
+        result = fmodel.solve(genfixtures.build_params())
+        self.assertIn("#Variables", result.model_stats)
+        self.assertIn("CpSolverResponse summary", result.solve_stats)
+        self.assertIn("status:", result.solve_stats)
+
+    def test_raises_when_infeasible(self) -> None:
+        # Two teams of one club, only a single shared home date: both the A1 v A2
+        # and A2 v A1 fixtures are forced onto it, but neither team may play twice
+        # in a window -- an unsatisfiable model, not just an empty schedule.
+        team1 = fmodel.Team(division=1, club="A", index=1)
+        team2 = fmodel.Team(division=1, club="A", index=2)
+        params = fmodel.Parameters(
+            teams=[team1, team2],
+            home_dates={"A": [date(2025, 1, 1)]},
+            unavailable_away_dates={"A": []},
+        )
+        with self.assertRaisesRegex(ValueError, "No solution found"):
+            fmodel.solve(params)
 
 
 class TestMaxConcurrentMatchesFor(unittest.TestCase):
@@ -394,7 +420,7 @@ class TestHomeDatesUsed(unittest.TestCase):
             min_gap_days=0,
             home_dates_used={"A": fmodel.HomeDatesUsedBounds(maximum=8)},
         )
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
 
         a_dates_used = {sf.date for sf in fixtures if sf.fixture.home_team.club == "A"}
         self.assertLessEqual(len(a_dates_used), 8)
@@ -436,7 +462,7 @@ class TestHomeDatesUsed(unittest.TestCase):
             min_gap_days=0,
             home_dates_used={"A": fmodel.HomeDatesUsedBounds(minimum=10)},
         )
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
 
         a_dates_used = {sf.date for sf in fixtures if sf.fixture.home_team.club == "A"}
         self.assertGreaterEqual(len(a_dates_used), 10)
@@ -539,7 +565,7 @@ class TestFixedFixtures(unittest.TestCase):
             fixture=fmodel.Fixture(home_team=a1, away_team=a2), date=date(2025, 1, 1)
         )
         params = self._params(fixed_fixtures=[fixed])
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         self.assertIn(fixed, fixtures)
 
     def test_fixed_fixture_on_non_home_date_rejected(self) -> None:
@@ -563,7 +589,7 @@ class TestFixedFixtures(unittest.TestCase):
             fixture=fmodel.Fixture(home_team=a1, away_team=a2), date=date(2025, 1, 1)
         )
         params = self._params(fixed_fixtures=[fixed])
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         # a2 v a1 (the reverse fixture) must be on a different date
         reverse = next(
             sf
@@ -596,7 +622,7 @@ class TestFixedFixtures(unittest.TestCase):
             min_gap_days=7,
             fixed_fixtures=fixed,
         )
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         self.assertCountEqual(fixtures, fixed)
 
     def test_reverse_fixture_one_day_inside_min_gap_days_is_rejected(self) -> None:
@@ -659,7 +685,7 @@ class TestLatestInternalMatchDate(unittest.TestCase):
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=1, club="A", index=2)
         params = self._params(latest_internal_match_date=date(2025, 2, 15))
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         internal = [
             sf
             for sf in fixtures
@@ -674,7 +700,7 @@ class TestLatestInternalMatchDate(unittest.TestCase):
         a1 = fmodel.Team(division=1, club="A", index=1)
         b1 = fmodel.Team(division=1, club="B", index=1)
         params = self._params(latest_internal_match_date=date(2025, 2, 15))
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         cross_club = next(
             sf
             for sf in fixtures
@@ -692,7 +718,7 @@ class TestLatestInternalMatchDate(unittest.TestCase):
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=1, club="A", index=2)
         params = self._params(latest_internal_match_date=date(2024, 12, 1))
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         internal = [
             sf
             for sf in fixtures
@@ -718,7 +744,7 @@ class TestLatestInternalMatchDate(unittest.TestCase):
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=1, club="A", index=2)
         params = self._params()
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         internal_dates = {
             sf.date
             for sf in fixtures
@@ -772,7 +798,7 @@ class TestEarliestMatchDate(unittest.TestCase):
         """A cutoff that excludes some (but not all) of club A's dates still
         leaves enough of them (4, the minimum -- see class docstring) to solve."""
         params = self._params(earliest_match_date=date(2025, 2, 1))
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         self.assertTrue(fixtures)
         for sf in fixtures:
             self.assertGreaterEqual(sf.date, date(2025, 2, 1))
@@ -786,7 +812,7 @@ class TestEarliestMatchDate(unittest.TestCase):
         fixtures are unaffected since none of B's dates are excluded.
         """
         params = self._params(earliest_match_date=date(2025, 4, 1))
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         self.assertFalse([sf for sf in fixtures if sf.fixture.home_team.club == "A"])
         self.assertTrue([sf for sf in fixtures if sf.fixture.home_team.club == "B"])
 
@@ -805,7 +831,7 @@ class TestEarliestMatchDate(unittest.TestCase):
         params = self._params(
             fixed_fixtures=[fixed], earliest_match_date=date(2025, 2, 1)
         )
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         self.assertIn(fixed, fixtures)
 
     def test_no_cutoff_by_default(self) -> None:
@@ -813,7 +839,7 @@ class TestEarliestMatchDate(unittest.TestCase):
         4-distinct-A-dates requirement from the class docstring, with no cutoff
         trimming club A's 6 candidate dates, is comfortably satisfiable)."""
         params = self._params()
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         self.assertEqual(len(fixtures), 6)
 
 
@@ -852,7 +878,7 @@ class TestExcludedFixtures(unittest.TestCase):
         a2 = fmodel.Team(division=1, club="A", index=2)
         excluded_fixture = fmodel.Fixture(home_team=a1, away_team=a2)
         params = self._params(excluded_fixtures=[excluded_fixture])
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         self.assertNotIn(excluded_fixture, [sf.fixture for sf in fixtures])
         # The other 5 fixtures in this 3-team division must still be scheduled
         self.assertEqual(len(fixtures), 5)
@@ -863,7 +889,7 @@ class TestExcludedFixtures(unittest.TestCase):
         a2 = fmodel.Team(division=1, club="A", index=2)
         excluded_fixture = fmodel.Fixture(home_team=a1, away_team=a2)
         params = self._params(excluded_fixtures=[excluded_fixture])
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         self.assertTrue(
             any(
                 sf.fixture.home_team == a2 and sf.fixture.away_team == a1
@@ -912,7 +938,7 @@ class TestDivisionSchemes(unittest.TestCase):
 
     def test_double_round_is_the_default_scheme(self) -> None:
         params = self._params(self._teams("ABCD"))
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         # 4 teams, home and away: 4 * 3 = 12 fixtures.
         self.assertEqual(12, len(fixtures))
         self.assertEqual(1, len(params.divisions))
@@ -923,7 +949,7 @@ class TestDivisionSchemes(unittest.TestCase):
             self._teams("ABCD"),
             division_schemes={1: fmodel.FixtureScheme.SINGLE_ROUND},
         )
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         self.assertEqual(6, len(fixtures))
         unordered = {
             frozenset((sf.fixture.home_team, sf.fixture.away_team)) for sf in fixtures
@@ -935,7 +961,7 @@ class TestDivisionSchemes(unittest.TestCase):
         params = self._params(
             teams, division_schemes={1: fmodel.FixtureScheme.SINGLE_ROUND}
         )
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         got = {
             (sf.fixture.home_team.club, sf.fixture.away_team.club) for sf in fixtures
         }
@@ -950,7 +976,7 @@ class TestDivisionSchemes(unittest.TestCase):
         params = self._params(
             teams, division_schemes={1: fmodel.FixtureScheme.SINGLE_ROUND}
         )
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         got = {
             (sf.fixture.home_team.club, sf.fixture.away_team.club) for sf in fixtures
         }
@@ -967,7 +993,7 @@ class TestDivisionSchemes(unittest.TestCase):
         params = self._params(
             teams, division_schemes={1: fmodel.FixtureScheme.SINGLE_ROUND}
         )
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         by_division = collections.Counter(
             sf.fixture.home_team.division for sf in fixtures
         )
@@ -1005,7 +1031,7 @@ class TestTeamConstraints(unittest.TestCase):
             # A1 can only host on Jan 1; A2 keeps A's full home_dates.
             team_home_dates={a1: [date(2025, 1, 1)]},
         )
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         a1_home_dates_used = {sf.date for sf in fixtures if sf.fixture.home_team == a1}
         self.assertEqual(a1_home_dates_used, {date(2025, 1, 1)})
         a2_home_dates_used = {sf.date for sf in fixtures if sf.fixture.home_team == a2}
@@ -1028,7 +1054,7 @@ class TestTeamConstraints(unittest.TestCase):
             min_gap_days=7,
             team_unavailable_away_dates={a1: [date(2025, 2, 1)]},
         )
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         # A1 v B1 (A1 away at B) can't be scheduled: B's only home date is blocked
         # for A1 specifically, so that fixture is left unschedulable.
         self.assertFalse(
@@ -1107,7 +1133,7 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
                 fmodel.AvoidCoschedulingConstraint(teams=[a1, a2])
             ],
         )
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         a1_home_date = next(sf.date for sf in fixtures if sf.fixture.home_team == a1)
         a2_home_date = next(sf.date for sf in fixtures if sf.fixture.home_team == a2)
         self.assertNotEqual(a1_home_date, a2_home_date)
@@ -1194,7 +1220,7 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
                 fmodel.AvoidCoschedulingConstraint(teams=[a1, a2], within_days=3)
             ],
         )
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         a1_home_date = next(sf.date for sf in fixtures if sf.fixture.home_team == a1)
         a2_home_date = next(sf.date for sf in fixtures if sf.fixture.home_team == a2)
         self.assertGreater(abs((a1_home_date - a2_home_date).days), 3)
@@ -1218,7 +1244,7 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
                 fmodel.AvoidCoschedulingConstraint(teams=[a1, a2])
             ],
         )
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         self.assertEqual(
             fixtures,
             [
@@ -1256,7 +1282,7 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
                 )
             ],
         )
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         a1_home_date = next(sf.date for sf in fixtures if sf.fixture.home_team == a1)
         a2_home_date = next(sf.date for sf in fixtures if sf.fixture.home_team == a2)
         self.assertEqual(a1_home_date, a2_home_date)
@@ -1315,7 +1341,7 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
                 )
             ],
         )
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         a1_away_date = next(sf.date for sf in fixtures if sf.fixture.away_team == a1)
         a2_away_date = next(sf.date for sf in fixtures if sf.fixture.away_team == a2)
         self.assertEqual(a1_away_date, a2_away_date)
@@ -1398,7 +1424,7 @@ class TestMaxConcurrentMatchesUnlimited(unittest.TestCase):
             },
             min_gap_days=7,
         )
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         a1_home_date = next(sf.date for sf in fixtures if sf.fixture.home_team == a1)
         a2_home_date = next(sf.date for sf in fixtures if sf.fixture.home_team == a2)
         self.assertEqual(a1_home_date, date(2025, 1, 1))
@@ -1431,7 +1457,7 @@ class TestMaxConcurrentMatchesUnlimited(unittest.TestCase):
             },
             min_gap_days=7,
         )
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         a1_home_date = next(sf.date for sf in fixtures if sf.fixture.home_team == a1)
         a2_home_date = next(sf.date for sf in fixtures if sf.fixture.home_team == a2)
         self.assertEqual(a1_home_date, date(2025, 1, 1))
@@ -1483,7 +1509,7 @@ class TestMaxConcurrentMatchesScopes(unittest.TestCase):
 
     def test_any_scope_limit_allows_up_to_the_limit(self) -> None:
         params = self._params(self._any(2), x_home_dates=[date(2025, 1, 1)])
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         away = sorted(sf.date for sf in fixtures if sf.fixture.away_team.club == "A")
         self.assertEqual(away, [date(2025, 1, 1), date(2025, 1, 1)])
 
@@ -1499,7 +1525,7 @@ class TestMaxConcurrentMatchesScopes(unittest.TestCase):
         params = self._params(
             self._away(1), x_home_dates=[date(2025, 1, 1), date(2025, 1, 8)]
         )
-        fixtures = list(fmodel.solve(params))
+        fixtures = list(fmodel.solve(params).fixtures)
         home = sorted(sf.date for sf in fixtures if sf.fixture.home_team.club == "A")
         self.assertEqual(home, [date(2025, 3, 1), date(2025, 3, 1)])
         away = sorted(sf.date for sf in fixtures if sf.fixture.away_team.club == "A")

--- a/report.py
+++ b/report.py
@@ -44,11 +44,11 @@ def report(spec_path: Path, solution_path: Path, output_dir: Path) -> Path:
     index.html."""
     spec = fixturespec.load_spec(spec_path)
     team_ids = fixturespec.load_team_ids(spec_path)
-    fixtures = fixturesolution.load_solution(
+    result = fixturesolution.load_solution(
         solution_path, spec.parameters.teams, team_ids
     )
-    csvreport.generate_csv(spec, fixtures, output_dir)
-    return htmlreport.generate_report(spec, fixtures, output_dir)
+    csvreport.generate_csv(spec, result.fixtures, output_dir)
+    return htmlreport.generate_report(spec, result, output_dir)
 
 
 def main() -> None:

--- a/report_test.py
+++ b/report_test.py
@@ -108,6 +108,14 @@ class TestReport(unittest.TestCase):
         self.assertIn('href="club-albany-dates.csv"', club_page)
         self.assertIn('href="team-albany-1.csv"', club_page)
 
+    def test_run_index_shows_solver_diagnostics_from_solution(self) -> None:
+        report.report(self.spec_path, self.solution_path, self.output_dir)
+
+        index = (self.output_dir / "index.html").read_text()
+        self.assertIn("<summary>Solver diagnostics</summary>", index)
+        self.assertIn("satisfaction model", index)
+        self.assertIn("CpSolverResponse summary", index)
+
     def test_does_not_require_resolving(self) -> None:
         """Deleting nothing but the intermediate solving step should still work:
         report.py only reads solution.yaml, never calls fmodel.solve()."""

--- a/runs/example/solution.yaml
+++ b/runs/example/solution.yaml
@@ -1,550 +1,575 @@
 fixtures:
-- home: muswell-hill-1
-  away: albany-1
-  date: 2025-09-02
-- home: hackney-2
-  away: hammersmith-3
-  date: 2025-09-03
-- home: west-london-1
-  away: hammersmith-1
-  date: 2025-09-03
-- home: willesden-brent-1
-  away: harrow-1
-  date: 2025-09-03
+- home: hammersmith-2
+  away: willesden-brent-1
+  date: 2025-09-04
 - home: hammersmith-4
   away: hendon-4
+  date: 2025-09-04
+- home: kings-head-1
+  away: west-london-1
   date: 2025-09-04
 - home: kings-head-2
   away: muswell-hill-2
   date: 2025-09-04
-- home: hackney-1
-  away: albany-1
-  date: 2025-09-10
-- home: harrow-1
-  away: harrow-2
+- home: potters-bar-1
+  away: ealing-2
+  date: 2025-09-08
+- home: harrow-2
+  away: harrow-1
   date: 2025-09-11
 - home: hendon-2
-  away: hendon-3
-  date: 2025-09-11
-- home: kings-head-3
-  away: hackney-2
+  away: muswell-hill-2
   date: 2025-09-11
 - home: metropolitan-1
-  away: hendon-1
+  away: west-london-1
   date: 2025-09-11
 - home: ealing-2
-  away: hammersmith-4
-  date: 2025-09-15
-- home: hendon-4
   away: hammersmith-3
-  date: 2025-09-18
-- home: kings-head-1
-  away: west-london-1
-  date: 2025-09-18
-- home: kings-head-2
+  date: 2025-09-15
+- home: hendon-3
   away: willesden-brent-1
   date: 2025-09-18
-- home: albany-1
-  away: hammersmith-1
-  date: 2025-09-22
-- home: ealing-1
-  away: muswell-hill-2
-  date: 2025-09-22
+- home: hendon-5
+  away: potters-bar-1
+  date: 2025-09-18
+- home: west-london-1
+  away: metropolitan-1
+  date: 2025-09-24
 - home: harrow-1
-  away: hammersmith-2
+  away: harrow-2
   date: 2025-09-25
-- home: hendon-3
-  away: hendon-2
+- home: hendon-4
+  away: hackney-2
   date: 2025-09-25
 - home: hendon-5
-  away: ealing-2
-  date: 2025-09-25
-- home: potters-bar-1
   away: hammersmith-3
-  date: 2025-09-29
-- home: muswell-hill-1
-  away: metropolitan-1
-  date: 2025-09-30
-- home: muswell-hill-2
-  away: harrow-2
-  date: 2025-09-30
-- home: hammersmith-1
-  away: hendon-1
-  date: 2025-10-02
+  date: 2025-09-25
 - home: ealing-1
   away: willesden-brent-1
-  date: 2025-10-06
-- home: ealing-2
-  away: hackney-2
-  date: 2025-10-06
-- home: west-london-1
-  away: muswell-hill-1
-  date: 2025-10-08
-- home: hammersmith-3
-  away: kings-head-3
-  date: 2025-10-09
-- home: hammersmith-4
-  away: hendon-5
-  date: 2025-10-09
+  date: 2025-09-29
 - home: kings-head-1
   away: hackney-1
+  date: 2025-10-02
+- home: kings-head-3
+  away: hammersmith-3
+  date: 2025-10-02
+- home: metropolitan-1
+  away: muswell-hill-1
+  date: 2025-10-02
+- home: ealing-1
+  away: hendon-2
+  date: 2025-10-06
+- home: muswell-hill-2
+  away: kings-head-2
+  date: 2025-10-07
+- home: hammersmith-1
+  away: kings-head-1
   date: 2025-10-09
-- home: hackney-2
+- home: hammersmith-4
   away: potters-bar-1
-  date: 2025-10-15
-- home: harrow-2
-  away: willesden-brent-1
+  date: 2025-10-09
+- home: hendon-1
+  away: hackney-1
+  date: 2025-10-09
+- home: hendon-4
+  away: hendon-5
+  date: 2025-10-09
+- home: metropolitan-1
+  away: albany-1
+  date: 2025-10-09
+- home: hendon-1
+  away: west-london-1
   date: 2025-10-16
 - home: hendon-2
-  away: muswell-hill-2
+  away: hendon-3
   date: 2025-10-16
-- home: hendon-3
-  away: hammersmith-2
+- home: kings-head-3
+  away: potters-bar-1
   date: 2025-10-16
-- home: kings-head-2
-  away: harrow-1
+- home: metropolitan-1
+  away: kings-head-1
   date: 2025-10-16
-- home: muswell-hill-1
-  away: west-london-1
+- home: ealing-1
+  away: harrow-2
+  date: 2025-10-20
+- home: ealing-2
+  away: hendon-5
+  date: 2025-10-20
+- home: muswell-hill-2
+  away: willesden-brent-1
   date: 2025-10-21
-- home: hendon-1
-  away: metropolitan-1
-  date: 2025-10-23
-- home: willesden-brent-1
-  away: hendon-2
-  date: 2025-10-29
-- home: hammersmith-2
+- home: hendon-3
   away: kings-head-2
-  date: 2025-10-30
+  date: 2025-10-23
+- home: kings-head-1
+  away: hendon-1
+  date: 2025-10-23
+- home: albany-1
+  away: hammersmith-1
+  date: 2025-10-27
+- home: ealing-1
+  away: harrow-1
+  date: 2025-10-27
 - home: hammersmith-3
   away: hammersmith-4
   date: 2025-10-30
-- home: harrow-2
-  away: harrow-1
+- home: hendon-4
+  away: potters-bar-1
   date: 2025-10-30
-- home: hendon-5
-  away: hendon-4
-  date: 2025-10-30
-- home: potters-bar-1
+- home: ealing-1
+  away: kings-head-2
+  date: 2025-11-03
+- home: ealing-2
   away: kings-head-3
   date: 2025-11-03
-- home: muswell-hill-2
-  away: ealing-1
+- home: muswell-hill-1
+  away: west-london-1
   date: 2025-11-04
 - home: hackney-1
   away: hendon-1
-  date: 2025-11-12
+  date: 2025-11-05
+- home: willesden-brent-1
+  away: hendon-3
+  date: 2025-11-05
+- home: muswell-hill-2
+  away: harrow-2
+  date: 2025-11-11
 - home: hackney-2
-  away: hendon-5
+  away: potters-bar-1
   date: 2025-11-12
-- home: hammersmith-1
-  away: albany-1
-  date: 2025-11-13
-- home: hammersmith-2
-  away: muswell-hill-2
-  date: 2025-11-13
 - home: hammersmith-4
   away: hammersmith-3
   date: 2025-11-13
-- home: harrow-1
-  away: kings-head-2
-  date: 2025-11-13
-- home: hendon-3
-  away: ealing-1
-  date: 2025-11-13
-- home: hendon-4
-  away: kings-head-3
-  date: 2025-11-13
-- home: metropolitan-1
-  away: kings-head-1
-  date: 2025-11-13
-- home: harrow-2
-  away: hendon-2
-  date: 2025-11-20
-- home: potters-bar-1
-  away: hendon-4
-  date: 2025-11-24
-- home: muswell-hill-2
-  away: kings-head-2
-  date: 2025-11-25
-- home: hammersmith-1
-  away: muswell-hill-1
-  date: 2025-11-27
 - home: hendon-1
-  away: kings-head-1
-  date: 2025-11-27
-- home: hendon-3
-  away: harrow-1
-  date: 2025-11-27
-- home: metropolitan-1
-  away: hackney-1
-  date: 2025-11-27
-- home: ealing-1
-  away: hammersmith-2
-  date: 2025-12-01
-- home: hammersmith-4
+  away: metropolitan-1
+  date: 2025-11-13
+- home: hendon-5
   away: ealing-2
-  date: 2025-12-04
-- home: kings-head-2
+  date: 2025-11-13
+- home: hammersmith-1
+  away: metropolitan-1
+  date: 2025-11-20
+- home: hammersmith-4
+  away: hendon-5
+  date: 2025-11-20
+- home: harrow-1
+  away: willesden-brent-1
+  date: 2025-11-20
+- home: ealing-1
+  away: hendon-3
+  date: 2025-11-24
+- home: potters-bar-1
+  away: hammersmith-3
+  date: 2025-11-24
+- home: hackney-1
+  away: albany-1
+  date: 2025-11-26
+- home: hammersmith-1
+  away: hendon-1
+  date: 2025-11-27
+- home: harrow-1
+  away: hammersmith-2
+  date: 2025-11-27
+- home: hendon-2
   away: harrow-2
-  date: 2025-12-04
+  date: 2025-11-27
 - home: hackney-1
   away: muswell-hill-1
-  date: 2025-12-10
+  date: 2025-12-03
+- home: hammersmith-2
+  away: ealing-1
+  date: 2025-12-04
+- home: kings-head-2
+  away: hendon-2
+  date: 2025-12-04
+- home: kings-head-3
+  away: ealing-2
+  date: 2025-12-04
+- home: potters-bar-1
+  away: hackney-2
+  date: 2025-12-08
 - home: west-london-1
-  away: albany-1
+  away: kings-head-1
+  date: 2025-12-10
+- home: willesden-brent-1
+  away: muswell-hill-2
   date: 2025-12-10
 - home: hendon-2
   away: harrow-1
   date: 2025-12-11
 - home: hendon-4
-  away: hendon-5
+  away: kings-head-3
   date: 2025-12-11
-- home: kings-head-3
-  away: hammersmith-3
+- home: kings-head-2
+  away: hammersmith-2
   date: 2025-12-11
-- home: potters-bar-1
+- home: metropolitan-1
+  away: hackney-1
+  date: 2025-12-11
+- home: west-london-1
+  away: hendon-1
+  date: 2025-12-17
+- home: hammersmith-3
   away: ealing-2
-  date: 2025-12-15
-- home: hammersmith-1
-  away: west-london-1
   date: 2025-12-18
-- home: hammersmith-2
-  away: willesden-brent-1
+- home: harrow-1
+  away: hendon-2
   date: 2025-12-18
 - home: hendon-3
   away: harrow-2
   date: 2025-12-18
-- home: kings-head-1
+- home: hendon-5
+  away: hammersmith-4
+  date: 2025-12-18
+- home: albany-1
   away: metropolitan-1
-  date: 2025-12-18
-- home: kings-head-2
-  away: ealing-1
-  date: 2025-12-18
-- home: hammersmith-3
-  away: hendon-5
-  date: 2025-12-25
-- home: hammersmith-4
-  away: kings-head-3
-  date: 2025-12-25
+  date: 2025-12-22
+- home: ealing-1
+  away: hammersmith-2
+  date: 2025-12-22
+- home: hackney-1
+  away: hammersmith-1
+  date: 2025-12-24
 - home: harrow-1
+  away: muswell-hill-2
+  date: 2025-12-25
+- home: hendon-3
   away: hendon-2
   date: 2025-12-25
-- home: hendon-1
-  away: albany-1
+- home: hendon-5
+  away: hendon-4
   date: 2025-12-25
-- home: ealing-1
-  away: harrow-2
+- home: albany-1
+  away: hendon-1
   date: 2025-12-29
 - home: willesden-brent-1
-  away: kings-head-2
+  away: ealing-1
   date: 2025-12-31
-- home: metropolitan-1
-  away: muswell-hill-1
+- home: kings-head-2
+  away: harrow-2
   date: 2026-01-01
-- home: hackney-1
-  away: west-london-1
+- home: kings-head-3
+  away: hammersmith-4
+  date: 2026-01-01
+- home: west-london-1
+  away: muswell-hill-1
   date: 2026-01-07
 - home: hammersmith-1
-  away: kings-head-1
+  away: albany-1
   date: 2026-01-08
-- home: harrow-2
-  away: ealing-1
+- home: hammersmith-2
+  away: hendon-2
   date: 2026-01-08
-- home: hendon-2
-  away: hammersmith-2
+- home: hendon-4
+  away: hammersmith-3
   date: 2026-01-08
 - home: kings-head-2
-  away: hendon-3
+  away: harrow-1
   date: 2026-01-08
-- home: ealing-2
+- home: willesden-brent-1
+  away: harrow-2
+  date: 2026-01-14
+- home: hammersmith-3
   away: hendon-4
-  date: 2026-01-12
-- home: muswell-hill-2
-  away: willesden-brent-1
-  date: 2026-01-13
+  date: 2026-01-15
 - home: hammersmith-4
-  away: hackney-2
+  away: ealing-2
   date: 2026-01-15
-- home: hendon-1
-  away: hackney-1
+- home: hendon-2
+  away: hammersmith-2
   date: 2026-01-15
-- home: hendon-5
-  away: kings-head-3
+- home: metropolitan-1
+  away: hammersmith-1
   date: 2026-01-15
-- home: albany-1
-  away: metropolitan-1
+- home: potters-bar-1
+  away: hendon-5
   date: 2026-01-19
-- home: muswell-hill-1
-  away: kings-head-1
-  date: 2026-01-20
-- home: harrow-1
+- home: muswell-hill-2
   away: hendon-3
+  date: 2026-01-20
+- home: hackney-1
+  away: kings-head-1
+  date: 2026-01-21
+- home: west-london-1
+  away: albany-1
+  date: 2026-01-21
+- home: harrow-2
+  away: kings-head-2
   date: 2026-01-22
 - home: hendon-2
-  away: harrow-2
+  away: willesden-brent-1
   date: 2026-01-22
 - home: ealing-2
-  away: hendon-5
+  away: hendon-4
   date: 2026-01-26
-- home: hackney-1
-  away: metropolitan-1
-  date: 2026-01-28
-- home: willesden-brent-1
-  away: hammersmith-2
-  date: 2026-01-28
-- home: hendon-4
-  away: potters-bar-1
+- home: muswell-hill-1
+  away: hendon-1
+  date: 2026-01-27
+- home: harrow-1
+  away: ealing-1
   date: 2026-01-29
-- home: kings-head-1
-  away: muswell-hill-1
-  date: 2026-01-29
-- home: albany-1
-  away: west-london-1
-  date: 2026-02-02
-- home: ealing-1
+- home: harrow-2
   away: hendon-2
-  date: 2026-02-02
-- home: hackney-2
-  away: kings-head-3
+  date: 2026-01-29
+- home: kings-head-3
+  away: hackney-2
+  date: 2026-01-29
+- home: west-london-1
+  away: hammersmith-1
   date: 2026-02-04
-- home: hammersmith-1
-  away: metropolitan-1
+- home: willesden-brent-1
+  away: kings-head-2
+  date: 2026-02-04
+- home: hammersmith-3
+  away: hendon-5
   date: 2026-02-05
-- home: hammersmith-2
-  away: hendon-3
+- home: hammersmith-4
+  away: hackney-2
   date: 2026-02-05
 - home: muswell-hill-1
-  away: hackney-1
-  date: 2026-02-10
-- home: west-london-1
   away: kings-head-1
-  date: 2026-02-11
+  date: 2026-02-10
 - home: hendon-2
   away: kings-head-2
   date: 2026-02-12
-- home: hendon-5
-  away: hammersmith-3
-  date: 2026-02-12
-- home: kings-head-3
-  away: hendon-4
-  date: 2026-02-12
-- home: albany-1
-  away: hendon-1
-  date: 2026-02-16
-- home: ealing-1
-  away: hendon-3
-  date: 2026-02-16
-- home: ealing-2
-  away: potters-bar-1
-  date: 2026-02-16
-- home: muswell-hill-2
-  away: hammersmith-2
-  date: 2026-02-17
-- home: harrow-1
-  away: willesden-brent-1
-  date: 2026-02-19
-- home: hackney-1
-  away: hammersmith-1
-  date: 2026-02-25
-- home: hackney-2
+- home: hendon-4
   away: ealing-2
-  date: 2026-02-25
-- home: west-london-1
+  date: 2026-02-12
+- home: metropolitan-1
   away: hendon-1
+  date: 2026-02-12
+- home: muswell-hill-1
+  away: albany-1
+  date: 2026-02-17
+- home: west-london-1
+  away: hackney-1
+  date: 2026-02-18
+- home: harrow-2
+  away: muswell-hill-2
+  date: 2026-02-19
+- home: hendon-1
+  away: kings-head-1
+  date: 2026-02-19
+- home: hendon-3
+  away: hammersmith-2
+  date: 2026-02-19
+- home: hackney-2
+  away: hendon-4
   date: 2026-02-25
+- home: harrow-2
+  away: hammersmith-2
+  date: 2026-02-26
 - home: hendon-3
   away: muswell-hill-2
   date: 2026-02-26
-- home: hendon-5
-  away: potters-bar-1
-  date: 2026-02-26
 - home: kings-head-2
-  away: hammersmith-2
-  date: 2026-02-26
-- home: kings-head-3
-  away: hammersmith-4
-  date: 2026-02-26
-- home: albany-1
-  away: muswell-hill-1
-  date: 2026-03-02
-- home: willesden-brent-1
-  away: harrow-2
-  date: 2026-03-04
-- home: kings-head-1
-  away: hendon-1
-  date: 2026-03-05
-- home: ealing-1
-  away: kings-head-2
-  date: 2026-03-09
-- home: ealing-2
-  away: hammersmith-3
-  date: 2026-03-09
-- home: muswell-hill-2
-  away: hendon-3
-  date: 2026-03-10
-- home: hendon-2
-  away: willesden-brent-1
-  date: 2026-03-12
-- home: metropolitan-1
-  away: albany-1
-  date: 2026-03-12
-- home: potters-bar-1
-  away: hendon-5
-  date: 2026-03-16
-- home: hackney-2
-  away: hammersmith-4
-  date: 2026-03-18
-- home: harrow-1
   away: ealing-1
-  date: 2026-03-19
+  date: 2026-02-26
+- home: ealing-2
+  away: potters-bar-1
+  date: 2026-03-02
+- home: hackney-2
+  away: kings-head-3
+  date: 2026-03-04
+- home: willesden-brent-1
+  away: harrow-1
+  date: 2026-03-04
+- home: kings-head-2
+  away: hendon-3
+  date: 2026-03-05
+- home: ealing-2
+  away: hammersmith-4
+  date: 2026-03-09
+- home: potters-bar-1
+  away: hendon-4
+  date: 2026-03-09
+- home: muswell-hill-1
+  away: hammersmith-1
+  date: 2026-03-10
 - home: harrow-2
+  away: ealing-1
+  date: 2026-03-12
+- home: hendon-3
+  away: harrow-1
+  date: 2026-03-12
+- home: hendon-5
+  away: hackney-2
+  date: 2026-03-12
+- home: muswell-hill-1
+  away: metropolitan-1
+  date: 2026-03-17
+- home: muswell-hill-2
+  away: hammersmith-2
+  date: 2026-03-17
+- home: harrow-1
   away: hendon-3
   date: 2026-03-19
-- home: hendon-1
-  away: muswell-hill-1
+- home: hendon-4
+  away: hammersmith-4
   date: 2026-03-19
 - home: kings-head-1
   away: hammersmith-1
   date: 2026-03-19
-- home: willesden-brent-1
-  away: muswell-hill-2
-  date: 2026-03-25
-- home: hendon-4
-  away: hammersmith-4
-  date: 2026-03-26
-- home: hendon-5
-  away: hackney-2
-  date: 2026-03-26
-- home: kings-head-2
-  away: hendon-2
-  date: 2026-03-26
 - home: kings-head-3
-  away: potters-bar-1
+  away: hendon-5
+  date: 2026-03-19
+- home: hackney-2
+  away: hammersmith-3
+  date: 2026-03-25
+- home: harrow-2
+  away: hendon-3
   date: 2026-03-26
-- home: metropolitan-1
-  away: west-london-1
-  date: 2026-03-26
-- home: albany-1
-  away: kings-head-1
+- home: ealing-1
+  away: muswell-hill-2
   date: 2026-03-30
+- home: hackney-1
+  away: west-london-1
+  date: 2026-04-01
 - home: hammersmith-2
   away: harrow-1
   date: 2026-04-02
 - home: hammersmith-3
-  away: ealing-2
+  away: hackney-2
   date: 2026-04-02
-- home: hackney-2
+- home: kings-head-3
   away: hendon-4
-  date: 2026-04-08
-- home: west-london-1
-  away: metropolitan-1
-  date: 2026-04-08
+  date: 2026-04-02
+- home: albany-1
+  away: muswell-hill-1
+  date: 2026-04-06
+- home: hammersmith-2
+  away: kings-head-2
+  date: 2026-04-09
+- home: hammersmith-3
+  away: kings-head-3
+  date: 2026-04-09
+- home: harrow-2
+  away: willesden-brent-1
+  date: 2026-04-09
+- home: hendon-3
+  away: ealing-1
+  date: 2026-04-09
+- home: hammersmith-2
+  away: muswell-hill-2
+  date: 2026-04-16
+- home: hammersmith-3
+  away: potters-bar-1
+  date: 2026-04-16
+- home: harrow-1
+  away: kings-head-2
+  date: 2026-04-16
+- home: hendon-1
+  away: hammersmith-1
+  date: 2026-04-16
+- home: hendon-5
+  away: kings-head-3
+  date: 2026-04-16
+- home: kings-head-1
+  away: albany-1
+  date: 2026-04-16
+- home: hackney-2
+  away: hammersmith-4
+  date: 2026-04-22
 - home: hammersmith-1
   away: hackney-1
-  date: 2026-04-09
-- home: hammersmith-4
-  away: potters-bar-1
-  date: 2026-04-09
-- home: kings-head-3
-  away: hendon-5
-  date: 2026-04-09
-- home: willesden-brent-1
-  away: ealing-1
-  date: 2026-04-15
-- home: hammersmith-2
-  away: hendon-2
-  date: 2026-04-16
-- home: hammersmith-3
-  away: hendon-4
-  date: 2026-04-16
-- home: harrow-1
-  away: muswell-hill-2
-  date: 2026-04-16
-- home: harrow-2
-  away: kings-head-2
-  date: 2026-04-16
-- home: hendon-1
-  away: west-london-1
-  date: 2026-04-16
-- home: potters-bar-1
-  away: hackney-2
-  date: 2026-04-20
-- home: kings-head-3
-  away: ealing-2
   date: 2026-04-23
-- home: metropolitan-1
-  away: hammersmith-1
-  date: 2026-04-23
-- home: muswell-hill-1
-  away: hendon-1
-  date: 2026-04-28
-- home: muswell-hill-2
-  away: harrow-1
-  date: 2026-04-28
-- home: willesden-brent-1
-  away: hendon-3
-  date: 2026-04-29
 - home: hammersmith-2
   away: harrow-2
-  date: 2026-04-30
-- home: hammersmith-3
-  away: potters-bar-1
-  date: 2026-04-30
+  date: 2026-04-23
+- home: hendon-1
+  away: muswell-hill-1
+  date: 2026-04-23
 - home: hendon-2
   away: ealing-1
-  date: 2026-04-30
-- home: hendon-4
-  away: hackney-2
-  date: 2026-04-30
+  date: 2026-04-23
 - home: kings-head-1
+  away: metropolitan-1
+  date: 2026-04-23
+- home: hackney-2
+  away: ealing-2
+  date: 2026-04-29
+- home: hammersmith-1
+  away: muswell-hill-1
+  date: 2026-04-30
+- home: hammersmith-2
+  away: hendon-3
+  date: 2026-04-30
+- home: hendon-1
   away: albany-1
   date: 2026-04-30
-- home: ealing-2
+- home: kings-head-2
+  away: willesden-brent-1
+  date: 2026-04-30
+- home: potters-bar-1
   away: kings-head-3
   date: 2026-05-04
-- home: west-london-1
-  away: hackney-1
-  date: 2026-05-06
 - home: muswell-hill-2
   away: hendon-2
-  date: 2026-05-12
-- home: harrow-2
-  away: hammersmith-2
-  date: 2026-05-14
-- home: hendon-3
-  away: kings-head-2
-  date: 2026-05-14
-- home: hendon-5
-  away: hammersmith-4
-  date: 2026-05-14
-- home: ealing-1
+  date: 2026-05-05
+- home: hackney-1
+  away: metropolitan-1
+  date: 2026-05-06
+- home: hackney-2
+  away: hendon-5
+  date: 2026-05-06
+- home: kings-head-1
+  away: muswell-hill-1
+  date: 2026-05-07
+- home: albany-1
+  away: west-london-1
+  date: 2026-05-11
+- home: muswell-hill-2
   away: harrow-1
+  date: 2026-05-12
+- home: willesden-brent-1
+  away: hendon-2
+  date: 2026-05-13
+- home: albany-1
+  away: kings-head-1
   date: 2026-05-18
-- home: muswell-hill-1
-  away: hammersmith-1
-  date: 2026-05-19
-- home: hendon-4
-  away: ealing-2
-  date: 2026-05-21
+- home: ealing-2
+  away: hackney-2
+  date: 2026-05-18
 - home: potters-bar-1
   away: hammersmith-4
-  date: 2026-05-25
-- home: hackney-1
-  away: kings-head-1
-  date: 2026-05-27
-- home: hammersmith-2
+  date: 2026-05-18
+- home: muswell-hill-2
   away: ealing-1
+  date: 2026-05-19
+- home: muswell-hill-1
+  away: hackney-1
+  date: 2026-05-26
+- home: willesden-brent-1
+  away: hammersmith-2
+  date: 2026-05-27
+- home: hammersmith-1
+  away: west-london-1
   date: 2026-05-28
-- home: hammersmith-3
-  away: hackney-2
+- home: hammersmith-4
+  away: kings-head-3
   date: 2026-05-28
-- home: harrow-2
-  away: muswell-hill-2
-  date: 2026-05-28
-- home: hendon-1
-  away: hammersmith-1
-  date: 2026-05-28
-- home: hendon-3
-  away: willesden-brent-1
-  date: 2026-05-28
+stats:
+  model: |-
+    satisfaction model '': (model_fingerprint: 0x68b6894f6868998c)
+    #Variables: 5'653 (5'470 primary variables)
+      - 5'653 Booleans in [0,1]
+    #kLinear3: 6
+    #kLinearN: 3'610 (#terms: 47'154)
+  solve: |
+    CpSolverResponse summary:
+    status: OPTIMAL
+    objective: 0
+    best_bound: 0
+    integers: 2216
+    booleans: 5642
+    conflicts: 0
+    branches: 6438
+    propagations: 209524
+    integer_propagations: 66211
+    restarts: 0
+    lp_iterations: 0
+    walltime: 0.195524
+    usertime: 0.195524
+    deterministic_time: 0.324075
+    gap_integral: 0
+    solution_fingerprint: 0x77614a8509939d58

--- a/solve.py
+++ b/solve.py
@@ -60,10 +60,10 @@ def solve(
         parameters = dataclasses.replace(
             parameters, earliest_match_date=earliest_match_date
         )
-    fixtures = fmodel.solve(parameters)
+    result = fmodel.solve(parameters)
     output_dir.mkdir(parents=True, exist_ok=True)
     solution_path = output_dir / "solution.yaml"
-    fixturesolution.save_solution(fixtures, team_ids, solution_path)
+    fixturesolution.save_solution(result, team_ids, solution_path)
     return solution_path
 
 

--- a/solve_test.py
+++ b/solve_test.py
@@ -86,8 +86,29 @@ class TestSolve(unittest.TestCase):
             ],
             {"albany-1": ("albany", 1), "hackney-1": ("hackney", 1)},
         )
-        self.assertEqual(len(loaded), 2)  # Albany v Hackney and Hackney v Albany
+        # Albany v Hackney and Hackney v Albany
+        self.assertEqual(len(loaded.fixtures), 2)
         self.assertIn("home: albany-1", solution_path.read_text())
+
+    def test_records_solver_stats_in_solution_yaml(self) -> None:
+        output_dir = self.dir / "out"
+        solution_path = solve.solve(self.spec_path, output_dir)
+
+        contents = solution_path.read_text()
+        self.assertIn("stats:", contents)
+        self.assertIn("satisfaction model", contents)
+        self.assertIn("CpSolverResponse summary", contents)
+
+        loaded = fixturesolution.load_solution(
+            solution_path,
+            [
+                fmodel.Team(division=1, club="albany", index=1),
+                fmodel.Team(division=1, club="hackney", index=1),
+            ],
+            {"albany-1": ("albany", 1), "hackney-1": ("hackney", 1)},
+        )
+        self.assertIn("#Variables", loaded.model_stats)
+        self.assertIn("status:", loaded.solve_stats)
 
     def test_creates_output_dir(self) -> None:
         output_dir = self.dir / "nested" / "out"
@@ -118,7 +139,7 @@ class TestSolve(unittest.TestCase):
             ],
             {"albany-1": ("albany", 1), "hackney-1": ("hackney", 1)},
         )
-        for sf in loaded:
+        for sf in loaded.fixtures:
             self.assertGreaterEqual(sf.date, date(2025, 9, 2))
 
     def test_no_cutoff_by_default(self) -> None:


### PR DESCRIPTION
Previously the model and solver summary blocks were only logged during a solve run. Capture them as data instead, persist them in solution.yaml, and surface them in the report.

- fmodel.solve() now returns a SolveResult (fixtures + model_stats + solve_stats) rather than a bare fixture collection, computing the two stats blocks unconditionally (cheap next to solving) and no longer logging them.
- Extract a _FixtureVars class that owns the decision-variable index bookkeeping, so _build_model and its constraint helpers read as constraints rather than map maintenance.
- fixturesolution: save_solution() takes a SolveResult and writes a trailing "stats" block (as readable YAML literal block scalars, omitted when empty); load_solution() returns a SolveResult. A solution.yaml written before this has no stats key and still loads.
- htmlreport.generate_report() takes a SolveResult and renders a collapsed "Solver diagnostics" <details> section at the foot of the run index when stats are present.
- runs/example/solution.yaml regenerated: it now carries a stats block. The schedule itself also changed -- CP-SAT's default multi-worker solve is non-deterministic, so re-solving picks a different valid schedule.


Claude-Session: https://claude.ai/code/session_014G35pA5EymtKcR3LBJJgBD