### PR TITLE
Fix off-by-one in avoid-coscheduling gap; rename within_days to min_g…

### DIFF
--- a/fixturespec.py
+++ b/fixturespec.py
@@ -425,7 +425,7 @@ _CLUB_CONSTRAINT_FIELD_KEYS = {
 
 _TEAM_CONSTRAINT_FIELD_KEYS = {"unavailable_home_dates", "unavailable_away_dates"}
 
-_AVOID_COSCHEDULING_FIELD_KEYS = {"teams", "within_days", "applies_to"}
+_AVOID_COSCHEDULING_FIELD_KEYS = {"teams", "min_gap_days", "applies_to"}
 
 _HOME_DATES_USED_FIELD_KEYS = {"min", "max"}
 
@@ -666,11 +666,15 @@ def _parse_avoid_coscheduling_teams(
     """Parse a club_constraints entry's optional 'avoid_coscheduling_teams' list.
 
     Each entry names a group of that club's own teams (all of which must belong to
-    this club), an optional 'within_days' window (default 0, i.e. the same date), and
-    an optional 'applies_to' scope ('home', 'away' or the default 'both'): the solver
-    then allows at most one match involving any of those teams -- counting only the
-    matches of the kind named by 'applies_to' -- within any window of that many days,
-    e.g. two teams that share players shouldn't both be fielded on the same date.
+    this club), an optional 'min_gap_days' minimum separation (default 1; 0 or 1
+    both just mean the same date), and an optional 'applies_to' scope ('home',
+    'away' or the default 'both'): the solver then keeps any two matches involving
+    those teams -- counting only the matches of the kind named by 'applies_to' -- at
+    least 'min_gap_days' days apart, so a gap of exactly that many days is allowed
+    and only shorter gaps are forbidden. This is the per-group counterpart of the
+    top-level 'min_gap_days'. E.g. two teams that share players shouldn't both be
+    fielded on the same date (min_gap_days: 1), or within a week of each other
+    (min_gap_days: 7 still permits matches exactly 7 days apart).
     """
     if entries_spec is None:
         return []
@@ -713,13 +717,13 @@ def _parse_avoid_coscheduling_teams(
                 )
             entry_teams.append(team)
 
-        within_days = 0
-        if "within_days" in entry:
-            within_days = _require_int(
-                entry["within_days"], f"{entry_context}.within_days"
+        min_gap_days = 1
+        if "min_gap_days" in entry:
+            min_gap_days = _require_int(
+                entry["min_gap_days"], f"{entry_context}.min_gap_days"
             )
-            if within_days < 0:
-                raise SpecError(f"{entry_context}.within_days must be >= 0")
+            if min_gap_days < 0:
+                raise SpecError(f"{entry_context}.min_gap_days must be >= 0")
 
         applies_to = fmodel.CoschedulingScope.BOTH
         if "applies_to" in entry:
@@ -734,7 +738,7 @@ def _parse_avoid_coscheduling_teams(
 
         constraints.append(
             fmodel.AvoidCoschedulingConstraint(
-                teams=entry_teams, within_days=within_days, applies_to=applies_to
+                teams=entry_teams, min_gap_days=min_gap_days, applies_to=applies_to
             )
         )
 

--- a/fixturespec_test.py
+++ b/fixturespec_test.py
@@ -1284,22 +1284,22 @@ club_constraints:
             list(spec.parameters.avoid_coscheduling_teams),
             [
                 fmodel.AvoidCoschedulingConstraint(
-                    teams=[albany_1, albany_2], within_days=0
+                    teams=[albany_1, albany_2], min_gap_days=1
                 )
             ],
         )
 
-    def test_avoid_coscheduling_teams_within_days_parsed(self) -> None:
+    def test_avoid_coscheduling_teams_min_gap_days_parsed(self) -> None:
         path = self._write(
             self._with_albany_avoid_coscheduling(
                 "    avoid_coscheduling_teams:\n"
                 "      - teams: [albany-1, albany-2]\n"
-                "        within_days: 3\n"
+                "        min_gap_days: 3\n"
             )
         )
         spec = fixturespec.load_spec(path)
         constraints = list(spec.parameters.avoid_coscheduling_teams)
-        self.assertEqual(constraints[0].within_days, 3)
+        self.assertEqual(constraints[0].min_gap_days, 3)
 
     def test_avoid_coscheduling_teams_applies_to_defaults_to_both(self) -> None:
         path = self._write(
@@ -1353,7 +1353,7 @@ club_constraints:
     def test_avoid_coscheduling_teams_missing_teams_field(self) -> None:
         path = self._write(
             self._with_albany_avoid_coscheduling(
-                "    avoid_coscheduling_teams:\n      - within_days: 1\n"
+                "    avoid_coscheduling_teams:\n      - min_gap_days: 1\n"
             )
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "teams"):
@@ -1407,15 +1407,15 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "not supported"):
             fixturespec.load_spec(path)
 
-    def test_avoid_coscheduling_teams_negative_within_days_rejected(self) -> None:
+    def test_avoid_coscheduling_teams_negative_min_gap_days_rejected(self) -> None:
         path = self._write(
             self._with_albany_avoid_coscheduling(
                 "    avoid_coscheduling_teams:\n"
                 "      - teams: [albany-1, albany-2]\n"
-                "        within_days: -1\n"
+                "        min_gap_days: -1\n"
             )
         )
-        with self.assertRaisesRegex(fixturespec.SpecError, "within_days"):
+        with self.assertRaisesRegex(fixturespec.SpecError, "min_gap_days"):
             fixturespec.load_spec(path)
 
     def test_exclude_fixtures_absent(self) -> None:

--- a/fmodel.py
+++ b/fmodel.py
@@ -223,10 +223,13 @@ class CoschedulingScope(enum.Enum):
 
 @dataclasses.dataclass(frozen=True)
 class AvoidCoschedulingConstraint:
-    """At most one match involving any of `teams` may be scheduled within any window
-    of `within_days` days -- e.g. within_days=0 (the default) means no two of them
-    may share a date. Typically used for a club's own teams that draw from the same
-    pool of players (e.g. adjacent-division teams), but not restricted to that.
+    """Any two matches involving `teams` must be scheduled at least `min_gap_days`
+    days apart -- i.e. a separation of exactly `min_gap_days` days is allowed, and
+    only shorter gaps are forbidden. This is the per-group counterpart of
+    Parameters.min_gap_days (which applies to every team); min_gap_days=1 (the
+    default) and min_gap_days=0 both mean simply that no two of them may share a
+    date. Typically used for a club's own teams that draw from the same pool of
+    players (e.g. adjacent-division teams), but not restricted to that.
 
     `applies_to` narrows which of those teams' matches count: CoschedulingScope.HOME
     only their home matches, CoschedulingScope.AWAY only their away matches,
@@ -236,7 +239,7 @@ class AvoidCoschedulingConstraint:
     """
 
     teams: Collection[Team]
-    within_days: int = 0
+    min_gap_days: int = 1
     applies_to: CoschedulingScope = CoschedulingScope.BOTH
 
 
@@ -370,7 +373,11 @@ class Parameters:
 
 
 def date_windows(dates: Collection[date], window_days: int) -> list[frozenset[date]]:
-    """Given a list of dates and a window size, return the maximal subsets of dates which fall within the window size."""
+    """Given a list of dates and a window size, return the maximal subsets of dates
+    which fall within the window size. The bound is inclusive: two dates exactly
+    `window_days` apart share a window. Callers enforcing a minimum gap of N days
+    between events therefore pass `window_days = N - 1`, so that a gap of exactly N
+    lands outside every window."""
     all_windows: list[frozenset[date]] = []
     dates = sorted(dates)
     for i, d in enumerate(dates):
@@ -497,8 +504,9 @@ def _add_avoid_coscheduling_constraints(
     constraints: Collection[AvoidCoschedulingConstraint],
     fixture_vars: _FixtureVars,
 ) -> None:
-    """For each AvoidCoschedulingConstraint, ensure at most one match involving any
-    of its teams is scheduled within any window of within_days days. The constraint's
+    """For each AvoidCoschedulingConstraint, ensure any two matches involving its
+    teams are scheduled at least min_gap_days days apart (a gap of exactly
+    min_gap_days days is allowed; only shorter gaps are forbidden). The constraint's
     `applies_to` scope limits which of those teams' matches are counted -- home only,
     away only, or (by default) both.
     """
@@ -523,7 +531,13 @@ def _add_avoid_coscheduling_constraints(
             ):
                 vars_by_date[d].append(var)
 
-        for window in date_windows(vars_by_date.keys(), constraint.within_days):
+        # date_windows groups dates up to and including its window arg apart, so
+        # pass min_gap_days - 1: a separation of exactly min_gap_days (e.g. two
+        # matches a week apart when min_gap_days=7) must be allowed, not treated as
+        # a violation -- the same convention as the per-team min_gap_days constraint
+        # in _build_model. min_gap_days <= 1 still forbids sharing a date (each
+        # date's own singleton window collects every counted match on it).
+        for window in date_windows(vars_by_date.keys(), constraint.min_gap_days - 1):
             window_vars = [v for d in window for v in vars_by_date[d]]
             if len(window_vars) > 1:
                 model.add(cp_model.LinearExpr.Sum(window_vars) <= 1)

--- a/model_test.py
+++ b/model_test.py
@@ -1086,15 +1086,16 @@ class TestTeamConstraints(unittest.TestCase):
 
 
 class TestAvoidCoschedulingTeams(unittest.TestCase):
-    """Test cases for AvoidCoschedulingConstraint: at most one match involving any of
-    a given set of teams may be scheduled within any window of within_days days.
+    """Test cases for AvoidCoschedulingConstraint: any two matches involving a given
+    set of teams must be scheduled at least min_gap_days days apart (a gap of exactly
+    min_gap_days days is allowed; only shorter gaps are forbidden).
     """
 
-    def test_within_days_defaults_to_zero(self) -> None:
+    def test_min_gap_days_defaults_to_one(self) -> None:
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=2, club="A", index=2)
         self.assertEqual(
-            fmodel.AvoidCoschedulingConstraint(teams=[a1, a2]).within_days, 0
+            fmodel.AvoidCoschedulingConstraint(teams=[a1, a2]).min_gap_days, 1
         )
 
     def test_applies_to_defaults_to_both(self) -> None:
@@ -1194,12 +1195,12 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
         with self.assertRaises(ValueError):
             fmodel.solve(params)
 
-    def test_within_days_window_enforced(self) -> None:
-        """With within_days=3, A1 and A2's home matches must land on dates more than
-        3 days apart -- of A's three candidate dates (Jan 1, 3, 10), only pairings
-        involving Jan 10 satisfy that, so the solver must pick one of those. (X's two
-        home dates, for A1/A2's away legs, are also more than 3 days apart, so they
-        don't introduce a second conflict of their own.)"""
+    def test_min_gap_days_forbids_shorter_gaps(self) -> None:
+        """With min_gap_days=3, A1 and A2's home matches must land at least 3 days
+        apart -- of A's three candidate dates (Jan 1, 3, 10), the only forbidden
+        pairing is Jan 1 / Jan 3 (2 days), so the solver must pick a pairing that
+        involves Jan 10. (X's two home dates, for A1/A2's away legs, are far enough
+        apart not to introduce a second conflict of their own.)"""
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=2, club="A", index=2)
         x1 = fmodel.Team(division=1, club="X", index=1)
@@ -1217,13 +1218,46 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
             },
             min_gap_days=7,
             avoid_coscheduling_teams=[
-                fmodel.AvoidCoschedulingConstraint(teams=[a1, a2], within_days=3)
+                fmodel.AvoidCoschedulingConstraint(teams=[a1, a2], min_gap_days=3)
             ],
         )
         fixtures = list(fmodel.solve(params).fixtures)
         a1_home_date = next(sf.date for sf in fixtures if sf.fixture.home_team == a1)
         a2_home_date = next(sf.date for sf in fixtures if sf.fixture.home_team == a2)
-        self.assertGreater(abs((a1_home_date - a2_home_date).days), 3)
+        self.assertGreaterEqual(abs((a1_home_date - a2_home_date).days), 3)
+
+    def test_min_gap_days_allows_exact_gap(self) -> None:
+        """min_gap_days=N is a minimum separation: a gap of exactly N days is legal,
+        only shorter gaps are forbidden. With min_gap_days=7 and A's only two home
+        dates exactly a week apart (Jan 1 and Jan 8), A1 and A2 must take one each --
+        the schedule stays feasible. An off-by-one that treated a 7-day gap as a
+        violation would make this infeasible."""
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        a2 = fmodel.Team(division=2, club="A", index=2)
+        x1 = fmodel.Team(division=1, club="X", index=1)
+        x2 = fmodel.Team(division=2, club="X", index=2)
+        params = fmodel.Parameters(
+            teams=[a1, a2, x1, x2],
+            home_dates={
+                "A": [date(2025, 1, 1), date(2025, 1, 8)],
+                "X": [date(2025, 3, 1), date(2025, 3, 15)],
+            },
+            unavailable_away_dates={"A": [], "X": []},
+            max_concurrent_matches={
+                "A": _home_limit(2),
+                "X": _home_limit(2),
+            },
+            min_gap_days=7,
+            avoid_coscheduling_teams=[
+                fmodel.AvoidCoschedulingConstraint(teams=[a1, a2], min_gap_days=7)
+            ],
+        )
+        fixtures = list(fmodel.solve(params).fixtures)
+        a1_home_date = next(sf.date for sf in fixtures if sf.fixture.home_team == a1)
+        a2_home_date = next(sf.date for sf in fixtures if sf.fixture.home_team == a2)
+        self.assertEqual(
+            {a1_home_date, a2_home_date}, {date(2025, 1, 1), date(2025, 1, 8)}
+        )
 
     def test_direct_fixture_between_constrained_teams_not_double_counted(self) -> None:
         """A single match between two constrained teams should count once towards

--- a/spec-schema.json
+++ b/spec-schema.json
@@ -305,11 +305,11 @@
           "minItems": 2,
           "uniqueItems": true
         },
-        "within_days": {
+        "min_gap_days": {
           "type": "integer",
-          "default": 0,
+          "default": 1,
           "minimum": 0,
-          "description": "The solver allows at most one match involving any of 'teams' -- home or away -- within any window of this many days. The default, 0, means no two of them may share a date at all; a higher value also keeps them some number of days apart."
+          "description": "Minimum number of days required between any two matches involving 'teams' (of the kind selected by 'applies_to'). The per-group counterpart of the top-level 'min_gap_days': a gap of exactly this many days is allowed, fewer is not. The default, 1 (0 behaves the same), means no two of them may share a date; 7 keeps them at least a week apart while still permitting matches exactly 7 days apart."
         },
         "applies_to": {
           "type": "string",

--- a/spec_schema_test.py
+++ b/spec_schema_test.py
@@ -109,7 +109,7 @@ club_constraints:
         unavailable_away_dates: [2025-09-22]
     avoid_coscheduling_teams:
       - teams: [hackney-1, hackney-5]
-        within_days: 0
+        min_gap_days: 7
         applies_to: away
 
 fixed_fixtures:


### PR DESCRIPTION
…ap_days

The avoid_coscheduling_teams constraint passed its window parameter straight to date_windows(), whose bound is inclusive, so within_days=7 forbade matches scheduled exactly 7 days apart. The per-team gap constraint already compensates for this by passing min_gap_days - 1, precisely so a gap of exactly N days stays legal; the coscheduling path did not. Subtract 1 there too so the two uses of date_windows() agree.

Rename the field to min_gap_days (default now 1, was 0; the default's behaviour -- forbid sharing a date -- is unchanged) so it matches the top-level Parameters.min_gap_days it mirrors and can't be misread the way "within 7 days" was. This renames the avoid_coscheduling_teams entry key in the spec schema accordingly.

Also document date_windows()'s inclusive boundary and the N - 1 convention its callers use.


Claude-Session: https://claude.ai/code/session_019icqQJ7L1MWjmufaS7qxoE