### PR TITLE
Record a SHA-256 checksum of the spec file in solution.yaml

### DIFF
--- a/fixturesolution.py
+++ b/fixturesolution.py
@@ -21,7 +21,10 @@ back into a report -- without re-running the solver -- given the original spec.
 Each fixture is identified by its home and away teams' stable spec team ID
 (the same IDs used by fixed_fixtures/exclude_fixtures in the spec file, e.g.
 "albany-1"), so a solution.yaml only makes sense alongside the spec it was
-solved from. fmodel.Team itself doesn't carry that ID (it's a
+solved from. To make that pairing checkable, the file also records a
+"spec_checksum" of the spec's bytes (see fixturespec.spec_checksum()).
+
+fmodel.Team itself doesn't carry that ID (it's a
 club/index/division/name_override value type, solver-internal), so callers
 provide a team_ids mapping -- see fixturespec.load_team_ids() -- to translate
 between the two.
@@ -94,6 +97,10 @@ def save_solution(
     pair (see fixturespec.load_team_ids()) -- used to translate fmodel.Team,
     which doesn't carry a spec team ID, back into one.
 
+    result.spec_checksum, when non-empty, is written under a "spec_checksum" key
+    after the fixtures so the solution records a fingerprint of the exact spec it
+    was solved from (see fixturespec.spec_checksum()).
+
     result.model_stats/result.solve_stats, when non-empty, are written under a
     trailing "stats" key so the OR-Tools summaries travel with the schedule to
     the report; empty strings leave the key out entirely. load_solution()
@@ -112,6 +119,8 @@ def save_solution(
     ]
     entries.sort(key=lambda e: (e["date"], e["home"], e["away"]))
     document: dict[str, Any] = {"fixtures": entries}
+    if result.spec_checksum:
+        document["spec_checksum"] = result.spec_checksum
     if result.model_stats or result.solve_stats:
         document["stats"] = {
             "model": result.model_stats,
@@ -151,6 +160,16 @@ def _load_stats(data: dict[str, Any], path: Path) -> tuple[str, str]:
     return model_stats, solve_stats
 
 
+def _load_spec_checksum(data: dict[str, Any], path: Path) -> str:
+    """Pull the optional spec-file checksum out of a loaded solution document. A
+    file with no 'spec_checksum' key (one written before it was recorded) yields
+    an empty string."""
+    checksum = data.get("spec_checksum", "")
+    if not isinstance(checksum, str):
+        raise SolutionError(f"{path}: 'spec_checksum' must be a string")
+    return checksum
+
+
 def load_solution(
     path: Path,
     teams: Collection[fmodel.Team],
@@ -162,8 +181,9 @@ def load_solution(
     solution was solved from) to recover full Team objects (division,
     name_override, etc.).
 
-    Any model/solver summary text stored under the file's 'stats' key comes back
-    on the result too (empty strings if the file predates it).
+    Any model/solver summary text stored under the file's 'stats' key, and the
+    spec-file checksum under its 'spec_checksum' key, come back on the result too
+    (empty strings if the file predates either).
     """
     with path.open() as f:
         data = yaml.safe_load(f)
@@ -176,6 +196,7 @@ def load_solution(
         raise SolutionError(f"{path}: 'fixtures' must be a list")
 
     model_stats, solve_stats = _load_stats(data, path)
+    spec_file_checksum = _load_spec_checksum(data, path)
 
     teams_by_club_index = {(t.club, t.index): t for t in teams}
     teams_by_id = {
@@ -219,5 +240,8 @@ def load_solution(
             )
         )
     return fmodel.SolveResult(
-        fixtures=result, model_stats=model_stats, solve_stats=solve_stats
+        fixtures=result,
+        model_stats=model_stats,
+        solve_stats=solve_stats,
+        spec_checksum=spec_file_checksum,
     )

--- a/fixturesolution_test.py
+++ b/fixturesolution_test.py
@@ -201,6 +201,48 @@ class TestSaveAndLoadSolution(unittest.TestCase):
         with self.assertRaisesRegex(fixturesolution.SolutionError, "stats"):
             fixturesolution.load_solution(self.path, [_ALBANY_1, _HACKNEY_1], _TEAM_IDS)
 
+    def test_spec_checksum_round_trip(self) -> None:
+        checksum = "sha256:" + "0" * 64
+        fixturesolution.save_solution(
+            fmodel.SolveResult(
+                [_sf(_ALBANY_1, _HACKNEY_1, date(2025, 9, 1))],
+                spec_checksum=checksum,
+            ),
+            _TEAM_IDS,
+            self.path,
+        )
+        contents = self.path.read_text()
+        self.assertIn(f"spec_checksum: {checksum}", contents)
+        # written after the fixtures
+        self.assertGreater(contents.index("spec_checksum"), contents.index("fixtures"))
+
+        loaded = fixturesolution.load_solution(
+            self.path, [_ALBANY_1, _HACKNEY_1], _TEAM_IDS
+        )
+        self.assertEqual(loaded.spec_checksum, checksum)
+
+    def test_spec_checksum_key_omitted_when_not_given(self) -> None:
+        fixturesolution.save_solution(
+            fmodel.SolveResult([_sf(_ALBANY_1, _HACKNEY_1, date(2025, 9, 1))]),
+            _TEAM_IDS,
+            self.path,
+        )
+        self.assertNotIn("spec_checksum", self.path.read_text())
+
+    def test_spec_checksum_absent_loads_as_empty_string(self) -> None:
+        self.path.write_text(
+            "fixtures:\n  - home: albany-1\n    away: hackney-1\n    date: 2025-09-01\n"
+        )
+        loaded = fixturesolution.load_solution(
+            self.path, [_ALBANY_1, _HACKNEY_1], _TEAM_IDS
+        )
+        self.assertEqual(loaded.spec_checksum, "")
+
+    def test_spec_checksum_not_a_string(self) -> None:
+        self.path.write_text("fixtures: []\nspec_checksum: [1, 2]\n")
+        with self.assertRaisesRegex(fixturesolution.SolutionError, "spec_checksum"):
+            fixturesolution.load_solution(self.path, [_ALBANY_1, _HACKNEY_1], _TEAM_IDS)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/fixturespec.py
+++ b/fixturespec.py
@@ -21,6 +21,7 @@ of the expected YAML structure; README.md covers how to use it.
 from __future__ import annotations
 
 import dataclasses
+import hashlib
 import itertools
 import logging
 from collections.abc import Mapping
@@ -972,6 +973,25 @@ def _load_yaml_data(path: Path) -> dict[str, Any]:
     return data
 
 
+_CHECKSUM_ALGORITHM = "sha256"
+
+
+def spec_checksum(spec_path: str | Path) -> str:
+    """Return a self-describing checksum ("sha256:<hex>") of the raw bytes of the
+    spec file at spec_path.
+
+    load_spec() records this on the Parameters it returns, so it travels through
+    fmodel.solve() onto the SolveResult and into solution.yaml: a solution then
+    carries a tamper-evident fingerprint of the exact spec it was solved from,
+    and report.py recomputes it from the spec it's handed and warns on a
+    mismatch. Being a hash of the file's bytes, it changes if the spec is merely
+    reformatted -- so a mismatch means "re-check this pairing", not necessarily
+    "the schedule is wrong".
+    """
+    digest = hashlib.new(_CHECKSUM_ALGORITHM, Path(spec_path).read_bytes()).hexdigest()
+    return f"{_CHECKSUM_ALGORITHM}:{digest}"
+
+
 def load_team_ids(spec_path: str | Path) -> dict[str, tuple[str, int]]:
     """Map each team ID in a spec to its (club, index) pair.
 
@@ -1086,6 +1106,7 @@ def load_spec(spec_path: str | Path) -> Spec:
         home_dates=home_dates,
         unavailable_away_dates=unavailable_away_dates,
         division_schemes=divisions.schemes,
+        spec_checksum=spec_checksum(path),
         **kwargs,
     )
     name = _require_str(data.get("name", ""), f"{path}: 'name'")

--- a/fixturespec_test.py
+++ b/fixturespec_test.py
@@ -14,6 +14,7 @@
 
 """Test cases for the YAML fixture specification reader."""
 
+import hashlib
 import tempfile
 import unittest
 from datetime import date
@@ -250,6 +251,19 @@ class TestLoadSpec(unittest.TestCase):
             fixturespec.SpecError, "top-level 'min_gap_days' is no longer supported"
         ):
             fixturespec.load_spec(path)
+
+    def test_spec_checksum_helper_is_self_describing_sha256(self) -> None:
+        path = self._write("name: Test\n")
+        self.assertEqual(
+            fixturespec.spec_checksum(path),
+            "sha256:" + hashlib.sha256(b"name: Test\n").hexdigest(),
+        )
+
+    def test_load_spec_records_matching_spec_checksum_on_parameters(self) -> None:
+        path = self._write(_MINIMAL_SPEC)
+        spec = fixturespec.load_spec(path)
+        self.assertEqual(spec.parameters.spec_checksum, fixturespec.spec_checksum(path))
+        self.assertTrue(spec.parameters.spec_checksum.startswith("sha256:"))
 
     def test_latest_internal_match_date_absent(self) -> None:
         path = self._write(_MINIMAL_SPEC)

--- a/fmodel.py
+++ b/fmodel.py
@@ -71,11 +71,18 @@ class SolveResult:
     rendering them (fixturesolution.save_solution into solution.yaml, the report's
     "Solver diagnostics" section) needs no structure. They default to "" for a
     solution file written before the text was recorded.
+
+    spec_checksum, when set, is a self-describing digest ("sha256:<hex>") of the
+    spec file this schedule was solved from -- see fixturespec.spec_checksum().
+    solve() copies it straight off Parameters.spec_checksum, which
+    fixturespec.load_spec() fills in; a solution file written before checksums
+    were recorded loads as "". The report verifies it against the spec it's given.
     """
 
     fixtures: list[ScheduledFixture]
     model_stats: str = ""
     solve_stats: str = ""
+    spec_checksum: str = ""
 
 
 ClubT = str
@@ -314,6 +321,11 @@ class Parameters:
     division_schemes: Mapping[int, FixtureScheme] = dataclasses.field(
         default_factory=dict
     )
+    # Pure provenance metadata: a self-describing digest ("sha256:<hex>") of the
+    # spec file these parameters were loaded from, set by fixturespec.load_spec()
+    # (see fixturespec.spec_checksum()). It has no effect on solving; solve() just
+    # copies it onto its SolveResult so it can be written into solution.yaml.
+    spec_checksum: str = ""
 
     def __post_init__(self) -> None:
         _check_no_duplicate_teams(self.teams)
@@ -691,4 +703,5 @@ def solve(params: Parameters) -> SolveResult:
         fixtures=_extract_fixtures(solver, fixture_vars),
         model_stats=model_stats,
         solve_stats=solve_stats,
+        spec_checksum=params.spec_checksum,
     )

--- a/model_test.py
+++ b/model_test.py
@@ -15,6 +15,7 @@
 """Test cases for fixtures model constraints."""
 
 import collections
+import dataclasses
 import random
 import unittest
 from datetime import date, timedelta
@@ -272,6 +273,13 @@ class TestSolveStats(unittest.TestCase):
         self.assertIn("#Variables", result.model_stats)
         self.assertIn("CpSolverResponse summary", result.solve_stats)
         self.assertIn("status:", result.solve_stats)
+
+    def test_copies_spec_checksum_from_parameters_to_result(self) -> None:
+        random.seed(42)
+        params = dataclasses.replace(
+            genfixtures.build_params(), spec_checksum="sha256:" + "ab" * 32
+        )
+        self.assertEqual(fmodel.solve(params).spec_checksum, "sha256:" + "ab" * 32)
 
     def test_raises_when_infeasible(self) -> None:
         # Two teams of one club, only a single shared home date: both the A1 v A2

--- a/report.py
+++ b/report.py
@@ -30,12 +30,35 @@ every run's report plus the top-level index -- into _site/, run build_site.py.
 from __future__ import annotations
 
 import argparse
+import logging
 from pathlib import Path
 
 import csvreport
 import fixturesolution
 import fixturespec
+import fmodel
 import htmlreport
+
+logger = logging.getLogger(__name__)
+
+
+def _check_spec_checksum(spec_path: Path, result: fmodel.SolveResult) -> None:
+    """Warn if the solution records a spec checksum that doesn't match the spec
+    we've been handed -- i.e. this report is being built from a different (or
+    reformatted) spec than the one the schedule was solved from."""
+    recorded = result.spec_checksum
+    if not recorded:
+        return
+    actual = fixturespec.spec_checksum(spec_path)
+    if actual != recorded:
+        logger.warning(
+            "Spec checksum mismatch: the solution was solved from a spec hashing "
+            "to %s, but %s hashes to %s -- this report may not match the spec the "
+            "schedule was solved from.",
+            recorded,
+            spec_path,
+            actual,
+        )
 
 
 def report(spec_path: Path, solution_path: Path, output_dir: Path) -> Path:
@@ -47,6 +70,7 @@ def report(spec_path: Path, solution_path: Path, output_dir: Path) -> Path:
     result = fixturesolution.load_solution(
         solution_path, spec.parameters.teams, team_ids
     )
+    _check_spec_checksum(spec_path, result)
     csvreport.generate_csv(spec, result.fixtures, output_dir)
     return htmlreport.generate_report(spec, result, output_dir)
 
@@ -61,6 +85,8 @@ def main() -> None:
         "output_dir", type=Path, help="Directory to write this run's HTML report into"
     )
     args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
 
     run_index_path = report(args.spec, args.solution, args.output_dir)
 

--- a/report_test.py
+++ b/report_test.py
@@ -116,6 +116,18 @@ class TestReport(unittest.TestCase):
         self.assertIn("satisfaction model", index)
         self.assertIn("CpSolverResponse summary", index)
 
+    def test_matching_spec_checksum_produces_no_warning(self) -> None:
+        with self.assertNoLogs(report.logger, level="WARNING"):
+            report.report(self.spec_path, self.solution_path, self.output_dir)
+
+    def test_mismatched_spec_checksum_warns(self) -> None:
+        self.spec_path.write_text(_SPEC + "\n# edited after solving\n")
+
+        with self.assertLogs(report.logger, level="WARNING") as cm:
+            report.report(self.spec_path, self.solution_path, self.output_dir)
+
+        self.assertIn("checksum mismatch", "\n".join(cm.output).lower())
+
     def test_does_not_require_resolving(self) -> None:
         """Deleting nothing but the intermediate solving step should still work:
         report.py only reads solution.yaml, never calls fmodel.solve()."""

--- a/runs/example/solution.yaml
+++ b/runs/example/solution.yaml
@@ -548,6 +548,7 @@ fixtures:
 - home: hendon-1
   away: hackney-1
   date: 2026-05-28
+spec_checksum: sha256:047ca7f38776496599e9ac9c8e63000e9720c7a029fa407f7cad6f8201e78eeb
 stats:
   model: |-
     satisfaction model '': (model_fingerprint: 0x68b3d8a681956b57)

--- a/solve_test.py
+++ b/solve_test.py
@@ -20,6 +20,7 @@ from datetime import date
 from pathlib import Path
 
 import fixturesolution
+import fixturespec
 import fmodel
 import solve
 
@@ -109,6 +110,24 @@ class TestSolve(unittest.TestCase):
         )
         self.assertIn("#Variables", loaded.model_stats)
         self.assertIn("status:", loaded.solve_stats)
+
+    def test_records_spec_checksum_matching_the_spec_file(self) -> None:
+        output_dir = self.dir / "out"
+        solution_path = solve.solve(self.spec_path, output_dir)
+
+        expected = fixturespec.spec_checksum(self.spec_path)
+        self.assertTrue(expected.startswith("sha256:"))
+        self.assertIn(f"spec_checksum: {expected}", solution_path.read_text())
+
+        loaded = fixturesolution.load_solution(
+            solution_path,
+            [
+                fmodel.Team(division=1, club="albany", index=1),
+                fmodel.Team(division=1, club="hackney", index=1),
+            ],
+            {"albany-1": ("albany", 1), "hackney-1": ("hackney", 1)},
+        )
+        self.assertEqual(loaded.spec_checksum, expected)
 
     def test_creates_output_dir(self) -> None:
         output_dir = self.dir / "nested" / "out"


### PR DESCRIPTION
fixturespec.spec_checksum() hashes the spec file's raw bytes into a self-describing "sha256:<hex>" string. load_spec() records it on the Parameters it returns, so it travels through fmodel.solve() onto the SolveResult and is written into solution.yaml (under a "spec_checksum" key after the fixtures). load_solution() reads it back; an older file without the key loads as "".

report.py recomputes the checksum from the spec it's handed and logs a warning on a mismatch, so regenerating a report from a changed (or reformatted) spec is flagged rather than silently producing a report that doesn't match the schedule.


Claude-Session: https://claude.ai/code/session_01NWWKJu3PiSoGcbc4FwVaF5