### PR TITLE
Consolidate match-count constraints into match_count_limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,19 +91,35 @@ divisions:                       # each team's division: the only place it's giv
 
 club_constraints:
   defaults:
-    min_gap_days: 7                # optional spec-wide default (7 if omitted)
+    match_count_limits:              # spec-wide, applied to every club
+      - override_key: weekly-gap     # each team plays at most once a week
+        apply_per: each_team
+        time_window_days: 7
+        max: 1
+      - override_key: venue-capacity # at most two home matches a night
+        venue_scope: home
+        max: 2
   albany:
     home_dates: [2025-09-01, 2025-09-15, 2025-09-29]
-    max_concurrent_matches: { home: 2 }
   hackney:
     home_dates: [2025-09-08, 2025-09-22]
-    max_concurrent_matches: { home: 2 }
-    min_gap_days: 14              # optional per-club override of the default
+    match_count_limits:
+      - override_key: weekly-gap     # a fortnight between this club's matches
+        apply_per: each_team          # (replaces the like-keyed spec-wide default)
+        time_window_days: 14
+        max: 1
 ```
 
+`match_count_limits` is the one match-count constraint: each entry caps how many
+matches involving a set of teams may fall in any window of `time_window_days`
+consecutive days. It expresses a per-team gap (`apply_per: each_team`), a venue's
+concurrent-match capacity (`venue_scope: home`, with per-date `overrides`), and a
+keep-these-teams-apart rule (`teams: [...]`) alike. Every spec-wide default entry
+carries a unique `override_key`; a club entry repeating one replaces that default
+for the club, and a club entry with no `override_key` is additive.
+
 That's only a fraction of what the format supports -- per-club/per-team date
-exclusions, per-scope (home/away/any) concurrency limits with per-date
-overrides, pinned and withheld fixtures, and more. For the full field-by-field
+exclusions, pinned and withheld fixtures, and more. For the full field-by-field
 reference, see:
 
 - **[spec-schema.json](spec-schema.json)**, the JSON Schema every field is

--- a/build_site_test.py
+++ b/build_site_test.py
@@ -55,8 +55,10 @@ divisions:
 
 club_constraints:
   defaults:
-    max_concurrent_matches:
-      home: 1
+    match_count_limits:
+      - override_key: venue-capacity
+        venue_scope: home
+        max: 1
   albany:
     home_dates: [2025-09-01, 2025-09-29]
   hackney:

--- a/fixturespec.py
+++ b/fixturespec.py
@@ -311,75 +311,6 @@ def _parse_divisions(
     )
 
 
-def _parse_concurrency_limit_value(value: Any, context: str) -> fmodel.ConcurrencyLimit:
-    """One ConcurrencyScope's limit within a max_concurrent_matches entry: either a
-    plain integer, null (no limit from this mechanism -- see
-    fmodel.ConcurrencyLimit), or a mapping with 'default' (an integer or null) and
-    optionally 'overrides' (a date-keyed mapping of integer-or-null overrides of
-    that default).
-    """
-    if value is None or (isinstance(value, int) and not isinstance(value, bool)):
-        return fmodel.ConcurrencyLimit(default=value)
-    if isinstance(value, dict):
-        unsupported = value.keys() - {"default", "overrides"}
-        if unsupported:
-            raise SpecError(f"{context}: unsupported field(s) {sorted(unsupported)}")
-        if "default" not in value:
-            raise SpecError(f"{context} missing required field 'default'")
-        default = _require_int_or_none(value["default"], f"{context}.default")
-
-        overrides_spec = value.get("overrides")
-        overrides: dict[date, int | None] = {}
-        if overrides_spec is not None:
-            if not isinstance(overrides_spec, dict):
-                raise SpecError(f"{context}.overrides must be a mapping")
-            for date_key, count in overrides_spec.items():
-                override_date = _parse_date(date_key, f"{context}.overrides")
-                overrides[override_date] = _require_int_or_none(
-                    count, f"{context}.overrides[{date_key!r}]"
-                )
-        return fmodel.ConcurrencyLimit(default=default, overrides=overrides)
-    raise SpecError(
-        f"{context}: expected an integer, null (unlimited), or a mapping with "
-        f"'default' and optionally 'overrides', got {value!r}"
-    )
-
-
-_CONCURRENCY_SCOPES_BY_KEY = {s.value: s for s in fmodel.ConcurrencyScope}
-
-
-def _parse_max_concurrent_matches_by_scope(
-    value: Any, context: str
-) -> dict[fmodel.ConcurrencyScope, fmodel.ConcurrencyLimit]:
-    """A max_concurrent_matches entry: a mapping keyed by ConcurrencyScope value
-    ('home', 'away', 'any'), each value a per-scope limit (see
-    _parse_concurrency_limit_value). At least one scope must be given. Returns the
-    parsed limits keyed by scope, for merging with any club_constraints.defaults
-    entry by the caller.
-    """
-    if not isinstance(value, dict):
-        raise SpecError(
-            f"{context}: expected a mapping keyed by "
-            f"{sorted(_CONCURRENCY_SCOPES_BY_KEY)}, got {value!r}"
-        )
-    unsupported = value.keys() - _CONCURRENCY_SCOPES_BY_KEY.keys()
-    if unsupported:
-        raise SpecError(
-            f"{context}: unsupported scope(s) {sorted(unsupported)} "
-            f"(only {sorted(_CONCURRENCY_SCOPES_BY_KEY)} are)"
-        )
-    if not value:
-        raise SpecError(
-            f"{context}: needs at least one of {sorted(_CONCURRENCY_SCOPES_BY_KEY)}"
-        )
-    return {
-        _CONCURRENCY_SCOPES_BY_KEY[key]: _parse_concurrency_limit_value(
-            scope_value, f"{context}.{key}"
-        )
-        for key, scope_value in value.items()
-    }
-
-
 def _parse_home_dates_used_value(
     value: Any, context: str
 ) -> fmodel.HomeDatesUsedBounds:
@@ -418,42 +349,77 @@ def _parse_home_dates_used_value(
 _CLUB_CONSTRAINT_FIELD_KEYS = {
     "home_dates",
     "unavailable_away_dates",
-    "min_gap_days",
-    "max_concurrent_matches",
     "home_dates_used",
     "latest_match_date",
     "teams",
-    "avoid_coscheduling_teams",
+    "match_count_limits",
 }
 
 _TEAM_CONSTRAINT_FIELD_KEYS = {"unavailable_home_dates", "unavailable_away_dates"}
 
-_AVOID_COSCHEDULING_FIELD_KEYS = {"teams", "min_gap_days", "applies_to"}
+_MATCH_COUNT_LIMIT_FIELD_KEYS = {
+    "teams",
+    "max",
+    "time_window_days",
+    "venue_scope",
+    "apply_per",
+    "overrides",
+    "override_key",
+}
 
 _HOME_DATES_USED_FIELD_KEYS = {"min", "max"}
 
-# Constraint types with a notion of a default, overridable per club. Other constraint
-# types (home_dates, unavailable_away_dates, home_dates_used, teams,
-# avoid_coscheduling_teams) have no meaningful spec-wide default, so aren't accepted
-# under 'defaults'.
-_CLUB_CONSTRAINT_DEFAULTS_KEYS = {"max_concurrent_matches", "min_gap_days"}
+# match_count_limits is the one constraint type accepted under 'defaults' (a
+# spec-wide list applied to every club). The rest (home_dates,
+# unavailable_away_dates, home_dates_used, latest_match_date, teams) are inherently
+# per-club and have no meaningful spec-wide default.
+_CLUB_CONSTRAINT_DEFAULTS_KEYS = {"match_count_limits"}
+
+_TOP_LEVEL_KEYS = {
+    "name",
+    "draft",
+    "description",
+    "latest_internal_match_date",
+    "avoid_dates",
+    "clubs",
+    "teams",
+    "divisions",
+    "club_constraints",
+    "fixed_fixtures",
+    "exclude_fixtures",
+}
+
+
+@dataclasses.dataclass(frozen=True)
+class _ParsedMatchCountLimit:
+    """One match_count_limits entry, parsed but not yet resolved to concrete Teams.
+
+    `team_ids` is None when the entry omitted 'teams' (meaning "every team of the
+    club it applies to"). `override_key`, on a club entry, names the
+    club_constraints.defaults entry this one replaces for that club; None means the
+    entry is purely additive. Every defaults entry has an `override_key`. `max` is
+    None only for an entry that exists solely to carry `overrides`, or to cancel an
+    inherited default (a club entry with an override_key and nothing else).
+    """
+
+    team_ids: tuple[str, ...] | None
+    max: int | None
+    time_window_days: int
+    venue_scope: fmodel.VenueScope
+    apply_per: fmodel.ApplyPer
+    overrides: Mapping[date, int | None]
+    override_key: str | None
 
 
 @dataclasses.dataclass(frozen=True)
 class _ClubConstraints:
     home_dates: dict[str, list[date]]
     unavailable_away_dates: dict[str, list[date]]
-    # club_constraints.defaults.min_gap_days -- the spec-wide default gap; None if
-    # unset (fmodel.Parameters then supplies its own default). Distinct from
-    # club_min_gap_days below, which holds the per-club overrides.
-    default_min_gap_days: int | None
-    club_min_gap_days: dict[str, int]
     club_latest_match_date: dict[str, date]
-    max_concurrent_matches: dict[str, fmodel.MaxConcurrentMatches]
     home_dates_used: dict[str, fmodel.HomeDatesUsedBounds]
     team_home_dates: dict[fmodel.Team, list[date]]
     team_unavailable_away_dates: dict[fmodel.Team, list[date]]
-    avoid_coscheduling_teams: list[fmodel.AvoidCoschedulingConstraint]
+    match_count_limits: list[fmodel.MatchCountLimit]
 
 
 def _parse_club_constraints(
@@ -462,32 +428,26 @@ def _parse_club_constraints(
     teams: Mapping[str, fmodel.Team],
     path: Path,
 ) -> _ClubConstraints:
-    """Parse the 'club_constraints' section: per-club home_dates, unavailable_away_dates,
-    max_concurrent_matches, home_dates_used, latest_match_date, teams and
-    avoid_coscheduling_teams, keyed directly by club ID.
+    """Parse the 'club_constraints' section: per-club home_dates,
+    unavailable_away_dates, home_dates_used, latest_match_date, teams and
+    match_count_limits, keyed directly by club ID.
 
     A club's optional 'latest_match_date' entry is the last date on which any fixture
     involving one of that club's teams -- home or away -- may be scheduled (a
     fixed_fixtures entry involving the club after it is an error). It has no spec-wide
     default, so it isn't accepted under 'defaults'.
 
-    An optional 'defaults' entry (a sibling of the club entries) supplies spec-wide
-    defaults for constraint types that support one (max_concurrent_matches and
-    min_gap_days). Its max_concurrent_matches is merged with a club's own entry per
-    scope: a club that sets only 'any' still inherits the default 'home' limit, and
-    its own value wins for any scope it does set. Every scope is optional -- a club
-    (and the spec as a whole) may have no concurrency limits at all. Its
-    min_gap_days is the spec-wide minimum gap between two matches involving the same
-    team; club_constraints.<club>.min_gap_days overrides it for that club.
+    An optional 'defaults' entry (a sibling of the club entries) supplies a spec-wide
+    'match_count_limits' list applied to every club. Every defaults entry carries a
+    unique 'override_key'; a club's own match_count_limits entry that repeats one of
+    those keys replaces that default for the club, and any club entry without an
+    'override_key' is purely additive. See _parse_match_count_limits() and
+    _resolve_match_count_limits().
 
     A club's optional 'teams' entry holds per-team exclusions, for clubs whose teams
     don't all share the same availability. Home dates are always specified at the club
     level; per-team variations are supported only via exclusions -- see
     _parse_club_team_constraints().
-
-    A club's optional 'avoid_coscheduling_teams' entry lists groups of that club's own
-    teams that shouldn't be scheduled too close together (e.g. adjacent-division teams
-    drawing from the same pool of players) -- see _parse_avoid_coscheduling_teams().
     """
     section_name = "club_constraints"
     section_spec = data.get(section_name, {})
@@ -503,25 +463,12 @@ def _parse_club_constraints(
             f"{path}: {section_name}.defaults.{sorted(unsupported_defaults)} not "
             f"supported (only {sorted(_CLUB_CONSTRAINT_DEFAULTS_KEYS)} are)"
         )
-    default_concurrency_by_scope: dict[
-        fmodel.ConcurrencyScope, fmodel.ConcurrencyLimit
-    ] = {}
-    if "max_concurrent_matches" in defaults_spec:
-        default_concurrency_by_scope = _parse_max_concurrent_matches_by_scope(
-            defaults_spec["max_concurrent_matches"],
-            f"{path}: {section_name}.defaults.max_concurrent_matches",
-        )
-
-    default_min_gap_days: int | None = None
-    if "min_gap_days" in defaults_spec:
-        default_min_gap_days = _require_int(
-            defaults_spec["min_gap_days"],
-            f"{path}: {section_name}.defaults.min_gap_days",
-        )
-        if default_min_gap_days < 0:
-            raise SpecError(
-                f"{path}: {section_name}.defaults.min_gap_days must be >= 0"
-            )
+    default_limits = _parse_match_count_limits(
+        defaults_spec.get("match_count_limits"),
+        None,
+        teams,
+        f"{path}: {section_name}.defaults.match_count_limits",
+    )
 
     unknown_clubs = section_spec.keys() - clubs.keys() - {"defaults"}
     if unknown_clubs:
@@ -531,13 +478,11 @@ def _parse_club_constraints(
 
     home_dates: dict[str, list[date]] = {}
     unavailable_away_dates: dict[str, list[date]] = {}
-    club_min_gap_days: dict[str, int] = {}
     club_latest_match_date: dict[str, date] = {}
-    max_concurrent_matches: dict[str, fmodel.MaxConcurrentMatches] = {}
     home_dates_used: dict[str, fmodel.HomeDatesUsedBounds] = {}
     team_home_dates: dict[fmodel.Team, list[date]] = {}
     team_unavailable_away_dates: dict[fmodel.Team, list[date]] = {}
-    avoid_coscheduling_teams: list[fmodel.AvoidCoschedulingConstraint] = []
+    club_limits: dict[str, list[_ParsedMatchCountLimit]] = {}
 
     for club_id in clubs:
         club_spec = section_spec.get(club_id, {})
@@ -559,34 +504,10 @@ def _parse_club_constraints(
             f"{path}: {section_name}[{club_id!r}].unavailable_away_dates",
         )
 
-        if "min_gap_days" in club_spec:
-            club_gap = _require_int(
-                club_spec["min_gap_days"],
-                f"{path}: {section_name}[{club_id!r}].min_gap_days",
-            )
-            if club_gap < 0:
-                raise SpecError(
-                    f"{path}: {section_name}[{club_id!r}].min_gap_days must be >= 0"
-                )
-            club_min_gap_days[club_id] = club_gap
-
         if "latest_match_date" in club_spec:
             club_latest_match_date[club_id] = _parse_date(
                 club_spec["latest_match_date"],
                 f"{path}: {section_name}[{club_id!r}].latest_match_date",
-            )
-
-        club_concurrency_by_scope = dict(default_concurrency_by_scope)
-        if "max_concurrent_matches" in club_spec:
-            club_concurrency_by_scope.update(
-                _parse_max_concurrent_matches_by_scope(
-                    club_spec["max_concurrent_matches"],
-                    f"{path}: {section_name}[{club_id!r}].max_concurrent_matches",
-                )
-            )
-        if club_concurrency_by_scope:
-            max_concurrent_matches[club_id] = fmodel.MaxConcurrentMatches(
-                by_scope=club_concurrency_by_scope
             )
 
         if "home_dates_used" in club_spec:
@@ -607,26 +528,25 @@ def _parse_club_constraints(
         team_home_dates.update(club_team_home_dates)
         team_unavailable_away_dates.update(club_team_unavailable_away_dates)
 
-        avoid_coscheduling_teams.extend(
-            _parse_avoid_coscheduling_teams(
-                club_spec.get("avoid_coscheduling_teams"),
-                club_id,
-                teams,
-                f"{path}: {section_name}[{club_id!r}].avoid_coscheduling_teams",
-            )
+        club_limits[club_id] = _parse_match_count_limits(
+            club_spec.get("match_count_limits"),
+            club_id,
+            teams,
+            f"{path}: {section_name}[{club_id!r}].match_count_limits",
         )
+
+    match_count_limits = _resolve_match_count_limits(
+        default_limits, club_limits, clubs, teams, path
+    )
 
     return _ClubConstraints(
         home_dates=home_dates,
         unavailable_away_dates=unavailable_away_dates,
-        default_min_gap_days=default_min_gap_days,
-        club_min_gap_days=club_min_gap_days,
         club_latest_match_date=club_latest_match_date,
-        max_concurrent_matches=max_concurrent_matches,
         home_dates_used=home_dates_used,
         team_home_dates=team_home_dates,
         team_unavailable_away_dates=team_unavailable_away_dates,
-        avoid_coscheduling_teams=avoid_coscheduling_teams,
+        match_count_limits=match_count_limits,
     )
 
 
@@ -706,92 +626,267 @@ def _parse_club_team_constraints(
     return team_home_dates, team_unavailable_away_dates
 
 
-def _parse_avoid_coscheduling_teams(
+def _club_team_ids(club_id: str, teams: Mapping[str, fmodel.Team]) -> list[str]:
+    """The IDs of `club_id`'s teams, in `teams` iteration order."""
+    return [tid for tid, team in teams.items() if team.club == club_id]
+
+
+def _parse_match_count_overrides(value: Any, context: str) -> dict[date, int | None]:
+    """Parse a match_count_limits entry's optional 'overrides': a date-keyed mapping
+    of per-date limits (an integer >= 1, or null to lift the limit that day)."""
+    if not isinstance(value, dict):
+        raise SpecError(f"{context} must be a mapping keyed by date")
+    overrides: dict[date, int | None] = {}
+    for date_key, count in value.items():
+        override_date = _parse_date(date_key, context)
+        count = _require_int_or_none(count, f"{context}[{date_key!r}]")
+        if count is not None and count < 1:
+            raise SpecError(f"{context}[{date_key!r}] must be >= 1 or null")
+        overrides[override_date] = count
+    return overrides
+
+
+def _parse_match_count_limits(
     entries_spec: Any,
-    club_id: str,
+    club_id: str | None,
     teams: Mapping[str, fmodel.Team],
     context: str,
-) -> list[fmodel.AvoidCoschedulingConstraint]:
-    """Parse a club_constraints entry's optional 'avoid_coscheduling_teams' list.
+) -> list[_ParsedMatchCountLimit]:
+    """Parse a 'match_count_limits' list -- a club's own entry, or (when club_id is
+    None) the club_constraints.defaults list applied to every club.
 
-    Each entry names a group of that club's own teams (all of which must belong to
-    this club), an optional 'min_gap_days' minimum separation (default 1; 0 or 1
-    both just mean the same date), and an optional 'applies_to' scope ('home',
-    'away' or the default 'both'): the solver then keeps any two matches involving
-    those teams -- counting only the matches of the kind named by 'applies_to' -- at
-    least 'min_gap_days' days apart, so a gap of exactly that many days is allowed
-    and only shorter gaps are forbidden. This is the per-group counterpart of the
-    top-level 'min_gap_days'. E.g. two teams that share players shouldn't both be
-    fielded on the same date (min_gap_days: 1), or within a week of each other
-    (min_gap_days: 7 still permits matches exactly 7 days apart).
+    Each entry:
+      - 'max' (required key): an integer >= 1, or null. null on its own is only
+        allowed for a club entry carrying an 'override_key' (it cancels that
+        default); otherwise null needs 'overrides' to carry the actual caps.
+      - 'teams' (optional): IDs of this club's teams whose matches are counted.
+        Omitted => every team of the club. Not allowed under 'defaults', nor
+        alongside 'override_key' (an override replaces a spec-wide, all-teams
+        default).
+      - 'apply_per' (optional, default 'across_teams'): 'across_teams' => the listed
+        teams share one budget of 'max' per window; 'each_team' => 'max' is enforced
+        per team.
+      - 'time_window_days' (optional, default 1): window length in consecutive
+        calendar days. 7 limits matches in any 7-consecutive-day period -- two
+        matches exactly a week apart fall in separate windows.
+      - 'venue_scope' (optional, default 'all'): 'home', 'away' or 'all'.
+      - 'overrides' (optional): per-date replacements of 'max'. Only allowed when
+        'time_window_days' is 1.
+      - 'override_key': required for a 'defaults' entry (and unique within that
+        list); optional for a club entry, where it names the default this one
+        replaces for the club.
     """
     if entries_spec is None:
         return []
     if not isinstance(entries_spec, list):
         raise SpecError(f"{context} must be a list")
 
-    constraints: list[fmodel.AvoidCoschedulingConstraint] = []
+    is_defaults = club_id is None
+    club_team_ids = [] if is_defaults else _club_team_ids(club_id, teams)  # type: ignore[arg-type]
+
+    limits: list[_ParsedMatchCountLimit] = []
+    seen_default_keys: set[str] = set()
     for i, entry in enumerate(entries_spec):
         entry_context = f"{context}[{i}]"
         if not isinstance(entry, dict):
             raise SpecError(f"{entry_context} must be a mapping")
-        unsupported = entry.keys() - _AVOID_COSCHEDULING_FIELD_KEYS
+        unsupported = entry.keys() - _MATCH_COUNT_LIMIT_FIELD_KEYS
         if unsupported:
             raise SpecError(
                 f"{entry_context}.{sorted(unsupported)} not supported (only "
-                f"{sorted(_AVOID_COSCHEDULING_FIELD_KEYS)} are)"
+                f"{sorted(_MATCH_COUNT_LIMIT_FIELD_KEYS)} are)"
             )
-        if "teams" not in entry:
-            raise SpecError(f"{entry_context} missing required field 'teams'")
 
-        team_ids = entry["teams"]
-        if not isinstance(team_ids, list) or not team_ids:
-            raise SpecError(f"{entry_context}.teams must be a non-empty list")
+        if "max" not in entry:
+            raise SpecError(f"{entry_context} missing required field 'max'")
+        max_ = _require_int_or_none(entry["max"], f"{entry_context}.max")
+        if max_ is not None and max_ < 1:
+            raise SpecError(f"{entry_context}.max must be >= 1 or null")
 
-        entry_teams: list[fmodel.Team] = []
-        seen_team_ids: set[str] = set()
-        for team_id in team_ids:
-            if team_id in seen_team_ids:
-                raise SpecError(f"{entry_context}.teams: duplicate team {team_id!r}")
-            seen_team_ids.add(team_id)
-            if team_id not in teams:
-                raise SpecError(
-                    f"{entry_context}.teams references unknown team {team_id!r}"
-                )
-            team = teams[team_id]
-            if team.club != club_id:
-                raise SpecError(
-                    f"{entry_context}.teams: team {team_id!r} belongs to club "
-                    f"{team.club!r}, not {club_id!r}"
-                )
-            entry_teams.append(team)
-
-        min_gap_days = 1
-        if "min_gap_days" in entry:
-            min_gap_days = _require_int(
-                entry["min_gap_days"], f"{entry_context}.min_gap_days"
+        override_key: str | None = None
+        if "override_key" in entry:
+            override_key = _require_str(
+                entry["override_key"], f"{entry_context}.override_key"
             )
-            if min_gap_days < 0:
-                raise SpecError(f"{entry_context}.min_gap_days must be >= 0")
+        if is_defaults:
+            if override_key is None:
+                raise SpecError(
+                    f"{entry_context} missing required field 'override_key' "
+                    "(every club_constraints.defaults.match_count_limits entry "
+                    "needs one, so a club can address it)"
+                )
+            if override_key in seen_default_keys:
+                raise SpecError(
+                    f"{entry_context}.override_key {override_key!r} is used by an "
+                    "earlier defaults entry"
+                )
+            seen_default_keys.add(override_key)
 
-        applies_to = fmodel.CoschedulingScope.BOTH
-        if "applies_to" in entry:
+        team_ids: tuple[str, ...] | None = None
+        if "teams" in entry:
+            if is_defaults:
+                raise SpecError(
+                    f"{entry_context}.teams is not allowed under "
+                    "club_constraints.defaults (defaults apply to every club); "
+                    "give an explicit 'teams' list in the club's own "
+                    "match_count_limits instead"
+                )
+            if override_key is not None:
+                raise SpecError(
+                    f"{entry_context}: 'teams' and 'override_key' can't be combined "
+                    "(an override replaces a spec-wide, all-teams default)"
+                )
+            raw_ids = entry["teams"]
+            if not isinstance(raw_ids, list) or not raw_ids:
+                raise SpecError(f"{entry_context}.teams must be a non-empty list")
+            seen_team_ids: set[str] = set()
+            for team_id in raw_ids:
+                if team_id in seen_team_ids:
+                    raise SpecError(
+                        f"{entry_context}.teams: duplicate team {team_id!r}"
+                    )
+                seen_team_ids.add(team_id)
+                if team_id not in teams:
+                    raise SpecError(
+                        f"{entry_context}.teams references unknown team {team_id!r}"
+                    )
+                if teams[team_id].club != club_id:
+                    raise SpecError(
+                        f"{entry_context}.teams: team {team_id!r} belongs to club "
+                        f"{teams[team_id].club!r}, not {club_id!r}"
+                    )
+            team_ids = tuple(raw_ids)
+        elif not is_defaults and not club_team_ids:
+            raise SpecError(
+                f"{entry_context}: club {club_id!r} has no teams (specify "
+                "'teams' explicitly)"
+            )
+
+        apply_per = fmodel.ApplyPer.ACROSS_TEAMS
+        if "apply_per" in entry:
             try:
-                applies_to = fmodel.CoschedulingScope(entry["applies_to"])
+                apply_per = fmodel.ApplyPer(entry["apply_per"])
             except ValueError:
-                allowed = ", ".join(repr(s.value) for s in fmodel.CoschedulingScope)
+                allowed = ", ".join(repr(a.value) for a in fmodel.ApplyPer)
                 raise SpecError(
-                    f"{entry_context}.applies_to must be one of {allowed}, got "
-                    f"{entry['applies_to']!r}"
+                    f"{entry_context}.apply_per must be one of {allowed}, got "
+                    f"{entry['apply_per']!r}"
                 ) from None
 
-        constraints.append(
-            fmodel.AvoidCoschedulingConstraint(
-                teams=entry_teams, min_gap_days=min_gap_days, applies_to=applies_to
+        time_window_days = 1
+        if "time_window_days" in entry:
+            time_window_days = _require_int(
+                entry["time_window_days"], f"{entry_context}.time_window_days"
+            )
+            if time_window_days < 1:
+                raise SpecError(f"{entry_context}.time_window_days must be >= 1")
+
+        venue_scope = fmodel.VenueScope.ALL
+        if "venue_scope" in entry:
+            try:
+                venue_scope = fmodel.VenueScope(entry["venue_scope"])
+            except ValueError:
+                allowed = ", ".join(repr(s.value) for s in fmodel.VenueScope)
+                raise SpecError(
+                    f"{entry_context}.venue_scope must be one of {allowed}, got "
+                    f"{entry['venue_scope']!r}"
+                ) from None
+
+        overrides: dict[date, int | None] = {}
+        if "overrides" in entry:
+            if time_window_days != 1:
+                raise SpecError(
+                    f"{entry_context}.overrides is only allowed when "
+                    "time_window_days is 1"
+                )
+            overrides = _parse_match_count_overrides(
+                entry["overrides"], f"{entry_context}.overrides"
+            )
+
+        if max_ is None and not overrides and override_key is None:
+            raise SpecError(
+                f"{entry_context}.max: null needs 'overrides' to carry the actual "
+                "per-date caps (or an 'override_key' to cancel a default)"
+            )
+
+        limits.append(
+            _ParsedMatchCountLimit(
+                team_ids=team_ids,
+                max=max_,
+                time_window_days=time_window_days,
+                venue_scope=venue_scope,
+                apply_per=apply_per,
+                overrides=overrides,
+                override_key=override_key,
             )
         )
 
-    return constraints
+    return limits
+
+
+def _resolve_match_count_limits(
+    default_limits: list[_ParsedMatchCountLimit],
+    club_limits: Mapping[str, list[_ParsedMatchCountLimit]],
+    clubs: Mapping[str, fmodel.Club],
+    teams: Mapping[str, fmodel.Team],
+    path: Path,
+) -> list[fmodel.MatchCountLimit]:
+    """Combine the spec-wide default match_count_limits with each club's own, and
+    resolve every entry to a concrete fmodel.MatchCountLimit.
+
+    A club entry whose 'override_key' names a default entry replaces that default
+    for the club (an unknown key, or two club entries sharing one, is an error);
+    every other club entry is additive. Entries that carry neither a 'max' nor any
+    'overrides' (a pure cancel-the-default marker) and entries that resolve to no
+    teams are dropped.
+    """
+    default_keys = {pl.override_key for pl in default_limits}
+    resolved: list[fmodel.MatchCountLimit] = []
+    for club_id in clubs:
+        own = list(club_limits.get(club_id, []))
+        overridden: dict[str, _ParsedMatchCountLimit] = {}
+        for pl in own:
+            if pl.override_key is None:
+                continue
+            if pl.override_key not in default_keys:
+                raise SpecError(
+                    f"{path}: club_constraints[{club_id!r}].match_count_limits "
+                    f"override_key {pl.override_key!r} does not match any "
+                    "club_constraints.defaults.match_count_limits entry"
+                )
+            if pl.override_key in overridden:
+                raise SpecError(
+                    f"{path}: club_constraints[{club_id!r}].match_count_limits "
+                    f"has two entries with override_key {pl.override_key!r}"
+                )
+            overridden[pl.override_key] = pl
+
+        effective = [
+            pl for pl in default_limits if pl.override_key not in overridden
+        ] + own
+
+        club_team_objs = [teams[tid] for tid in _club_team_ids(club_id, teams)]
+        for pl in effective:
+            if pl.max is None and not pl.overrides:
+                continue
+            team_objs = (
+                club_team_objs
+                if pl.team_ids is None
+                else [teams[tid] for tid in pl.team_ids]
+            )
+            if not team_objs:
+                continue
+            resolved.append(
+                fmodel.MatchCountLimit(
+                    teams=team_objs,
+                    max=pl.max,
+                    time_window_days=pl.time_window_days,
+                    venue_scope=pl.venue_scope,
+                    apply_per=pl.apply_per,
+                    overrides=pl.overrides,
+                )
+            )
+    return resolved
 
 
 def _parse_fixed_fixtures(
@@ -1030,6 +1125,13 @@ def load_spec(spec_path: str | Path) -> Spec:
     path = Path(spec_path)
     data = _load_yaml_data(path)
 
+    unsupported = data.keys() - _TOP_LEVEL_KEYS
+    if unsupported:
+        raise SpecError(
+            f"{path}: top-level key(s) {sorted(unsupported)} not supported "
+            f"(only {sorted(_TOP_LEVEL_KEYS)} are)"
+        )
+
     clubs = _parse_clubs(data, path)
     team_shells = _parse_teams(data, clubs, path)
     divisions = _parse_divisions(data, team_shells, path)
@@ -1057,30 +1159,17 @@ def load_spec(spec_path: str | Path) -> Spec:
     team_home_dates = club_constraints.team_home_dates
     team_unavailable_away_dates = club_constraints.team_unavailable_away_dates
 
-    if "min_gap_days" in data:
-        raise SpecError(
-            f"{path}: top-level 'min_gap_days' is no longer supported; put the "
-            "spec-wide default under club_constraints.defaults.min_gap_days (and "
-            "any per-club override under club_constraints.<club>.min_gap_days)"
-        )
-
     kwargs: dict[str, Any] = {}
-    if club_constraints.default_min_gap_days is not None:
-        kwargs["min_gap_days"] = club_constraints.default_min_gap_days
-    if club_constraints.club_min_gap_days:
-        kwargs["club_min_gap_days"] = club_constraints.club_min_gap_days
     if club_constraints.club_latest_match_date:
         kwargs["club_latest_match_date"] = club_constraints.club_latest_match_date
-    if club_constraints.max_concurrent_matches:
-        kwargs["max_concurrent_matches"] = club_constraints.max_concurrent_matches
     if club_constraints.home_dates_used:
         kwargs["home_dates_used"] = club_constraints.home_dates_used
     if team_home_dates:
         kwargs["team_home_dates"] = team_home_dates
     if team_unavailable_away_dates:
         kwargs["team_unavailable_away_dates"] = team_unavailable_away_dates
-    if club_constraints.avoid_coscheduling_teams:
-        kwargs["avoid_coscheduling_teams"] = club_constraints.avoid_coscheduling_teams
+    if club_constraints.match_count_limits:
+        kwargs["match_count_limits"] = club_constraints.match_count_limits
 
     fixed_fixtures = _parse_fixed_fixtures(
         data, teams, home_dates, team_home_dates, path

--- a/fixturespec_test.py
+++ b/fixturespec_test.py
@@ -17,6 +17,7 @@
 import hashlib
 import tempfile
 import unittest
+from collections.abc import Collection
 from datetime import date
 from pathlib import Path
 
@@ -24,14 +25,24 @@ import fixturespec
 import fmodel
 
 
-def _mcm(**scopes: fmodel.ConcurrencyLimit) -> fmodel.MaxConcurrentMatches:
-    """Terse fmodel.MaxConcurrentMatches builder for tests: keyword args are
-    ConcurrencyScope names, e.g. _mcm(home=fmodel.ConcurrencyLimit(2))."""
-    return fmodel.MaxConcurrentMatches(
-        by_scope={
-            fmodel.ConcurrencyScope(name): limit for name, limit in scopes.items()
-        }
-    )
+def _find_limit(
+    limits: Collection[fmodel.MatchCountLimit],
+    *,
+    club: str,
+    venue_scope: fmodel.VenueScope,
+    apply_per: fmodel.ApplyPer,
+) -> fmodel.MatchCountLimit:
+    """The one resolved MatchCountLimit for `club` with the given venue_scope /
+    apply_per (fails the calling assertion if there isn't exactly one)."""
+    matches = [
+        limit
+        for limit in limits
+        if all(t.club == club for t in limit.teams)
+        and limit.venue_scope is venue_scope
+        and limit.apply_per is apply_per
+    ]
+    assert len(matches) == 1, f"expected exactly one, got {matches}"
+    return matches[0]
 
 
 # Clubs/teams/divisions boilerplate, minus 'club_constraints', for tests that need to
@@ -85,7 +96,7 @@ club_constraints:
 
 _MINIMAL_SPEC = (
     _MINIMAL_SPEC_NO_CONCURRENCY
-    + "  defaults:\n    max_concurrent_matches:\n      home: 1\n"
+    + "  defaults:\n    match_count_limits:\n      - override_key: venue-capacity\n        venue_scope: home\n        max: 1\n"
 )
 
 # A three-team spec (two Albany teams plus Hackney) for exclude_fixtures tests, which
@@ -122,9 +133,6 @@ divisions:
     teams: [albany-1, albany-2, hackney-1]
 
 club_constraints:
-  defaults:
-    max_concurrent_matches:
-      home: 2
   albany:
     home_dates: [2025-09-01, 2025-10-01, 2025-11-01, 2025-12-01]
   hackney:
@@ -177,17 +185,16 @@ class TestLoadSpec(unittest.TestCase):
         )
         # hackney has no unavailable_away_dates entry, should default to empty
         self.assertEqual(spec.parameters.unavailable_away_dates["hackney"], [])
-        self.assertEqual(spec.parameters.min_gap_days, 7)
-        # Neither club has its own entry, so both inherit _MINIMAL_SPEC's
-        # club_constraints.defaults.max_concurrent_matches (home: 1).
-        self.assertEqual(
-            spec.parameters.max_concurrent_matches["albany"],
-            _mcm(home=fmodel.ConcurrencyLimit(1)),
-        )
-        self.assertEqual(
-            spec.parameters.max_concurrent_matches["hackney"],
-            _mcm(home=fmodel.ConcurrencyLimit(1)),
-        )
+        # Neither club has its own match_count_limits, so both inherit
+        # _MINIMAL_SPEC's club_constraints.defaults entry (home limit 1).
+        for club in ("albany", "hackney"):
+            limit = _find_limit(
+                spec.parameters.match_count_limits,
+                club=club,
+                venue_scope=fmodel.VenueScope.HOME,
+                apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
+            )
+            self.assertEqual(limit.max, 1)
         self.assertEqual(spec.name, "")
         self.assertFalse(spec.draft)
 
@@ -235,20 +242,16 @@ class TestLoadSpec(unittest.TestCase):
         team = next(t for t in spec.parameters.teams if t.club == "hackney")
         self.assertEqual(team.name_override, "Hackney Herons")
 
-    def test_default_min_gap_days_from_club_constraints_defaults(self) -> None:
-        path = self._write(_MINIMAL_SPEC + "    min_gap_days: 10\n")
+    def test_match_count_limits_empty_when_none_configured(self) -> None:
+        path = self._write(_MINIMAL_SPEC_NO_CONCURRENCY)
         spec = fixturespec.load_spec(path)
-        self.assertEqual(spec.parameters.min_gap_days, 10)
+        self.assertEqual(spec.parameters.match_count_limits, ())
 
-    def test_min_gap_days_defaults_to_seven_when_unset(self) -> None:
-        path = self._write(_MINIMAL_SPEC)
-        spec = fixturespec.load_spec(path)
-        self.assertEqual(spec.parameters.min_gap_days, 7)
-
-    def test_top_level_min_gap_days_rejected(self) -> None:
+    def test_unknown_top_level_key_rejected(self) -> None:
         path = self._write(_MINIMAL_SPEC + "\nmin_gap_days: 10\n")
         with self.assertRaisesRegex(
-            fixturespec.SpecError, "top-level 'min_gap_days' is no longer supported"
+            fixturespec.SpecError,
+            r"top-level key\(s\) \['min_gap_days'\] not supported",
         ):
             fixturespec.load_spec(path)
 
@@ -322,7 +325,8 @@ class TestLoadSpec(unittest.TestCase):
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
-            "    max_concurrent_matches:\n      home: 1\n"
+            "    match_count_limits:\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        max: 1\n"
             "  albany:\n"
             "    home_dates: [2025-09-01]\n"
             "  albany:\n"
@@ -337,163 +341,279 @@ class TestLoadSpec(unittest.TestCase):
     # duplicate YAML key, which PyYAML resolves by silently letting the later one
     # clobber the earlier one.
 
-    def test_max_concurrent_matches_home_shorthand_int(self) -> None:
+    def test_match_count_limits_override_key_replaces_default(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
-            "    max_concurrent_matches:\n"
-            "      home: 1\n"
+            "    match_count_limits:\n"
+            "      - override_key: venue-capacity\n"
+            "        venue_scope: home\n"
+            "        max: 1\n"
             "  albany:\n"
-            "    max_concurrent_matches:\n"
-            "      home: 3\n"
+            "    match_count_limits:\n"
+            "      - override_key: venue-capacity\n"
+            "        venue_scope: home\n"
+            "        max: 3\n"
         )
         spec = fixturespec.load_spec(path)
-        self.assertEqual(
-            spec.parameters.max_concurrent_matches["albany"],
-            _mcm(home=fmodel.ConcurrencyLimit(3)),
+        albany = _find_limit(
+            spec.parameters.match_count_limits,
+            club="albany",
+            venue_scope=fmodel.VenueScope.HOME,
+            apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        # hackney wasn't given its own entry, so it inherits club_constraints.defaults
-        self.assertEqual(
-            spec.parameters.max_concurrent_matches["hackney"],
-            _mcm(home=fmodel.ConcurrencyLimit(1)),
+        self.assertEqual(albany.max, 3)
+        # hackney has no entry of its own, so it keeps the default home cap 1.
+        hackney = _find_limit(
+            spec.parameters.match_count_limits,
+            club="hackney",
+            venue_scope=fmodel.VenueScope.HOME,
+            apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
+        self.assertEqual(hackney.max, 1)
 
-    def test_max_concurrent_matches_default_and_overrides(self) -> None:
+    def test_match_count_limits_overrides_parsed(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
-            "    max_concurrent_matches:\n"
-            "      home:\n"
-            "        default: 2\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        max: 2\n"
             "        overrides:\n"
             "          2025-09-01: 3\n"
         )
         spec = fixturespec.load_spec(path)
-        self.assertEqual(
-            spec.parameters.max_concurrent_matches["albany"],
-            _mcm(home=fmodel.ConcurrencyLimit(2, {date(2025, 9, 1): 3})),
+        albany = _find_limit(
+            spec.parameters.match_count_limits,
+            club="albany",
+            venue_scope=fmodel.VenueScope.HOME,
+            apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
+        self.assertEqual(albany.max, 2)
+        self.assertEqual(albany.overrides, {date(2025, 9, 1): 3})
 
-    def test_max_concurrent_matches_null_shorthand(self) -> None:
+    def test_match_count_limits_override_null_lifts_the_cap_that_day(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
-            "    max_concurrent_matches:\n"
-            "      home: null\n"
-        )
-        spec = fixturespec.load_spec(path)
-        self.assertEqual(
-            spec.parameters.max_concurrent_matches["albany"],
-            _mcm(home=fmodel.ConcurrencyLimit(None)),
-        )
-
-    def test_max_concurrent_matches_null_default_with_override(self) -> None:
-        path = self._write(
-            _BOILERPLATE + "club_constraints:\n"
-            "  albany:\n"
-            "    max_concurrent_matches:\n"
-            "      home:\n"
-            "        default: null\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        max: null\n"
             "        overrides:\n"
             "          2025-09-01: 3\n"
         )
         spec = fixturespec.load_spec(path)
-        self.assertEqual(
-            spec.parameters.max_concurrent_matches["albany"],
-            _mcm(home=fmodel.ConcurrencyLimit(None, {date(2025, 9, 1): 3})),
+        albany = _find_limit(
+            spec.parameters.match_count_limits,
+            club="albany",
+            venue_scope=fmodel.VenueScope.HOME,
+            apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
+        self.assertIsNone(albany.max)
+        self.assertEqual(albany.overrides, {date(2025, 9, 1): 3})
 
-    def test_max_concurrent_matches_missing_default(self) -> None:
+    def test_match_count_limits_null_max_cancels_default_via_override_key(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
+            "  defaults:\n"
+            "    match_count_limits:\n"
+            "      - override_key: venue-capacity\n"
+            "        venue_scope: home\n"
+            "        max: 1\n"
             "  albany:\n"
-            "    max_concurrent_matches:\n"
-            "      home:\n"
-            "        overrides:\n"
-            "          2025-09-01: 3\n"
+            "    match_count_limits:\n"
+            "      - override_key: venue-capacity\n"
+            "        venue_scope: home\n"
+            "        max: null\n"
         )
-        with self.assertRaisesRegex(fixturespec.SpecError, "default"):
+        spec = fixturespec.load_spec(path)
+        albany_home = [
+            limit
+            for limit in spec.parameters.match_count_limits
+            if all(t.club == "albany" for t in limit.teams)
+            and limit.venue_scope is fmodel.VenueScope.HOME
+        ]
+        self.assertEqual(albany_home, [])
+        # hackney still gets the default.
+        self.assertEqual(
+            _find_limit(
+                spec.parameters.match_count_limits,
+                club="hackney",
+                venue_scope=fmodel.VenueScope.HOME,
+                apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
+            ).max,
+            1,
+        )
+
+    def test_match_count_limits_unknown_override_key_rejected(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  defaults:\n"
+            "    match_count_limits:\n"
+            "      - override_key: venue-capacity\n"
+            "        venue_scope: home\n"
+            "        max: 1\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - override_key: typo\n"
+            "        venue_scope: home\n"
+            "        max: 2\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "override_key"):
             fixturespec.load_spec(path)
 
-    def test_max_concurrent_matches_away_and_any_scopes(self) -> None:
-        path = self._write(
-            _BOILERPLATE + "club_constraints:\n"
-            "  albany:\n"
-            "    max_concurrent_matches:\n"
-            "      away: 2\n"
-            "      any:\n"
-            "        default: null\n"
-            "        overrides:\n"
-            "          2025-09-01: 1\n"
-        )
-        spec = fixturespec.load_spec(path)
-        self.assertEqual(
-            spec.parameters.max_concurrent_matches["albany"],
-            _mcm(
-                away=fmodel.ConcurrencyLimit(2),
-                any=fmodel.ConcurrencyLimit(None, {date(2025, 9, 1): 1}),
-            ),
-        )
-
-    def test_max_concurrent_matches_defaults_merge_per_scope(self) -> None:
-        # defaults set only 'home'; albany sets only 'any'. albany should end up
-        # with both (its own 'any', the inherited default 'home'); hackney, with no
-        # entry of its own, gets just the default 'home'.
+    def test_match_count_limits_defaults_require_override_key(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
-            "    max_concurrent_matches:\n"
-            "      home: 1\n"
-            "  albany:\n"
-            "    max_concurrent_matches:\n"
-            "      any: 1\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        max: 1\n"
         )
-        spec = fixturespec.load_spec(path)
-        self.assertEqual(
-            spec.parameters.max_concurrent_matches["albany"],
-            _mcm(
-                home=fmodel.ConcurrencyLimit(1),
-                any=fmodel.ConcurrencyLimit(1),
-            ),
-        )
-        self.assertEqual(
-            spec.parameters.max_concurrent_matches["hackney"],
-            _mcm(home=fmodel.ConcurrencyLimit(1)),
-        )
-
-    def test_max_concurrent_matches_club_scope_overrides_default_scope(self) -> None:
-        path = self._write(
-            _BOILERPLATE + "club_constraints:\n"
-            "  defaults:\n"
-            "    max_concurrent_matches:\n"
-            "      home: 1\n"
-            "  albany:\n"
-            "    max_concurrent_matches:\n"
-            "      home: 3\n"
-        )
-        spec = fixturespec.load_spec(path)
-        self.assertEqual(
-            spec.parameters.max_concurrent_matches["albany"],
-            _mcm(home=fmodel.ConcurrencyLimit(3)),
-        )
-
-    def test_max_concurrent_matches_unknown_scope_rejected(self) -> None:
-        path = self._write(
-            _BOILERPLATE + "club_constraints:\n"
-            "  albany:\n"
-            "    max_concurrent_matches:\n"
-            "      sideways: 1\n"
-        )
-        with self.assertRaisesRegex(fixturespec.SpecError, "sideways"):
+        with self.assertRaisesRegex(fixturespec.SpecError, "override_key"):
             fixturespec.load_spec(path)
 
-    def test_max_concurrent_matches_empty_mapping_rejected(self) -> None:
+    def test_match_count_limits_defaults_duplicate_override_key_rejected(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  defaults:\n"
+            "    match_count_limits:\n"
+            "      - override_key: cap\n"
+            "        venue_scope: home\n"
+            "        max: 1\n"
+            "      - override_key: cap\n"
+            "        venue_scope: away\n"
+            "        max: 1\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "override_key"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_override_key_with_teams_rejected(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  defaults:\n"
+            "    match_count_limits:\n"
+            "      - override_key: cap\n"
+            "        venue_scope: home\n"
+            "        max: 1\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - override_key: cap\n"
+            "        teams: [albany-1]\n"
+            "        max: 1\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "override_key"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_overrides_require_one_day_window(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
-            "    max_concurrent_matches: {}\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        max: 2\n"
+            "        time_window_days: 7\n"
+            "        overrides:\n"
+            "          2025-09-01: 3\n"
         )
-        with self.assertRaisesRegex(fixturespec.SpecError, "at least one"):
+        with self.assertRaisesRegex(fixturespec.SpecError, "overrides"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_missing_max_field_rejected(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "max"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_defaults_additive_when_no_override_key(self) -> None:
+        # A club entry without an override_key is additive, even if a default
+        # covers the same venue_scope.
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  defaults:\n"
+            "    match_count_limits:\n"
+            "      - override_key: venue-capacity\n"
+            "        venue_scope: home\n"
+            "        max: 2\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: all\n"
+            "        max: 1\n"
+        )
+        spec = fixturespec.load_spec(path)
+        self.assertEqual(
+            _find_limit(
+                spec.parameters.match_count_limits,
+                club="albany",
+                venue_scope=fmodel.VenueScope.HOME,
+                apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
+            ).max,
+            2,
+        )
+        self.assertEqual(
+            _find_limit(
+                spec.parameters.match_count_limits,
+                club="albany",
+                venue_scope=fmodel.VenueScope.ALL,
+                apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
+            ).max,
+            1,
+        )
+
+    def test_match_count_limits_defaults_reject_teams_field(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  defaults:\n"
+            "    match_count_limits:\n"
+            "      - override_key: k\n"
+            "        teams: [albany-1]\n"
+            "        max: 1\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "teams is not allowed"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_apply_per_each_team_parsed(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - apply_per: each_team\n"
+            "        time_window_days: 7\n"
+            "        max: 1\n"
+        )
+        spec = fixturespec.load_spec(path)
+        limit = _find_limit(
+            spec.parameters.match_count_limits,
+            club="albany",
+            venue_scope=fmodel.VenueScope.ALL,
+            apply_per=fmodel.ApplyPer.EACH_TEAM,
+        )
+        self.assertEqual((limit.time_window_days, limit.max), (7, 1))
+
+    def test_match_count_limits_unknown_venue_scope_rejected(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: sideways\n"
+            "        max: 1\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "venue_scope"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_unknown_apply_per_rejected(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - apply_per: sometimes\n"
+            "        max: 1\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "apply_per"):
             fixturespec.load_spec(path)
 
     def test_club_constraints_unknown_club(self) -> None:
@@ -507,27 +627,27 @@ class TestLoadSpec(unittest.TestCase):
         with self.assertRaisesRegex(fixturespec.SpecError, "nonexistent"):
             fixturespec.load_spec(path)
 
-    def test_max_concurrent_matches_absent_for_a_club_is_allowed(self) -> None:
-        # No defaults, and only albany has an entry: hackney simply has no
-        # concurrency limits (nothing is required).
+    def test_match_count_limits_absent_for_a_club_is_allowed(self) -> None:
+        # No defaults, and only albany has an entry: hackney simply has no limits.
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
-            "    max_concurrent_matches:\n"
-            "      home: 1\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        max: 1\n"
         )
         spec = fixturespec.load_spec(path)
-        self.assertEqual(
-            spec.parameters.max_concurrent_matches,
-            {"albany": _mcm(home=fmodel.ConcurrencyLimit(1))},
-        )
+        clubs = {
+            t.club for limit in spec.parameters.match_count_limits for t in limit.teams
+        }
+        self.assertEqual(clubs, {"albany"})
 
-    def test_max_concurrent_matches_omitted_everywhere_is_allowed(self) -> None:
-        # No club_constraints.defaults and no per-club max_concurrent_matches:
-        # concurrency limits are entirely optional.
+    def test_match_count_limits_omitted_everywhere_is_allowed(self) -> None:
+        # No club_constraints.defaults and no per-club match_count_limits: limits
+        # are entirely optional.
         path = self._write(_MINIMAL_SPEC_NO_CONCURRENCY)
         spec = fixturespec.load_spec(path)
-        self.assertEqual(spec.parameters.max_concurrent_matches, {})
+        self.assertEqual(spec.parameters.match_count_limits, ())
 
     def test_club_constraints_defaults_unsupported_field(self) -> None:
         path = self._write(
@@ -723,7 +843,7 @@ divisions:
     # to load successfully (the failure-path tests don't get this far).
     _SCHEME_SPEC_TAIL = (
         "club_constraints:\n"
-        "  defaults:\n    max_concurrent_matches:\n      home: 1\n"
+        "  defaults:\n    match_count_limits:\n      - override_key: venue-capacity\n        venue_scope: home\n        max: 1\n"
         "  albany:\n    home_dates: [2025-09-01, 2025-09-08, 2025-09-15]\n"
     )
 
@@ -809,8 +929,10 @@ divisions:
     teams: [albany-1, albany-2, albany-3]
 club_constraints:
   defaults:
-    max_concurrent_matches:
-      home: 1
+    match_count_limits:
+      - override_key: venue-capacity
+        venue_scope: home
+        max: 1
   albany:
     home_dates: [2025-09-01, 2025-09-08, 2025-09-15]
 """)
@@ -926,7 +1048,8 @@ club_constraints:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
-            "    max_concurrent_matches:\n      home: 1\n"
+            "    match_count_limits:\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        max: 1\n"
             "  albany:\n"
             "    home_dates_used:\n"
             "      max: 1\n"
@@ -949,7 +1072,8 @@ club_constraints:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
-            "    max_concurrent_matches:\n      home: 1\n"
+            "    match_count_limits:\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        max: 1\n"
             "  albany:\n"
             "    home_dates_used:\n"
             "      min: 3\n"
@@ -969,7 +1093,8 @@ club_constraints:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
-            "    max_concurrent_matches:\n      home: 1\n"
+            "    match_count_limits:\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        max: 1\n"
             "  unknown-club:\n"
             "    home_dates_used:\n"
             "      max: 1\n"
@@ -981,7 +1106,8 @@ club_constraints:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
-            "    max_concurrent_matches:\n      home: 1\n"
+            "    match_count_limits:\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        max: 1\n"
             "  albany:\n"
             "    home_dates_used:\n"
             "      max: not-an-int\n"
@@ -993,7 +1119,8 @@ club_constraints:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
-            "    max_concurrent_matches:\n      home: 1\n"
+            "    match_count_limits:\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        max: 1\n"
             "  albany:\n"
             "    home_dates_used: 1\n"
         )
@@ -1004,7 +1131,8 @@ club_constraints:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
-            "    max_concurrent_matches:\n      home: 1\n"
+            "    match_count_limits:\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        max: 1\n"
             "  albany:\n"
             "    home_dates_used: {}\n"
         )
@@ -1015,7 +1143,8 @@ club_constraints:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
-            "    max_concurrent_matches:\n      home: 1\n"
+            "    match_count_limits:\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        max: 1\n"
             "  albany:\n"
             "    home_dates_used:\n"
             "      minimum: 2\n"
@@ -1027,7 +1156,8 @@ club_constraints:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
-            "    max_concurrent_matches:\n      home: 1\n"
+            "    match_count_limits:\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        max: 1\n"
             "  albany:\n"
             "    home_dates_used:\n"
             "      min: 0\n"
@@ -1039,7 +1169,8 @@ club_constraints:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
-            "    max_concurrent_matches:\n      home: 1\n"
+            "    match_count_limits:\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        max: 1\n"
             "  albany:\n"
             "    home_dates_used:\n"
             "      min: 5\n"
@@ -1048,30 +1179,68 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "exceeds"):
             fixturespec.load_spec(path)
 
-    def test_club_min_gap_days_parsed(self) -> None:
-        """A per-club min_gap_days lands in Parameters.club_min_gap_days, keyed by
-        club, and only for the clubs that set one."""
-        path = self._write(_MINIMAL_SPEC_NO_CONCURRENCY + "    min_gap_days: 3\n")
+    def test_per_club_gap_via_override_key(self) -> None:
+        """A per-club weekly gap is an apply_per: each_team match_count_limits entry
+        with override_key: weekly-gap; it replaces the spec-wide default for that
+        club only."""
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  defaults:\n"
+            "    match_count_limits:\n"
+            "      - override_key: weekly-gap\n"
+            "        apply_per: each_team\n"
+            "        time_window_days: 7\n"
+            "        max: 1\n"
+            "  albany:\n"
+            "    home_dates: [2025-09-01]\n"
+            "    match_count_limits:\n"
+            "      - override_key: weekly-gap\n"
+            "        apply_per: each_team\n"
+            "        time_window_days: 14\n"
+            "        max: 1\n"
+            "  hackney:\n"
+            "    home_dates: [2025-09-15]\n"
+        )
         spec = fixturespec.load_spec(path)
-        self.assertEqual(spec.parameters.club_min_gap_days, {"hackney": 3})
-        # The spec-wide default is untouched.
-        self.assertEqual(spec.parameters.min_gap_days, 7)
+        self.assertEqual(
+            _find_limit(
+                spec.parameters.match_count_limits,
+                club="albany",
+                venue_scope=fmodel.VenueScope.ALL,
+                apply_per=fmodel.ApplyPer.EACH_TEAM,
+            ).time_window_days,
+            14,
+        )
+        self.assertEqual(
+            _find_limit(
+                spec.parameters.match_count_limits,
+                club="hackney",
+                venue_scope=fmodel.VenueScope.ALL,
+                apply_per=fmodel.ApplyPer.EACH_TEAM,
+            ).time_window_days,
+            7,
+        )
 
-    def test_club_min_gap_days_absent(self) -> None:
-        path = self._write(_MINIMAL_SPEC)
-        spec = fixturespec.load_spec(path)
-        self.assertEqual(spec.parameters.club_min_gap_days, {})
-
-    def test_club_min_gap_days_negative_rejected(self) -> None:
-        path = self._write(_MINIMAL_SPEC_NO_CONCURRENCY + "    min_gap_days: -1\n")
-        with self.assertRaisesRegex(fixturespec.SpecError, "min_gap_days"):
+    def test_match_count_limits_negative_max_rejected(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        max: -1\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "max"):
             fixturespec.load_spec(path)
 
-    def test_defaults_min_gap_days_negative_rejected(self) -> None:
-        path = self._write(_MINIMAL_SPEC + "    min_gap_days: -1\n")
-        with self.assertRaisesRegex(
-            fixturespec.SpecError, r"defaults\.min_gap_days must be >= 0"
-        ):
+    def test_match_count_limits_null_max_without_overrides_rejected(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        max: null\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "max"):
             fixturespec.load_spec(path)
 
     def test_club_latest_match_date_parsed(self) -> None:
@@ -1327,9 +1496,9 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "home dates"):
             fixturespec.load_spec(path)
 
-    def _with_albany_avoid_coscheduling(self, block: str) -> str:
+    def _with_albany_match_count_limits(self, block: str) -> str:
         """_THREE_TEAM_SPEC (which has two Albany teams) with the given
-        'avoid_coscheduling_teams:' block (already indented as it should appear)
+        'match_count_limits:' block (already indented as it should appear)
         nested under club_constraints.albany, alongside its home_dates."""
         return _THREE_TEAM_SPEC.replace(
             "  albany:\n    home_dates: [2025-09-01, 2025-10-01, 2025-11-01, 2025-12-01]\n",
@@ -1337,15 +1506,17 @@ club_constraints:
             + block,
         )
 
-    def test_avoid_coscheduling_teams_absent(self) -> None:
+    def test_match_count_limits_absent(self) -> None:
         path = self._write(_THREE_TEAM_SPEC)
         spec = fixturespec.load_spec(path)
-        self.assertEqual(spec.parameters.avoid_coscheduling_teams, ())
+        self.assertEqual(spec.parameters.match_count_limits, ())
 
-    def test_avoid_coscheduling_teams_parsed(self) -> None:
+    def test_match_count_limits_parsed(self) -> None:
         path = self._write(
-            self._with_albany_avoid_coscheduling(
-                "    avoid_coscheduling_teams:\n      - teams: [albany-1, albany-2]\n"
+            self._with_albany_match_count_limits(
+                "    match_count_limits:\n"
+                "      - teams: [albany-1, albany-2]\n"
+                "        max: 1\n"
             )
         )
         spec = fixturespec.load_spec(path)
@@ -1356,141 +1527,194 @@ club_constraints:
             t for t in spec.parameters.teams if t.club == "albany" and t.index == 2
         )
         self.assertEqual(
-            list(spec.parameters.avoid_coscheduling_teams),
+            list(spec.parameters.match_count_limits),
             [
-                fmodel.AvoidCoschedulingConstraint(
-                    teams=[albany_1, albany_2], min_gap_days=1
+                fmodel.MatchCountLimit(
+                    teams=[albany_1, albany_2], max=1, time_window_days=1
                 )
             ],
         )
 
-    def test_avoid_coscheduling_teams_min_gap_days_parsed(self) -> None:
+    def test_match_count_limits_teams_defaults_to_all_of_club(self) -> None:
         path = self._write(
-            self._with_albany_avoid_coscheduling(
-                "    avoid_coscheduling_teams:\n"
-                "      - teams: [albany-1, albany-2]\n"
-                "        min_gap_days: 3\n"
+            self._with_albany_match_count_limits(
+                "    match_count_limits:\n      - max: 3\n        time_window_days: 7\n"
             )
         )
         spec = fixturespec.load_spec(path)
-        constraints = list(spec.parameters.avoid_coscheduling_teams)
-        self.assertEqual(constraints[0].min_gap_days, 3)
+        albany_1 = next(
+            t for t in spec.parameters.teams if t.club == "albany" and t.index == 1
+        )
+        albany_2 = next(
+            t for t in spec.parameters.teams if t.club == "albany" and t.index == 2
+        )
+        constraints = list(spec.parameters.match_count_limits)
+        self.assertEqual(list(constraints[0].teams), [albany_1, albany_2])
+        self.assertEqual(constraints[0].max, 3)
+        self.assertEqual(constraints[0].time_window_days, 7)
 
-    def test_avoid_coscheduling_teams_applies_to_defaults_to_both(self) -> None:
+    def test_match_count_limits_time_window_days_parsed(self) -> None:
         path = self._write(
-            self._with_albany_avoid_coscheduling(
-                "    avoid_coscheduling_teams:\n      - teams: [albany-1, albany-2]\n"
+            self._with_albany_match_count_limits(
+                "    match_count_limits:\n"
+                "      - teams: [albany-1, albany-2]\n"
+                "        max: 1\n"
+                "        time_window_days: 3\n"
             )
         )
         spec = fixturespec.load_spec(path)
-        constraints = list(spec.parameters.avoid_coscheduling_teams)
-        self.assertEqual(constraints[0].applies_to, fmodel.CoschedulingScope.BOTH)
+        constraints = list(spec.parameters.match_count_limits)
+        self.assertEqual(constraints[0].time_window_days, 3)
 
-    def test_avoid_coscheduling_teams_applies_to_parsed(self) -> None:
+    def test_match_count_limits_time_window_days_defaults_to_one(self) -> None:
         path = self._write(
-            self._with_albany_avoid_coscheduling(
-                "    avoid_coscheduling_teams:\n"
+            self._with_albany_match_count_limits(
+                "    match_count_limits:\n"
                 "      - teams: [albany-1, albany-2]\n"
-                "        applies_to: away\n"
+                "        max: 1\n"
             )
         )
         spec = fixturespec.load_spec(path)
-        constraints = list(spec.parameters.avoid_coscheduling_teams)
-        self.assertEqual(constraints[0].applies_to, fmodel.CoschedulingScope.AWAY)
+        constraints = list(spec.parameters.match_count_limits)
+        self.assertEqual(constraints[0].time_window_days, 1)
 
-    def test_avoid_coscheduling_teams_invalid_applies_to_rejected(self) -> None:
+    def test_match_count_limits_venue_scope_defaults_to_all(self) -> None:
         path = self._write(
-            self._with_albany_avoid_coscheduling(
-                "    avoid_coscheduling_teams:\n"
+            self._with_albany_match_count_limits(
+                "    match_count_limits:\n"
                 "      - teams: [albany-1, albany-2]\n"
-                "        applies_to: sometimes\n"
+                "        max: 1\n"
             )
         )
-        with self.assertRaisesRegex(fixturespec.SpecError, "applies_to"):
+        spec = fixturespec.load_spec(path)
+        constraints = list(spec.parameters.match_count_limits)
+        self.assertEqual(constraints[0].venue_scope, fmodel.VenueScope.ALL)
+
+    def test_match_count_limits_venue_scope_parsed(self) -> None:
+        path = self._write(
+            self._with_albany_match_count_limits(
+                "    match_count_limits:\n"
+                "      - teams: [albany-1, albany-2]\n"
+                "        max: 1\n"
+                "        venue_scope: away\n"
+            )
+        )
+        spec = fixturespec.load_spec(path)
+        constraints = list(spec.parameters.match_count_limits)
+        self.assertEqual(constraints[0].venue_scope, fmodel.VenueScope.AWAY)
+
+    def test_match_count_limits_invalid_venue_scope_rejected(self) -> None:
+        path = self._write(
+            self._with_albany_match_count_limits(
+                "    match_count_limits:\n"
+                "      - teams: [albany-1, albany-2]\n"
+                "        max: 1\n"
+                "        venue_scope: sometimes\n"
+            )
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "venue_scope"):
             fixturespec.load_spec(path)
 
-    def test_avoid_coscheduling_teams_not_a_list(self) -> None:
+    def test_match_count_limits_missing_max_field(self) -> None:
         path = self._write(
-            self._with_albany_avoid_coscheduling("    avoid_coscheduling_teams: {}\n")
+            self._with_albany_match_count_limits(
+                "    match_count_limits:\n      - teams: [albany-1, albany-2]\n"
+            )
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "max"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_max_below_one_rejected(self) -> None:
+        path = self._write(
+            self._with_albany_match_count_limits(
+                "    match_count_limits:\n"
+                "      - teams: [albany-1, albany-2]\n"
+                "        max: 0\n"
+            )
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "max"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_time_window_days_below_one_rejected(self) -> None:
+        path = self._write(
+            self._with_albany_match_count_limits(
+                "    match_count_limits:\n"
+                "      - teams: [albany-1, albany-2]\n"
+                "        max: 1\n"
+                "        time_window_days: 0\n"
+            )
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "time_window_days"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_not_a_list(self) -> None:
+        path = self._write(
+            self._with_albany_match_count_limits("    match_count_limits: {}\n")
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "list"):
             fixturespec.load_spec(path)
 
-    def test_avoid_coscheduling_teams_entry_not_a_mapping(self) -> None:
+    def test_match_count_limits_entry_not_a_mapping(self) -> None:
         path = self._write(
-            self._with_albany_avoid_coscheduling(
-                "    avoid_coscheduling_teams:\n      - just-a-string\n"
+            self._with_albany_match_count_limits(
+                "    match_count_limits:\n      - just-a-string\n"
             )
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "mapping"):
             fixturespec.load_spec(path)
 
-    def test_avoid_coscheduling_teams_missing_teams_field(self) -> None:
+    def test_match_count_limits_empty_teams_list(self) -> None:
         path = self._write(
-            self._with_albany_avoid_coscheduling(
-                "    avoid_coscheduling_teams:\n      - min_gap_days: 1\n"
-            )
-        )
-        with self.assertRaisesRegex(fixturespec.SpecError, "teams"):
-            fixturespec.load_spec(path)
-
-    def test_avoid_coscheduling_teams_empty_teams_list(self) -> None:
-        path = self._write(
-            self._with_albany_avoid_coscheduling(
-                "    avoid_coscheduling_teams:\n      - teams: []\n"
+            self._with_albany_match_count_limits(
+                "    match_count_limits:\n      - teams: []\n        max: 1\n"
             )
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "non-empty"):
             fixturespec.load_spec(path)
 
-    def test_avoid_coscheduling_teams_duplicate_team(self) -> None:
+    def test_match_count_limits_duplicate_team(self) -> None:
         path = self._write(
-            self._with_albany_avoid_coscheduling(
-                "    avoid_coscheduling_teams:\n      - teams: [albany-1, albany-1]\n"
+            self._with_albany_match_count_limits(
+                "    match_count_limits:\n"
+                "      - teams: [albany-1, albany-1]\n"
+                "        max: 1\n"
             )
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "duplicate"):
             fixturespec.load_spec(path)
 
-    def test_avoid_coscheduling_teams_unknown_team(self) -> None:
+    def test_match_count_limits_unknown_team(self) -> None:
         path = self._write(
-            self._with_albany_avoid_coscheduling(
-                "    avoid_coscheduling_teams:\n"
+            self._with_albany_match_count_limits(
+                "    match_count_limits:\n"
                 "      - teams: [albany-1, nonexistent]\n"
+                "        max: 1\n"
             )
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "nonexistent"):
             fixturespec.load_spec(path)
 
-    def test_avoid_coscheduling_teams_team_belongs_to_different_club(self) -> None:
+    def test_match_count_limits_team_belongs_to_different_club(self) -> None:
         path = self._write(
-            self._with_albany_avoid_coscheduling(
-                "    avoid_coscheduling_teams:\n      - teams: [albany-1, hackney-1]\n"
+            self._with_albany_match_count_limits(
+                "    match_count_limits:\n"
+                "      - teams: [albany-1, hackney-1]\n"
+                "        max: 1\n"
             )
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "hackney-1"):
             fixturespec.load_spec(path)
 
-    def test_avoid_coscheduling_teams_unsupported_field(self) -> None:
+    def test_match_count_limits_unsupported_field(self) -> None:
         path = self._write(
-            self._with_albany_avoid_coscheduling(
-                "    avoid_coscheduling_teams:\n"
+            self._with_albany_match_count_limits(
+                "    match_count_limits:\n"
                 "      - teams: [albany-1, albany-2]\n"
+                "        max: 1\n"
                 "        venue: elsewhere\n"
             )
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "not supported"):
-            fixturespec.load_spec(path)
-
-    def test_avoid_coscheduling_teams_negative_min_gap_days_rejected(self) -> None:
-        path = self._write(
-            self._with_albany_avoid_coscheduling(
-                "    avoid_coscheduling_teams:\n"
-                "      - teams: [albany-1, albany-2]\n"
-                "        min_gap_days: -1\n"
-            )
-        )
-        with self.assertRaisesRegex(fixturespec.SpecError, "min_gap_days"):
             fixturespec.load_spec(path)
 
     def test_exclude_fixtures_absent(self) -> None:

--- a/fmodel.py
+++ b/fmodel.py
@@ -99,54 +99,6 @@ class Club:
     home_time_limit: str  # chess time control, e.g. "75+15" for 75 min + 15 sec/move
 
 
-class ConcurrencyScope(enum.Enum):
-    """Which of a club's matches on a date a MaxConcurrentMatches limit counts:
-    HOME only its home matches, AWAY only its away matches, ANY every match its
-    teams play (an internal match -- both teams the club's -- counted once).
-
-    Parallel to CoschedulingScope but kept separate: that one's third value is
-    BOTH ("home") and it names a different feature.
-    """
-
-    HOME = "home"
-    AWAY = "away"
-    ANY = "any"
-
-
-@dataclasses.dataclass(frozen=True)
-class ConcurrencyLimit:
-    """A match-count limit for one ConcurrencyScope: a default, overridable for
-    specific dates. A value of None (for the default or an override) means no limit
-    is imposed by this mechanism -- e.g. for a club whose concurrency is already
-    bounded by another constraint (such as avoid_coscheduling_teams), where adding
-    an explicit number here would just be a redundant, easy-to-forget-to-update
-    restatement of that bound.
-    """
-
-    default: int | None
-    overrides: Mapping[date, int | None] = dataclasses.field(default_factory=dict)
-
-    def for_date(self, d: date) -> int | None:
-        return self.overrides.get(d, self.default)
-
-
-@dataclasses.dataclass(frozen=True)
-class MaxConcurrentMatches:
-    """A club's per-scope limits on how many matches its teams may play on the same
-    date. Each ConcurrencyScope present in `by_scope` has its own ConcurrencyLimit;
-    a scope with no entry imposes no limit. See ConcurrencyScope for what each
-    scope counts.
-    """
-
-    by_scope: Mapping[ConcurrencyScope, ConcurrencyLimit] = dataclasses.field(
-        default_factory=dict
-    )
-
-    def for_date(self, scope: ConcurrencyScope, d: date) -> int | None:
-        limit = self.by_scope.get(scope)
-        return None if limit is None else limit.for_date(d)
-
-
 @dataclasses.dataclass(frozen=True)
 class HomeDatesUsedBounds:
     """Bounds on how many distinct dates a club actually hosts home matches on in
@@ -219,35 +171,73 @@ class Division:
         return [Fixture(home_team=home, away_team=away) for home, away in pairs]
 
 
-class CoschedulingScope(enum.Enum):
-    """Which of an AvoidCoschedulingConstraint's teams' matches are counted towards
-    its limit: only their home matches, only their away matches, or both."""
+class VenueScope(enum.Enum):
+    """Which of a MatchCountLimit's teams' matches are counted towards its cap:
+    only their home matches, only their away matches, or all of them."""
 
     HOME = "home"
     AWAY = "away"
-    BOTH = "both"
+    ALL = "all"
+
+
+class ApplyPer(enum.Enum):
+    """How a MatchCountLimit's `max` applies to its `teams`. ACROSS_TEAMS: one
+    shared budget for the whole set (a venue capacity, or a keep-these-teams-apart
+    rule). EACH_TEAM: the cap is enforced separately for every team in the set (a
+    per-team gap -- `teams` is then typically every team of a club and `max` is 1).
+    """
+
+    EACH_TEAM = "each_team"
+    ACROSS_TEAMS = "across_teams"
 
 
 @dataclasses.dataclass(frozen=True)
-class AvoidCoschedulingConstraint:
-    """Any two matches involving `teams` must be scheduled at least `min_gap_days`
-    days apart -- i.e. a separation of exactly `min_gap_days` days is allowed, and
-    only shorter gaps are forbidden. This is the per-group counterpart of
-    Parameters.min_gap_days (which applies to every team); min_gap_days=1 (the
-    default) and min_gap_days=0 both mean simply that no two of them may share a
-    date. Typically used for a club's own teams that draw from the same pool of
-    players (e.g. adjacent-division teams), but not restricted to that.
+class MatchCountLimit:
+    """At most `max` matches involving `teams` may fall within any window of
+    `time_window_days` consecutive calendar days. This is the sole match-count
+    constraint mechanism -- a per-team gap ("each team plays at most once a week"),
+    a venue's concurrent-match capacity ("at most two home matches a night"), and a
+    keep-these-teams-apart rule are all expressed as instances of it.
 
-    `applies_to` narrows which of those teams' matches count: CoschedulingScope.HOME
-    only their home matches, CoschedulingScope.AWAY only their away matches,
-    CoschedulingScope.BOTH (the default) every match they play. So an AWAY constraint
-    keeps the teams' away fixtures on separate dates while still allowing one to play
-    away on a night another is hosting.
+    `time_window_days` counts a run of consecutive days, not a gap between two
+    endpoints: `time_window_days=1` (the default) limits matches on a single date;
+    `time_window_days=7` limits matches in any seven-consecutive-day period, so two
+    matches exactly a week apart (day N and day N+7) never share a window and are
+    unrestricted relative to each other.
+
+    `apply_per` (see ApplyPer) decides whether `max` is one shared budget for the
+    whole `teams` set (ACROSS_TEAMS, the default) or enforced separately per team
+    (EACH_TEAM).
+
+    `venue_scope` narrows which of those teams' matches count: VenueScope.HOME only
+    their home matches, VenueScope.AWAY only their away matches, VenueScope.ALL (the
+    default) every match they play. So an AWAY cap counts only the teams' away
+    fixtures, still allowing one to play away on a night another is hosting.
+
+    `max` may be None, meaning no cap from the plain value -- only useful alongside
+    `overrides`, which replace `max` on specific dates (an int, or None to lift the
+    cap that day). Overrides are only meaningful, and only permitted, when
+    `time_window_days` is 1, so each window is a single date.
     """
 
     teams: Collection[Team]
-    min_gap_days: int = 1
-    applies_to: CoschedulingScope = CoschedulingScope.BOTH
+    max: int | None
+    time_window_days: int = 1
+    venue_scope: VenueScope = VenueScope.ALL
+    apply_per: ApplyPer = ApplyPer.ACROSS_TEAMS
+    overrides: Mapping[date, int | None] = dataclasses.field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.overrides and self.time_window_days != 1:
+            raise ValueError("MatchCountLimit.overrides requires time_window_days == 1")
+
+    def max_for_window(self, window: Collection[date]) -> int | None:
+        """The effective cap for one window: an `overrides` entry when the window
+        is a single overridden date, otherwise `max`."""
+        if self.overrides and len(window) == 1:
+            (d,) = tuple(window)
+            return self.overrides.get(d, self.max)
+        return self.max
 
 
 def _check_no_duplicate_teams(teams: Collection[Team]) -> None:
@@ -280,16 +270,6 @@ class Parameters:
     teams: Collection[Team]
     home_dates: Mapping[ClubT, list[date]]
     unavailable_away_dates: Mapping[ClubT, list[date]]
-    min_gap_days: int = 7
-    # Per-club overrides of min_gap_days: a club listed here uses its value for the
-    # minimum gap between any two matches involving one of its teams, in place of
-    # the spec-wide min_gap_days. A club not present here uses min_gap_days as
-    # before. (This is about the every-team window; the per-group
-    # avoid_coscheduling_teams constraints are separate and always additive.)
-    club_min_gap_days: Mapping[ClubT, int] = dataclasses.field(default_factory=dict)
-    max_concurrent_matches: Mapping[ClubT, MaxConcurrentMatches] = dataclasses.field(
-        default_factory=dict
-    )
     home_dates_used: Mapping[ClubT, HomeDatesUsedBounds] = dataclasses.field(
         default_factory=dict
     )
@@ -320,7 +300,7 @@ class Parameters:
     team_unavailable_away_dates: Mapping[Team, list[date]] = dataclasses.field(
         default_factory=dict
     )
-    avoid_coscheduling_teams: Collection[AvoidCoschedulingConstraint] = ()
+    match_count_limits: Collection[MatchCountLimit] = ()
     # Fixture generation scheme per division number (see FixtureScheme); a division
     # with no entry here uses FixtureScheme.DOUBLE_ROUND. This is the only
     # per-division input -- the `divisions` view below, including each SINGLE_ROUND
@@ -363,34 +343,6 @@ class Parameters:
             )
             for number, division_teams in by_number.items()
         )
-
-    @functools.cached_property
-    def _teams_per_club(self) -> Mapping[ClubT, int]:
-        return collections.Counter(team.club for team in self.teams)
-
-    def max_concurrent_matches_for(
-        self, club: ClubT, scope: ConcurrencyScope, d: date
-    ) -> int | None:
-        """The most matches of `scope` (see ConcurrencyScope) `club` may play on
-        date `d`, or None if unlimited.
-
-        A configured limit that is >= the club's own number of teams is reported as
-        unlimited too: the club can never play more simultaneous matches (of any
-        scope) than it has teams, so such a limit could never actually bind.
-        """
-        entry = self.max_concurrent_matches.get(club)
-        if entry is None:
-            return None
-        limit = entry.for_date(scope, d)
-        if limit is not None and limit >= self._teams_per_club[club]:
-            return None
-        return limit
-
-    def min_gap_days_for(self, team: Team) -> int:
-        """The minimum gap in days between any two matches involving `team`: its
-        club's club_min_gap_days override if it has one, otherwise the spec-wide
-        min_gap_days."""
-        return self.club_min_gap_days.get(team.club, self.min_gap_days)
 
     def home_dates_for(self, team: Team) -> list[date]:
         """The candidate home dates for `team`: its own override if it has one
@@ -455,11 +407,11 @@ class _FixtureVars:
         self._by_team_date: MutableMapping[
             Team, MutableMapping[date, list[cp_model.IntVar]]
         ] = collections.defaultdict(lambda: collections.defaultdict(list))
-        # One (club, date) -> vars map per ConcurrencyScope (see ConcurrencyScope
-        # for what each counts).
-        self._by_club_date: Mapping[
-            ConcurrencyScope, MutableMapping[tuple[ClubT, date], list[cp_model.IntVar]]
-        ] = {scope: collections.defaultdict(list) for scope in ConcurrencyScope}
+        # (club, date) -> vars for that club's home matches on that date (for the
+        # home_dates_used bound).
+        self._by_club_home_date: MutableMapping[
+            tuple[ClubT, date], list[cp_model.IntVar]
+        ] = collections.defaultdict(list)
 
     def register(
         self, fixture: Fixture, match_date: date, var: cp_model.IntVar
@@ -478,11 +430,7 @@ class _FixtureVars:
         self._by_fixture[fixture].append(var)
         self._by_team_date[home][match_date].append(var)
         self._by_team_date[away][match_date].append(var)
-        self._by_club_date[ConcurrencyScope.HOME][home.club, match_date].append(var)
-        self._by_club_date[ConcurrencyScope.AWAY][away.club, match_date].append(var)
-        self._by_club_date[ConcurrencyScope.ANY][home.club, match_date].append(var)
-        if away.club != home.club:
-            self._by_club_date[ConcurrencyScope.ANY][away.club, match_date].append(var)
+        self._by_club_home_date[home.club, match_date].append(var)
 
     def fixture_date_vars(self) -> Mapping[tuple[Fixture, date], cp_model.IntVar]:
         """The master map: the single bool var for each candidate (fixture, date)."""
@@ -492,18 +440,11 @@ class _FixtureVars:
         """Each fixture's vars over all its candidate dates (exactly one is true)."""
         return self._by_fixture.values()
 
-    def per_team_dates(
+    def by_club_home_date(
         self,
-    ) -> Iterable[tuple[Team, Mapping[date, list[cp_model.IntVar]]]]:
-        """Per team, the team paired with its vars grouped by date (for the
-        min-gap window limit, whose length can vary by the team's club)."""
-        return self._by_team_date.items()
-
-    def by_club_date(
-        self, scope: ConcurrencyScope
     ) -> Mapping[tuple[ClubT, date], list[cp_model.IntVar]]:
-        """Per (club, date), the vars counting towards `scope` (see ConcurrencyScope)."""
-        return self._by_club_date[scope]
+        """Per (club, date), the vars for that club's home matches on that date."""
+        return self._by_club_home_date
 
 
 def _add_home_dates_used_constraints(
@@ -513,7 +454,7 @@ def _add_home_dates_used_constraints(
 ) -> None:
     """For each club in home_dates_used, bound the number of its home dates that
     end up hosting at least one match (below by `minimum`, above by `maximum`)."""
-    vars_by_club_home_date = fixture_vars.by_club_date(ConcurrencyScope.HOME)
+    vars_by_club_home_date = fixture_vars.by_club_home_date()
     # Collect the set of home dates per club that appear in the variable map
     clubs_home_dates: MutableMapping[str, list[date]] = collections.defaultdict(list)
     for club, d in vars_by_club_home_date:
@@ -540,48 +481,54 @@ def _add_home_dates_used_constraints(
             model.add(total_used >= bounds.minimum)
 
 
-def _add_avoid_coscheduling_constraints(
+def _add_match_count_limit_constraints(
     model: cp_model.CpModel,
-    constraints: Collection[AvoidCoschedulingConstraint],
+    limits: Collection[MatchCountLimit],
     fixture_vars: _FixtureVars,
 ) -> None:
-    """For each AvoidCoschedulingConstraint, ensure any two matches involving its
-    teams are scheduled at least min_gap_days days apart (a gap of exactly
-    min_gap_days days is allowed; only shorter gaps are forbidden). The constraint's
-    `applies_to` scope limits which of those teams' matches are counted -- home only,
-    away only, or (by default) both.
+    """Apply every MatchCountLimit: no window of `time_window_days` consecutive days
+    may hold more than the rule's effective cap (see max_for_window) matches from
+    the counted set. `venue_scope` selects which of the teams' matches count (home
+    only, away only, or all); `apply_per` decides whether `max` is a shared budget
+    for the whole group or enforced separately per team.
     """
-    for constraint in constraints:
-        team_set = set(constraint.teams)
-        count_home = constraint.applies_to in (
-            CoschedulingScope.HOME,
-            CoschedulingScope.BOTH,
-        )
-        count_away = constraint.applies_to in (
-            CoschedulingScope.AWAY,
-            CoschedulingScope.BOTH,
-        )
-        # Each (fixture, date) maps to a single variable, visited once here, so a
-        # match between two teams both in `constraint.teams` is counted once.
-        vars_by_date: MutableMapping[date, list[cp_model.IntVar]] = (
-            collections.defaultdict(list)
-        )
-        for (fixture, d), var in fixture_vars.fixture_date_vars().items():
-            if (count_home and fixture.home_team in team_set) or (
-                count_away and fixture.away_team in team_set
-            ):
-                vars_by_date[d].append(var)
+    fixture_date_vars = fixture_vars.fixture_date_vars()
+    for rule in limits:
+        count_home = rule.venue_scope in (VenueScope.HOME, VenueScope.ALL)
+        count_away = rule.venue_scope in (VenueScope.AWAY, VenueScope.ALL)
+        each_team = rule.apply_per is ApplyPer.EACH_TEAM
+        groups = [{team} for team in rule.teams] if each_team else [set(rule.teams)]
+        for team_set in groups:
+            # Each (fixture, date) maps to a single variable, visited once here, so
+            # a match between two teams both in `team_set` is counted once.
+            vars_by_date: MutableMapping[date, list[cp_model.IntVar]] = (
+                collections.defaultdict(list)
+            )
+            for (fixture, d), var in fixture_date_vars.items():
+                if (count_home and fixture.home_team in team_set) or (
+                    count_away and fixture.away_team in team_set
+                ):
+                    vars_by_date[d].append(var)
 
-        # date_windows groups dates up to and including its window arg apart, so
-        # pass min_gap_days - 1: a separation of exactly min_gap_days (e.g. two
-        # matches a week apart when min_gap_days=7) must be allowed, not treated as
-        # a violation -- the same convention as the per-team min_gap_days constraint
-        # in _build_model. min_gap_days <= 1 still forbids sharing a date (each
-        # date's own singleton window collects every counted match on it).
-        for window in date_windows(vars_by_date.keys(), constraint.min_gap_days - 1):
-            window_vars = [v for d in window for v in vars_by_date[d]]
-            if len(window_vars) > 1:
-                model.add(cp_model.LinearExpr.Sum(window_vars) <= 1)
+            # date_windows groups dates spanning up to its window arg in days, so
+            # pass time_window_days - 1: a window is then any run of
+            # time_window_days consecutive calendar days, and two dates exactly
+            # time_window_days apart (e.g. a week apart when time_window_days=7)
+            # fall in separate windows. time_window_days=1 gives one window per
+            # date.
+            for window in date_windows(vars_by_date.keys(), rule.time_window_days - 1):
+                cap = rule.max_for_window(window)
+                if cap is None:
+                    continue
+                # A shared-budget cap that is >= the group size can never bind: the
+                # teams can't play more simultaneous matches than there are of them
+                # (this is how a stated venue capacity above a club's team count
+                # stays a no-op).
+                if not each_team and cap >= len(team_set):
+                    continue
+                window_vars = [v for d in window for v in vars_by_date[d]]
+                if len(window_vars) > cap:
+                    model.add(cp_model.LinearExpr.Sum(window_vars) <= cap)
 
 
 def _add_fixed_fixtures_constraints(
@@ -656,31 +603,8 @@ def _build_model(params: Parameters) -> tuple[cp_model.CpModel, _FixtureVars]:
         # Each fixture must be scheduled exactly once
         model.add(cp_model.LinearExpr.Sum(scheduled_vars) == 1)
 
-    for team, team_date_vars in fixture_vars.per_team_dates():
-        # Each team can play at most one match in each window. date_windows groups
-        # dates up to and including window_days apart, so pass min_gap_days - 1: a
-        # gap of exactly min_gap_days (e.g. two matches a week apart when
-        # min_gap_days=7) must be allowed, not treated as a violation. The gap can
-        # be overridden per club (club_min_gap_days), so resolve it per team.
-        gap = params.min_gap_days_for(team)
-        for window in date_windows(team_date_vars.keys(), gap - 1):
-            window_vars = [v for d in window for v in team_date_vars[d]]
-            model.add(cp_model.LinearExpr.Sum(window_vars) <= 1)
-
-    for scope in ConcurrencyScope:
-        for (club, match_date), club_date_vars in fixture_vars.by_club_date(
-            scope
-        ).items():
-            # Each club may play at most max_concurrent_matches matches of this
-            # scope per date (None means unlimited: no constraint to add).
-            max_matches = params.max_concurrent_matches_for(club, scope, match_date)
-            if max_matches is not None:
-                model.add(cp_model.LinearExpr.Sum(club_date_vars) <= max_matches)
-
     _add_home_dates_used_constraints(model, params.home_dates_used, fixture_vars)
-    _add_avoid_coscheduling_constraints(
-        model, params.avoid_coscheduling_teams, fixture_vars
-    )
+    _add_match_count_limit_constraints(model, params.match_count_limits, fixture_vars)
     _add_fixed_fixtures_constraints(model, params.fixed_fixtures, fixture_vars)
 
     return model, fixture_vars

--- a/genfixtures.py
+++ b/genfixtures.py
@@ -153,13 +153,30 @@ _UNAVAILABLE_AWAY_DATES = {
     ),
 }
 
-_MAX_CONCURRENT_MATCHES = {
-    club: fmodel.MaxConcurrentMatches(
-        by_scope={fmodel.ConcurrencyScope.HOME: fmodel.ConcurrencyLimit(default=2)}
-    )
-    for club in _HOME_DATES
-}
 _MIN_MATCH_GAP_DAYS = 7
+
+_TEAMS_BY_CLUB: dict[str, list[fmodel.Team]] = collections.defaultdict(list)
+for _team in _TEAMS:
+    _TEAMS_BY_CLUB[_team.club].append(_team)
+
+# One match per team per week, plus at most two home matches a night per club --
+# expressed as match_count_limits, the sole match-count constraint mechanism.
+_MATCH_COUNT_LIMITS = [
+    fmodel.MatchCountLimit(
+        teams=club_teams,
+        max=1,
+        time_window_days=_MIN_MATCH_GAP_DAYS,
+        apply_per=fmodel.ApplyPer.EACH_TEAM,
+    )
+    for club_teams in _TEAMS_BY_CLUB.values()
+] + [
+    fmodel.MatchCountLimit(
+        teams=club_teams,
+        max=2,
+        venue_scope=fmodel.VenueScope.HOME,
+    )
+    for club_teams in _TEAMS_BY_CLUB.values()
+]
 
 
 def print_fixtures(fixtures: Collection[fmodel.ScheduledFixture]) -> None:
@@ -222,8 +239,7 @@ def build_params() -> fmodel.Parameters:
         teams=_TEAMS,
         home_dates=_HOME_DATES,
         unavailable_away_dates=_UNAVAILABLE_AWAY_DATES,
-        min_gap_days=_MIN_MATCH_GAP_DAYS,
-        max_concurrent_matches=_MAX_CONCURRENT_MATCHES,
+        match_count_limits=_MATCH_COUNT_LIMITS,
     )
 
 

--- a/model_test.py
+++ b/model_test.py
@@ -18,6 +18,7 @@ import collections
 import dataclasses
 import random
 import unittest
+from collections.abc import Collection
 from datetime import date, timedelta
 from typing import Any
 
@@ -26,12 +27,51 @@ import fmodel
 import genfixtures
 
 
-def _home_limit(n: int | None) -> fmodel.MaxConcurrentMatches:
-    """A club's MaxConcurrentMatches carrying just a HOME-scope limit with default
-    n (no per-date overrides) -- the shape most of these tests need."""
-    return fmodel.MaxConcurrentMatches(
-        by_scope={fmodel.ConcurrencyScope.HOME: fmodel.ConcurrencyLimit(default=n)}
-    )
+def _home_limit(n: int | None) -> tuple[fmodel.VenueScope, int | None]:
+    """Legacy shorthand: a club's per-date HOME-scope match cap of `n` (None =
+    unlimited). Consumed by _params() below, which turns it into a
+    fmodel.MatchCountLimit over that club's teams."""
+    return (fmodel.VenueScope.HOME, n)
+
+
+def _params(
+    *,
+    min_gap_days: int | None = None,
+    max_concurrent_matches: (
+        dict[str, tuple[fmodel.VenueScope, int | None]] | None
+    ) = None,
+    match_count_limits: Collection[fmodel.MatchCountLimit] = (),
+    **kwargs: Any,
+) -> fmodel.Parameters:
+    """fmodel.Parameters with the old min_gap_days / max_concurrent_matches
+    conveniences expressed as match_count_limits.
+
+    `min_gap_days` (falsy -> skipped) adds a per-team window of that length,
+    limit 1, for every club. Each `max_concurrent_matches` entry (a club ID ->
+    (scope, n) pair, e.g. from _home_limit) adds a shared cap of `n` matches of
+    that scope for the club's teams. Any explicit `match_count_limits` are kept.
+    """
+    teams = list(kwargs["teams"])
+    teams_by_club: dict[str, list[fmodel.Team]] = collections.defaultdict(list)
+    for team in teams:
+        teams_by_club[team.club].append(team)
+
+    limits = list(match_count_limits)
+    if min_gap_days:
+        for club_teams in teams_by_club.values():
+            limits.append(
+                fmodel.MatchCountLimit(
+                    teams=club_teams,
+                    max=1,
+                    time_window_days=min_gap_days,
+                    apply_per=fmodel.ApplyPer.EACH_TEAM,
+                )
+            )
+    for club, (scope, n) in (max_concurrent_matches or {}).items():
+        limits.append(
+            fmodel.MatchCountLimit(teams=teams_by_club[club], max=n, venue_scope=scope)
+        )
+    return fmodel.Parameters(match_count_limits=limits, **kwargs)
 
 
 class TestSolve(unittest.TestCase):
@@ -102,13 +142,13 @@ class TestSolve(unittest.TestCase):
                 gap = (sorted_dates[i] - sorted_dates[i - 1]).days
                 self.assertGreaterEqual(
                     gap,
-                    self.params.min_gap_days,
+                    genfixtures._MIN_MATCH_GAP_DAYS,
                     f"Team {team.name} has fixtures too close: {sorted_dates[i - 1]} and {sorted_dates[i]} (gap: {gap} days)",
                 )
 
     def test_max_concurrent_home_constraint(self) -> None:
-        """Test max concurrent home matches constraint with real parameters."""
-        # Count home fixtures per club per date
+        """Test max concurrent home matches constraint with real parameters
+        (genfixtures caps each club at two home matches a night)."""
         home_fixtures_by_club_date: dict[tuple[str, date], int] = (
             collections.defaultdict(int)
         )
@@ -117,18 +157,10 @@ class TestSolve(unittest.TestCase):
             home_fixtures_by_club_date[key] += 1
 
         for (club, fixture_date), count in home_fixtures_by_club_date.items():
-            limit = self.params.max_concurrent_matches_for(
-                club, fmodel.ConcurrencyScope.HOME, fixture_date
-            )
-            # None means unlimited -- including a configured limit that's >= the
-            # club's number of teams, which can never actually bind (see
-            # TestMaxConcurrentMatchesFor) -- so there's nothing to check.
-            if limit is None:
-                continue
             self.assertLessEqual(
                 count,
-                limit,
-                f"Club {club} has {count} home matches on {fixture_date}, exceeding limit of {limit}",
+                2,
+                f"Club {club} has {count} home matches on {fixture_date}, exceeding limit of 2",
             )
 
     def test_unavailable_away_dates(self) -> None:
@@ -231,7 +263,7 @@ class TestSolve(unittest.TestCase):
         team1 = fmodel.Team(division=1, club="Test Club A", index=1)
         team2 = fmodel.Team(division=1, club="Test Club B", index=1)
 
-        params = fmodel.Parameters(
+        params = _params(
             teams=[team1, team2],
             home_dates={
                 "Test Club A": [date(2025, 1, 1)],  # A can only play home on Jan 1
@@ -283,89 +315,71 @@ class TestSolveStats(unittest.TestCase):
 
     def test_raises_when_infeasible(self) -> None:
         # Two teams of one club, only a single shared home date: both the A1 v A2
-        # and A2 v A1 fixtures are forced onto it, but neither team may play twice
-        # in a window -- an unsatisfiable model, not just an empty schedule.
+        # and A2 v A1 fixtures are forced onto it, but the per-team weekly limit
+        # forbids either team playing twice that day -- an unsatisfiable model,
+        # not just an empty schedule.
         team1 = fmodel.Team(division=1, club="A", index=1)
         team2 = fmodel.Team(division=1, club="A", index=2)
-        params = fmodel.Parameters(
+        params = _params(
             teams=[team1, team2],
             home_dates={"A": [date(2025, 1, 1)]},
             unavailable_away_dates={"A": []},
+            min_gap_days=7,
         )
         with self.assertRaisesRegex(ValueError, "No solution found"):
             fmodel.solve(params)
 
 
-class TestMaxConcurrentMatchesFor(unittest.TestCase):
-    """A configured max_concurrent_matches limit that is >= a club's number of
-    teams can never actually restrict anything (the club can never play more
-    simultaneous matches than it has teams), so max_concurrent_matches_for()
-    should report it as unlimited (None) too. See issue #22.
+class TestSharedLimitAtOrAboveGroupSize(unittest.TestCase):
+    """A shared-budget MatchCountLimit (apply_per=ACROSS_TEAMS) with max >= the number
+    of teams it covers can never bind -- the teams can't play more simultaneous
+    matches than there are of them -- so the solver skips it (this is how a
+    venue capacity stated above a club's team count stays a no-op). See issue #22.
     """
 
-    def _params(self, num_teams: int, limit: int | None) -> fmodel.Parameters:
+    def _solve(self, num_teams: int, limit: int) -> list[fmodel.ScheduledFixture]:
         teams = [
             fmodel.Team(division=1, club="A", index=i) for i in range(1, num_teams + 1)
         ]
-        return fmodel.Parameters(
+        params = fmodel.Parameters(
             teams=teams,
             home_dates={"A": [date(2025, 1, 1)]},
             unavailable_away_dates={"A": []},
-            max_concurrent_matches={
-                "A": _home_limit(limit),
-            },
+            match_count_limits=[
+                fmodel.MatchCountLimit(
+                    teams=teams, max=limit, venue_scope=fmodel.VenueScope.HOME
+                )
+            ],
         )
+        return list(fmodel.solve(params).fixtures)
 
-    def test_limit_below_team_count_is_kept(self) -> None:
-        params = self._params(num_teams=3, limit=2)
-        self.assertEqual(
-            params.max_concurrent_matches_for(
-                "A", fmodel.ConcurrencyScope.HOME, date(2025, 1, 1)
-            ),
-            2,
-        )
+    def test_limit_at_group_size_does_not_bind(self) -> None:
+        # 2 teams, one shared home date, limit 2: both home legs (A1 v A2 and
+        # A2 v A1) land on that date -- the limit is a no-op, so this solves.
+        fixtures = self._solve(num_teams=2, limit=2)
+        self.assertEqual({sf.date for sf in fixtures}, {date(2025, 1, 1)})
+        self.assertEqual(len(fixtures), 2)
 
-    def test_limit_equal_to_team_count_is_reported_as_unlimited(self) -> None:
-        params = self._params(num_teams=2, limit=2)
-        self.assertIsNone(
-            params.max_concurrent_matches_for(
-                "A", fmodel.ConcurrencyScope.HOME, date(2025, 1, 1)
-            )
-        )
+    def test_limit_above_group_size_does_not_bind(self) -> None:
+        fixtures = self._solve(num_teams=2, limit=5)
+        self.assertEqual(len(fixtures), 2)
 
-    def test_limit_above_team_count_is_reported_as_unlimited(self) -> None:
-        params = self._params(num_teams=2, limit=5)
-        self.assertIsNone(
-            params.max_concurrent_matches_for(
-                "A", fmodel.ConcurrencyScope.HOME, date(2025, 1, 1)
-            )
+    def test_limit_below_group_size_still_binds(self) -> None:
+        # 3 teams, one shared home date, home limit 2: three home legs can't all
+        # fit -> infeasible.
+        teams = [fmodel.Team(division=1, club="A", index=i) for i in range(1, 4)]
+        params = fmodel.Parameters(
+            teams=teams,
+            home_dates={"A": [date(2025, 1, 1)]},
+            unavailable_away_dates={"A": []},
+            match_count_limits=[
+                fmodel.MatchCountLimit(
+                    teams=teams, max=2, venue_scope=fmodel.VenueScope.HOME
+                )
+            ],
         )
-
-    def test_explicit_unlimited_stays_unlimited(self) -> None:
-        params = self._params(num_teams=2, limit=None)
-        self.assertIsNone(
-            params.max_concurrent_matches_for(
-                "A", fmodel.ConcurrencyScope.HOME, date(2025, 1, 1)
-            )
-        )
-
-    def test_club_with_no_entry_is_unlimited(self) -> None:
-        params = self._params(num_teams=3, limit=2)
-        # "B" isn't in max_concurrent_matches at all.
-        self.assertIsNone(
-            params.max_concurrent_matches_for(
-                "B", fmodel.ConcurrencyScope.HOME, date(2025, 1, 1)
-            )
-        )
-
-    def test_scope_with_no_entry_is_unlimited(self) -> None:
-        params = self._params(num_teams=3, limit=2)
-        # Only the HOME scope is configured; AWAY/ANY have no limit.
-        self.assertIsNone(
-            params.max_concurrent_matches_for(
-                "A", fmodel.ConcurrencyScope.AWAY, date(2025, 1, 1)
-            )
-        )
+        with self.assertRaises(ValueError):
+            fmodel.solve(params)
 
 
 class TestHomeDatesUsedBounds(unittest.TestCase):
@@ -417,7 +431,7 @@ class TestHomeDatesUsed(unittest.TestCase):
         home_dates = {"A": a_home_dates} | other_home_dates
 
         all_clubs = ["A"] + other_clubs
-        params = fmodel.Parameters(
+        params = _params(
             teams=teams,
             home_dates=home_dates,
             unavailable_away_dates={c: [] for c in all_clubs},
@@ -459,7 +473,7 @@ class TestHomeDatesUsed(unittest.TestCase):
         home_dates = {"A": a_home_dates} | other_home_dates
 
         all_clubs = ["A"] + other_clubs
-        params = fmodel.Parameters(
+        params = _params(
             teams=teams,
             home_dates=home_dates,
             unavailable_away_dates={c: [] for c in all_clubs},
@@ -487,7 +501,7 @@ class TestHomeDatesUsed(unittest.TestCase):
             "A": [date(2025, 1, 1), date(2025, 2, 1), date(2025, 3, 1)],
             "B": [date(2025, 4, 1), date(2025, 5, 1), date(2025, 6, 1)],
         }
-        params = fmodel.Parameters(
+        params = _params(
             teams=teams,
             home_dates=home_dates,
             unavailable_away_dates={"A": [], "B": []},
@@ -515,7 +529,7 @@ class TestHomeDatesUsed(unittest.TestCase):
             "A": [date(2025, 1, 1), date(2025, 2, 1), date(2025, 3, 1)],
             "B": [date(2025, 4, 1), date(2025, 5, 1), date(2025, 6, 1)],
         }
-        params = fmodel.Parameters(
+        params = _params(
             teams=teams,
             home_dates=home_dates,
             unavailable_away_dates={"A": [], "B": []},
@@ -554,7 +568,7 @@ class TestFixedFixtures(unittest.TestCase):
             ],
             "B": [date(2025, 5, 1), date(2025, 6, 1)],
         }
-        return fmodel.Parameters(
+        return _params(
             teams=teams,
             home_dates=home_dates,
             unavailable_away_dates={"A": [], "B": []},
@@ -622,7 +636,7 @@ class TestFixedFixtures(unittest.TestCase):
                 date=date(2025, 1, 8),
             ),
         ]
-        params = fmodel.Parameters(
+        params = _params(
             teams=[a1, a2],
             home_dates={"A": [date(2025, 1, 1), date(2025, 1, 8)]},
             unavailable_away_dates={"A": []},
@@ -647,7 +661,7 @@ class TestFixedFixtures(unittest.TestCase):
                 date=date(2025, 1, 7),
             ),
         ]
-        params = fmodel.Parameters(
+        params = _params(
             teams=[a1, a2],
             home_dates={"A": [date(2025, 1, 1), date(2025, 1, 7)]},
             unavailable_away_dates={"A": []},
@@ -677,7 +691,7 @@ class TestLatestInternalMatchDate(unittest.TestCase):
             ],
             "B": [date(2025, 5, 1), date(2025, 6, 1)],
         }
-        return fmodel.Parameters(
+        return _params(
             teams=teams,
             home_dates=home_dates,
             unavailable_away_dates={"A": [], "B": []},
@@ -787,7 +801,7 @@ class TestClubLatestMatchDate(unittest.TestCase):
             ],
             "B": [date(2025, 5, 1), date(2025, 6, 1)],
         }
-        return fmodel.Parameters(
+        return _params(
             teams=teams,
             home_dates=home_dates,
             unavailable_away_dates={"A": [], "B": []},
@@ -826,7 +840,7 @@ class TestClubLatestMatchDate(unittest.TestCase):
             fmodel.Team(division=1, club="B", index=1),
             fmodel.Team(division=1, club="C", index=1),
         ]
-        params = fmodel.Parameters(
+        params = _params(
             teams=teams,
             home_dates={
                 "A": [date(2025, 1, 1), date(2025, 1, 15)],
@@ -894,7 +908,7 @@ class TestEarliestMatchDate(unittest.TestCase):
             ],
             "B": [date(2025, 5, 1), date(2025, 6, 1)],
         }
-        return fmodel.Parameters(
+        return _params(
             teams=teams,
             home_dates=home_dates,
             unavailable_away_dates={"A": [], "B": []},
@@ -973,7 +987,7 @@ class TestExcludedFixtures(unittest.TestCase):
             ],
             "B": [date(2025, 5, 1), date(2025, 6, 1)],
         }
-        return fmodel.Parameters(
+        return _params(
             teams=teams,
             home_dates=home_dates,
             unavailable_away_dates={"A": [], "B": []},
@@ -1035,7 +1049,7 @@ class TestDivisionSchemes(unittest.TestCase):
         # A generous common pool of home dates, > min_gap_days apart, so date
         # feasibility never masks a wrong fixture count.
         dates = [date(2025, 1, 1) + timedelta(days=7 * i) for i in range(20)]
-        return fmodel.Parameters(
+        return _params(
             teams=teams,
             home_dates={c: list(dates) for c in clubs},
             unavailable_away_dates={c: [] for c in clubs},
@@ -1132,7 +1146,7 @@ class TestTeamConstraints(unittest.TestCase):
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=1, club="A", index=2)
         a_home_dates = [date(2025, 1, 1), date(2025, 2, 1), date(2025, 3, 1)]
-        params = fmodel.Parameters(
+        params = _params(
             teams=[a1, a2],
             home_dates={"A": a_home_dates},
             unavailable_away_dates={"A": []},
@@ -1155,7 +1169,7 @@ class TestTeamConstraints(unittest.TestCase):
         B's home date, even though club A has no such club-wide restriction."""
         a1 = fmodel.Team(division=1, club="A", index=1)
         b1 = fmodel.Team(division=1, club="B", index=1)
-        params = fmodel.Parameters(
+        params = _params(
             teams=[a1, b1],
             home_dates={"A": [date(2025, 1, 1)], "B": [date(2025, 2, 1)]},
             unavailable_away_dates={"A": [], "B": []},
@@ -1185,7 +1199,7 @@ class TestTeamConstraints(unittest.TestCase):
 
     def test_team_without_override_falls_back_to_club(self) -> None:
         a1 = fmodel.Team(division=1, club="A", index=1)
-        params = fmodel.Parameters(
+        params = _params(
             teams=[a1],
             home_dates={"A": [date(2025, 1, 1), date(2025, 2, 1)]},
             unavailable_away_dates={"A": []},
@@ -1197,25 +1211,25 @@ class TestTeamConstraints(unittest.TestCase):
         self.assertEqual(params.unavailable_away_dates_for(a1), set())
 
 
-class TestAvoidCoschedulingTeams(unittest.TestCase):
-    """Test cases for AvoidCoschedulingConstraint: any two matches involving a given
-    set of teams must be scheduled at least min_gap_days days apart (a gap of exactly
-    min_gap_days days is allowed; only shorter gaps are forbidden).
+class TestMatchCountLimits(unittest.TestCase):
+    """Test cases for MatchCountLimit: no window of time_window_days consecutive
+    days may hold more than `limit` matches involving a given set of teams (two
+    dates exactly time_window_days apart fall in separate windows).
     """
 
-    def test_min_gap_days_defaults_to_one(self) -> None:
+    def test_time_window_days_defaults_to_one(self) -> None:
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=2, club="A", index=2)
         self.assertEqual(
-            fmodel.AvoidCoschedulingConstraint(teams=[a1, a2]).min_gap_days, 1
+            fmodel.MatchCountLimit(teams=[a1, a2], max=1).time_window_days, 1
         )
 
-    def test_applies_to_defaults_to_both(self) -> None:
+    def test_venue_scope_defaults_to_all(self) -> None:
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=2, club="A", index=2)
         self.assertEqual(
-            fmodel.AvoidCoschedulingConstraint(teams=[a1, a2]).applies_to,
-            fmodel.CoschedulingScope.BOTH,
+            fmodel.MatchCountLimit(teams=[a1, a2], max=1).venue_scope,
+            fmodel.VenueScope.ALL,
         )
 
     def test_forces_different_dates_for_constrained_teams(self) -> None:
@@ -1230,7 +1244,7 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
         a2 = fmodel.Team(division=2, club="A", index=2)
         x1 = fmodel.Team(division=1, club="X", index=1)
         x2 = fmodel.Team(division=2, club="X", index=2)
-        params = fmodel.Parameters(
+        params = _params(
             teams=[a1, a2, x1, x2],
             home_dates={
                 "A": [date(2025, 1, 1), date(2025, 1, 8)],
@@ -1242,9 +1256,7 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
                 "X": _home_limit(2),
             },
             min_gap_days=7,
-            avoid_coscheduling_teams=[
-                fmodel.AvoidCoschedulingConstraint(teams=[a1, a2])
-            ],
+            match_count_limits=[fmodel.MatchCountLimit(teams=[a1, a2], max=1)],
         )
         fixtures = list(fmodel.solve(params).fixtures)
         a1_home_date = next(sf.date for sf in fixtures if sf.fixture.home_team == a1)
@@ -1259,7 +1271,7 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
         a2 = fmodel.Team(division=2, club="A", index=2)
         x1 = fmodel.Team(division=1, club="X", index=1)
         x2 = fmodel.Team(division=2, club="X", index=2)
-        params = fmodel.Parameters(
+        params = _params(
             teams=[a1, a2, x1, x2],
             home_dates={
                 "A": [date(2025, 1, 1), date(2025, 1, 8)],
@@ -1271,9 +1283,7 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
                 "X": _home_limit(2),
             },
             min_gap_days=7,
-            avoid_coscheduling_teams=[
-                fmodel.AvoidCoschedulingConstraint(teams=[a1, a2])
-            ],
+            match_count_limits=[fmodel.MatchCountLimit(teams=[a1, a2], max=1)],
         )
         with self.assertRaises(ValueError):
             fmodel.solve(params)
@@ -1288,7 +1298,7 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
         a2 = fmodel.Team(division=2, club="A", index=2)
         x1 = fmodel.Team(division=1, club="X", index=1)
         x2 = fmodel.Team(division=2, club="X", index=2)
-        params = fmodel.Parameters(
+        params = _params(
             teams=[a1, a2, x1, x2],
             home_dates={
                 "A": [date(2025, 1, 1)],
@@ -1300,24 +1310,23 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
                 "X": _home_limit(2),
             },
             min_gap_days=7,
-            avoid_coscheduling_teams=[
-                fmodel.AvoidCoschedulingConstraint(teams=[a1, a2])
-            ],
+            match_count_limits=[fmodel.MatchCountLimit(teams=[a1, a2], max=1)],
         )
         with self.assertRaises(ValueError):
             fmodel.solve(params)
 
-    def test_min_gap_days_forbids_shorter_gaps(self) -> None:
-        """With min_gap_days=3, A1 and A2's home matches must land at least 3 days
-        apart -- of A's three candidate dates (Jan 1, 3, 10), the only forbidden
-        pairing is Jan 1 / Jan 3 (2 days), so the solver must pick a pairing that
-        involves Jan 10. (X's two home dates, for A1/A2's away legs, are far enough
-        apart not to introduce a second conflict of their own.)"""
+    def test_time_window_days_forbids_shorter_gaps(self) -> None:
+        """With time_window_days=3 and max=1, A1 and A2's home matches can't share
+        any 3-consecutive-day window -- of A's three candidate dates (Jan 1, 3, 10),
+        the only forbidden pairing is Jan 1 / Jan 3 (2 days apart), so the solver
+        must pick a pairing that involves Jan 10. (X's two home dates, for A1/A2's
+        away legs, are far enough apart not to introduce a second conflict of their
+        own.)"""
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=2, club="A", index=2)
         x1 = fmodel.Team(division=1, club="X", index=1)
         x2 = fmodel.Team(division=2, club="X", index=2)
-        params = fmodel.Parameters(
+        params = _params(
             teams=[a1, a2, x1, x2],
             home_dates={
                 "A": [date(2025, 1, 1), date(2025, 1, 3), date(2025, 1, 10)],
@@ -1329,8 +1338,8 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
                 "X": _home_limit(2),
             },
             min_gap_days=7,
-            avoid_coscheduling_teams=[
-                fmodel.AvoidCoschedulingConstraint(teams=[a1, a2], min_gap_days=3)
+            match_count_limits=[
+                fmodel.MatchCountLimit(teams=[a1, a2], max=1, time_window_days=3)
             ],
         )
         fixtures = list(fmodel.solve(params).fixtures)
@@ -1338,17 +1347,18 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
         a2_home_date = next(sf.date for sf in fixtures if sf.fixture.home_team == a2)
         self.assertGreaterEqual(abs((a1_home_date - a2_home_date).days), 3)
 
-    def test_min_gap_days_allows_exact_gap(self) -> None:
-        """min_gap_days=N is a minimum separation: a gap of exactly N days is legal,
-        only shorter gaps are forbidden. With min_gap_days=7 and A's only two home
-        dates exactly a week apart (Jan 1 and Jan 8), A1 and A2 must take one each --
-        the schedule stays feasible. An off-by-one that treated a 7-day gap as a
-        violation would make this infeasible."""
+    def test_time_window_days_allows_exact_gap(self) -> None:
+        """time_window_days=N counts a run of N consecutive days, not a gap between
+        endpoints: two dates exactly N days apart fall in separate windows. With
+        time_window_days=7, max=1 and A's only two home dates exactly a week apart
+        (Jan 1 and Jan 8), A1 and A2 must take one each -- the schedule stays
+        feasible. An off-by-one that put a 7-day span in one window would make this
+        infeasible."""
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=2, club="A", index=2)
         x1 = fmodel.Team(division=1, club="X", index=1)
         x2 = fmodel.Team(division=2, club="X", index=2)
-        params = fmodel.Parameters(
+        params = _params(
             teams=[a1, a2, x1, x2],
             home_dates={
                 "A": [date(2025, 1, 1), date(2025, 1, 8)],
@@ -1360,8 +1370,8 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
                 "X": _home_limit(2),
             },
             min_gap_days=7,
-            avoid_coscheduling_teams=[
-                fmodel.AvoidCoschedulingConstraint(teams=[a1, a2], min_gap_days=7)
+            match_count_limits=[
+                fmodel.MatchCountLimit(teams=[a1, a2], max=1, time_window_days=7)
             ],
         )
         fixtures = list(fmodel.solve(params).fixtures)
@@ -1379,16 +1389,14 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
         be counted twice and wrongly made unschedulable."""
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=1, club="A", index=2)
-        params = fmodel.Parameters(
+        params = _params(
             teams=[a1, a2],
             home_dates={"A": [date(2025, 1, 1)]},
             unavailable_away_dates={"A": []},
             max_concurrent_matches={"A": _home_limit(1)},
             min_gap_days=7,
             excluded_fixtures=[fmodel.Fixture(home_team=a2, away_team=a1)],
-            avoid_coscheduling_teams=[
-                fmodel.AvoidCoschedulingConstraint(teams=[a1, a2])
-            ],
+            match_count_limits=[fmodel.MatchCountLimit(teams=[a1, a2], max=1)],
         )
         fixtures = list(fmodel.solve(params).fixtures)
         self.assertEqual(
@@ -1410,7 +1418,7 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
         a2 = fmodel.Team(division=2, club="A", index=2)
         x1 = fmodel.Team(division=1, club="X", index=1)
         x2 = fmodel.Team(division=2, club="X", index=2)
-        params = fmodel.Parameters(
+        params = _params(
             teams=[a1, a2, x1, x2],
             home_dates={
                 "A": [date(2025, 1, 1)],
@@ -1422,9 +1430,9 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
                 "X": _home_limit(2),
             },
             min_gap_days=7,
-            avoid_coscheduling_teams=[
-                fmodel.AvoidCoschedulingConstraint(
-                    teams=[a1, a2], applies_to=fmodel.CoschedulingScope.AWAY
+            match_count_limits=[
+                fmodel.MatchCountLimit(
+                    teams=[a1, a2], max=1, venue_scope=fmodel.VenueScope.AWAY
                 )
             ],
         )
@@ -1440,7 +1448,7 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
         a2 = fmodel.Team(division=2, club="A", index=2)
         x1 = fmodel.Team(division=1, club="X", index=1)
         x2 = fmodel.Team(division=2, club="X", index=2)
-        params = fmodel.Parameters(
+        params = _params(
             teams=[a1, a2, x1, x2],
             home_dates={
                 "A": [date(2025, 1, 1), date(2025, 1, 8)],
@@ -1452,9 +1460,9 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
                 "X": _home_limit(2),
             },
             min_gap_days=7,
-            avoid_coscheduling_teams=[
-                fmodel.AvoidCoschedulingConstraint(
-                    teams=[a1, a2], applies_to=fmodel.CoschedulingScope.AWAY
+            match_count_limits=[
+                fmodel.MatchCountLimit(
+                    teams=[a1, a2], max=1, venue_scope=fmodel.VenueScope.AWAY
                 )
             ],
         )
@@ -1469,7 +1477,7 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
         a2 = fmodel.Team(division=2, club="A", index=2)
         x1 = fmodel.Team(division=1, club="X", index=1)
         x2 = fmodel.Team(division=2, club="X", index=2)
-        params = fmodel.Parameters(
+        params = _params(
             teams=[a1, a2, x1, x2],
             home_dates={
                 "A": [date(2025, 1, 1), date(2025, 1, 8)],
@@ -1481,9 +1489,9 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
                 "X": _home_limit(2),
             },
             min_gap_days=7,
-            avoid_coscheduling_teams=[
-                fmodel.AvoidCoschedulingConstraint(
-                    teams=[a1, a2], applies_to=fmodel.CoschedulingScope.HOME
+            match_count_limits=[
+                fmodel.MatchCountLimit(
+                    teams=[a1, a2], max=1, venue_scope=fmodel.VenueScope.HOME
                 )
             ],
         )
@@ -1499,7 +1507,7 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
         a2 = fmodel.Team(division=2, club="A", index=2)
         x1 = fmodel.Team(division=1, club="X", index=1)
         x2 = fmodel.Team(division=2, club="X", index=2)
-        params = fmodel.Parameters(
+        params = _params(
             teams=[a1, a2, x1, x2],
             home_dates={
                 "A": [date(2025, 1, 1)],
@@ -1511,32 +1519,74 @@ class TestAvoidCoschedulingTeams(unittest.TestCase):
                 "X": _home_limit(2),
             },
             min_gap_days=7,
-            avoid_coscheduling_teams=[
-                fmodel.AvoidCoschedulingConstraint(
-                    teams=[a1, a2], applies_to=fmodel.CoschedulingScope.HOME
+            match_count_limits=[
+                fmodel.MatchCountLimit(
+                    teams=[a1, a2], max=1, venue_scope=fmodel.VenueScope.HOME
                 )
             ],
         )
         with self.assertRaises(ValueError):
             fmodel.solve(params)
 
+    def _three_a_teams_in_one_window(self, limit: int) -> fmodel.Parameters:
+        """A1/A2/A3 each have exactly one fixture (their home leg; the reverse legs
+        against X are excluded), and A's only three home dates all sit inside a
+        single 30-day window. A match_count_limit of `limit` over that window then
+        allows only `limit` of the three to be scheduled."""
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        a2 = fmodel.Team(division=2, club="A", index=2)
+        a3 = fmodel.Team(division=3, club="A", index=3)
+        x1 = fmodel.Team(division=1, club="X", index=1)
+        x2 = fmodel.Team(division=2, club="X", index=2)
+        x3 = fmodel.Team(division=3, club="X", index=3)
+        return _params(
+            teams=[a1, a2, a3, x1, x2, x3],
+            home_dates={
+                "A": [date(2025, 1, 1), date(2025, 1, 15), date(2025, 1, 29)],
+                "X": [],
+            },
+            unavailable_away_dates={"A": [], "X": []},
+            min_gap_days=7,
+            excluded_fixtures=[
+                fmodel.Fixture(home_team=x1, away_team=a1),
+                fmodel.Fixture(home_team=x2, away_team=a2),
+                fmodel.Fixture(home_team=x3, away_team=a3),
+            ],
+            match_count_limits=[
+                fmodel.MatchCountLimit(
+                    teams=[a1, a2, a3], max=limit, time_window_days=30
+                )
+            ],
+        )
 
-class TestClubMinGapDays(unittest.TestCase):
-    """Per-club overrides of the spec-wide min_gap_days (Parameters.club_min_gap_days
-    / min_gap_days_for): a club listed there uses its own gap for the every-team
-    window, other clubs keep min_gap_days."""
+    def test_limit_above_one_still_binds_when_exceeded(self) -> None:
+        """limit=2 over the shared window leaves nowhere for the third of A1/A2/A3's
+        fixtures -> infeasible."""
+        with self.assertRaises(ValueError):
+            fmodel.solve(self._three_a_teams_in_one_window(limit=2))
 
-    def _params(
-        self, club_min_gap_days: dict[str, int] | None = None
-    ) -> fmodel.Parameters:
+    def test_limit_above_one_permits_up_to_the_limit(self) -> None:
+        """limit=3 admits all three of A1/A2/A3's fixtures in the same window."""
+        fixtures = list(
+            fmodel.solve(self._three_a_teams_in_one_window(limit=3)).fixtures
+        )
+        self.assertEqual(len(fixtures), 3)
+
+
+class TestPerClubGap(unittest.TestCase):
+    """A per-team gap expressed per club: each club gets its own apply_per=EACH_TEAM
+    MatchCountLimit, so one club can be given a closer gap than another."""
+
+    def _params(self, gaps: dict[str, int]) -> fmodel.Parameters:
         """Two teams per club, each club's pair sharing a division so they play a
         double round against each other. Each club has exactly two home dates
-        three days apart -- inside the default 7-day gap, so without an override
-        the return leg has nowhere to go."""
+        three days apart -- inside a 7-day gap, so a club given a 7-day window has
+        nowhere to put its return leg."""
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=1, club="A", index=2)
         b1 = fmodel.Team(division=2, club="B", index=1)
         b2 = fmodel.Team(division=2, club="B", index=2)
+        teams_by_club = {"A": [a1, a2], "B": [b1, b2]}
         return fmodel.Parameters(
             teams=[a1, a2, b1, b2],
             home_dates={
@@ -1544,25 +1594,30 @@ class TestClubMinGapDays(unittest.TestCase):
                 "B": [date(2025, 2, 3), date(2025, 2, 6)],
             },
             unavailable_away_dates={"A": [], "B": []},
-            min_gap_days=7,
-            club_min_gap_days=club_min_gap_days or {},
+            match_count_limits=[
+                fmodel.MatchCountLimit(
+                    teams=teams_by_club[club],
+                    max=1,
+                    time_window_days=gap,
+                    apply_per=fmodel.ApplyPer.EACH_TEAM,
+                )
+                for club, gap in gaps.items()
+            ],
         )
 
-    def test_without_override_global_gap_applies(self) -> None:
+    def test_seven_day_gap_for_both_is_infeasible(self) -> None:
         with self.assertRaises(ValueError):
-            fmodel.solve(self._params())
+            fmodel.solve(self._params({"A": 7, "B": 7}))
 
-    def test_override_lets_that_club_use_a_closer_gap(self) -> None:
+    def test_closer_gap_for_one_club_only_still_infeasible(self) -> None:
         """A gap of 2 for club A only: A's two fixtures fill A's two dates three
-        days apart, while B (no override) is still stuck on the 7-day gap, so the
-        solve as a whole stays infeasible -- the override is per club."""
+        days apart, while B keeps the 7-day gap, so the solve as a whole stays
+        infeasible -- the gap is per club."""
         with self.assertRaises(ValueError):
-            fmodel.solve(self._params(club_min_gap_days={"A": 2}))
+            fmodel.solve(self._params({"A": 2, "B": 7}))
 
-    def test_override_for_every_constrained_club_makes_it_feasible(self) -> None:
-        fixtures = list(
-            fmodel.solve(self._params(club_min_gap_days={"A": 2, "B": 2})).fixtures
-        )
+    def test_closer_gap_for_every_club_makes_it_feasible(self) -> None:
+        fixtures = list(fmodel.solve(self._params({"A": 2, "B": 2})).fixtures)
         by_club_dates = collections.defaultdict(set)
         for sf in fixtures:
             by_club_dates[sf.fixture.home_team.club].add(sf.date)
@@ -1570,9 +1625,9 @@ class TestClubMinGapDays(unittest.TestCase):
         self.assertEqual(by_club_dates["B"], {date(2025, 2, 3), date(2025, 2, 6)})
 
 
-class TestMaxConcurrentMatchesUnlimited(unittest.TestCase):
-    """Test cases for ConcurrencyLimit(default=None) / overrides=None: no
-    limit imposed by this mechanism, as opposed to a finite one.
+class TestSharedHomeLimitNullAndOverrides(unittest.TestCase):
+    """A shared home-scope MatchCountLimit with max=None imposes no cap; an
+    `overrides` entry of None lifts it for that one date, an int replaces it.
     """
 
     def test_finite_default_makes_it_infeasible(self) -> None:
@@ -1583,7 +1638,7 @@ class TestMaxConcurrentMatchesUnlimited(unittest.TestCase):
         a2 = fmodel.Team(division=2, club="A", index=2)
         x1 = fmodel.Team(division=1, club="X", index=1)
         x2 = fmodel.Team(division=2, club="X", index=2)
-        params = fmodel.Parameters(
+        params = _params(
             teams=[a1, a2, x1, x2],
             home_dates={
                 "A": [date(2025, 1, 1)],
@@ -1606,7 +1661,7 @@ class TestMaxConcurrentMatchesUnlimited(unittest.TestCase):
         a2 = fmodel.Team(division=2, club="A", index=2)
         x1 = fmodel.Team(division=1, club="X", index=1)
         x2 = fmodel.Team(division=2, club="X", index=2)
-        params = fmodel.Parameters(
+        params = _params(
             teams=[a1, a2, x1, x2],
             home_dates={
                 "A": [date(2025, 1, 1)],
@@ -1633,23 +1688,22 @@ class TestMaxConcurrentMatchesUnlimited(unittest.TestCase):
         a2 = fmodel.Team(division=2, club="A", index=2)
         x1 = fmodel.Team(division=1, club="X", index=1)
         x2 = fmodel.Team(division=2, club="X", index=2)
-        params = fmodel.Parameters(
+        params = _params(
             teams=[a1, a2, x1, x2],
             home_dates={
                 "A": [date(2025, 1, 1)],
                 "X": [date(2025, 3, 1), date(2025, 3, 8)],
             },
             unavailable_away_dates={"A": [], "X": []},
-            max_concurrent_matches={
-                "A": fmodel.MaxConcurrentMatches(
-                    by_scope={
-                        fmodel.ConcurrencyScope.HOME: fmodel.ConcurrencyLimit(
-                            default=1, overrides={date(2025, 1, 1): None}
-                        )
-                    }
+            max_concurrent_matches={"X": _home_limit(2)},
+            match_count_limits=(
+                fmodel.MatchCountLimit(
+                    teams=[a1, a2],
+                    max=1,
+                    venue_scope=fmodel.VenueScope.HOME,
+                    overrides={date(2025, 1, 1): None},
                 ),
-                "X": _home_limit(2),
-            },
+            ),
             min_gap_days=7,
         )
         fixtures = list(fmodel.solve(params).fixtures)
@@ -1659,16 +1713,16 @@ class TestMaxConcurrentMatchesUnlimited(unittest.TestCase):
         self.assertEqual(a2_home_date, date(2025, 1, 1))
 
 
-class TestMaxConcurrentMatchesScopes(unittest.TestCase):
-    """The AWAY and ANY ConcurrencyScopes at the solve() level (HOME is covered by
-    the classes above). Scenario: club A's two teams (different divisions, so no
+class TestSharedLimitAwayAndAllScopes(unittest.TestCase):
+    """A shared-budget MatchCountLimit with venue_scope AWAY or ALL (HOME is covered
+    by the classes above). Scenario: club A's two teams (different divisions, so no
     direct fixture) play their away legs at club X, whose single home date forces
     both onto the same night unless something says otherwise.
     """
 
     def _params(
         self,
-        a_limits: fmodel.MaxConcurrentMatches,
+        a_limit: fmodel.MatchCountLimit,
         *,
         x_home_dates: list[date],
     ) -> fmodel.Parameters:
@@ -1676,27 +1730,27 @@ class TestMaxConcurrentMatchesScopes(unittest.TestCase):
         a2 = fmodel.Team(division=2, club="A", index=2)
         x1 = fmodel.Team(division=1, club="X", index=1)
         x2 = fmodel.Team(division=2, club="X", index=2)
-        return fmodel.Parameters(
+        return _params(
             teams=[a1, a2, x1, x2],
             home_dates={"A": [date(2025, 3, 1)], "X": x_home_dates},
             unavailable_away_dates={"A": [], "X": []},
             # X can host both its teams' matches whenever it has the dates for them.
-            max_concurrent_matches={"A": a_limits},
+            match_count_limits=(dataclasses.replace(a_limit, teams=[a1, a2]),),
             min_gap_days=7,
         )
 
-    def _any(self, limit: int | None) -> fmodel.MaxConcurrentMatches:
-        return fmodel.MaxConcurrentMatches(
-            by_scope={fmodel.ConcurrencyScope.ANY: fmodel.ConcurrencyLimit(limit)}
+    def _any(self, limit: int | None) -> fmodel.MatchCountLimit:
+        return fmodel.MatchCountLimit(
+            teams=[], max=limit, venue_scope=fmodel.VenueScope.ALL
         )
 
-    def _away(self, limit: int | None) -> fmodel.MaxConcurrentMatches:
-        return fmodel.MaxConcurrentMatches(
-            by_scope={fmodel.ConcurrencyScope.AWAY: fmodel.ConcurrencyLimit(limit)}
+    def _away(self, limit: int | None) -> fmodel.MatchCountLimit:
+        return fmodel.MatchCountLimit(
+            teams=[], max=limit, venue_scope=fmodel.VenueScope.AWAY
         )
 
     def test_any_scope_limit_blocks_two_matches_on_one_date(self) -> None:
-        # X has one home date, so A1 and A2 must both play away that night; an ANY
+        # X has one home date, so A1 and A2 must both play away that night; an ALL
         # limit of 1 forbids A playing two matches (home or away) on a date.
         params = self._params(self._any(1), x_home_dates=[date(2025, 1, 1)])
         with self.assertRaises(ValueError):
@@ -1738,7 +1792,7 @@ class TestDuplicateRejection(unittest.TestCase):
             fmodel.Team(division=1, club="B", index=1),
         ]
         with self.assertRaisesRegex(ValueError, "Duplicate team"):
-            fmodel.Parameters(
+            _params(
                 teams=teams,
                 home_dates={"A": [date(2025, 1, 1)], "B": [date(2025, 2, 1)]},
                 unavailable_away_dates={"A": [], "B": []},
@@ -1754,7 +1808,7 @@ class TestDuplicateRejection(unittest.TestCase):
             fmodel.Team(division=1, club="B", index=1),
         ]
         with self.assertRaisesRegex(ValueError, "Duplicate home date"):
-            fmodel.Parameters(
+            _params(
                 teams=teams,
                 home_dates={
                     "A": [date(2025, 1, 1), date(2025, 1, 1)],  # duplicate
@@ -1771,7 +1825,7 @@ class TestDuplicateRejection(unittest.TestCase):
         a1 = fmodel.Team(division=1, club="A", index=1)
         b1 = fmodel.Team(division=1, club="B", index=1)
         with self.assertRaisesRegex(ValueError, "Duplicate home date"):
-            fmodel.Parameters(
+            _params(
                 teams=[a1, b1],
                 home_dates={
                     "A": [date(2025, 1, 1), date(2025, 1, 2)],

--- a/report_test.py
+++ b/report_test.py
@@ -53,8 +53,10 @@ divisions:
 
 club_constraints:
   defaults:
-    max_concurrent_matches:
-      home: 1
+    match_count_limits:
+      - override_key: venue-capacity
+        venue_scope: home
+        max: 1
   albany:
     home_dates: [2025-09-01, 2025-09-29]
   hackney:

--- a/runs/example/solution.yaml
+++ b/runs/example/solution.yaml
@@ -548,10 +548,10 @@ fixtures:
 - home: hendon-1
   away: hackney-1
   date: 2026-05-28
-spec_checksum: sha256:047ca7f38776496599e9ac9c8e63000e9720c7a029fa407f7cad6f8201e78eeb
+spec_checksum: sha256:687409765b48c9c643dd647803c104ec058112645fe106af848e06e10b73e4a7
 stats:
   model: |-
-    satisfaction model '': (model_fingerprint: 0x68b3d8a681956b57)
+    satisfaction model '': (model_fingerprint: 0x7a72f3dd866787a9)
     #Variables: 5'653 (5'470 primary variables)
       - 5'653 Booleans in [0,1]
     #kLinear3: 4
@@ -564,13 +564,13 @@ stats:
     integers: 2215
     booleans: 5639
     conflicts: 0
-    branches: 6016
-    propagations: 210404
-    integer_propagations: 60780
+    branches: 7600
+    propagations: 269012
+    integer_propagations: 84076
     restarts: 0
     lp_iterations: 0
-    walltime: 0.199018
-    usertime: 0.199018
-    deterministic_time: 0.354404
+    walltime: 0.204949
+    usertime: 0.204949
+    deterministic_time: 0.371173
     gap_integral: 0
     solution_fingerprint: 0x5ef51ce980a21f5d

--- a/runs/example/spec.yaml
+++ b/runs/example/spec.yaml
@@ -189,9 +189,16 @@ divisions:
       - potters-bar-1
 club_constraints:
   defaults:
-    min_gap_days: 7
-    max_concurrent_matches:
-      home: 2
+    match_count_limits:
+      # Each team plays at most one match in any 7-day window.
+      - override_key: weekly-gap
+        apply_per: each_team
+        time_window_days: 7
+        max: 1
+      # Each club hosts at most two home matches a night (shared venue).
+      - override_key: venue-capacity
+        venue_scope: home
+        max: 2
   albany:
     home_dates:
       - "2025-09-01"
@@ -356,13 +363,21 @@ club_constraints:
       - "2026-04-23"
       - "2026-04-30"
       - "2026-05-28"
-    max_concurrent_matches:
-      home:
-        default: 2
+    match_count_limits:
+      # Replaces the spec-wide two-home-matches-a-night default: the venue can
+      # take a third on 2025-11-13 only.
+      - override_key: venue-capacity
+        venue_scope: home
+        max: 2
         overrides:
           "2025-11-13": 3
   harrow:
-    min_gap_days: 14
+    match_count_limits:
+      # Replaces the spec-wide per-team weekly gap
+      - override_key: weekly-gap
+        apply_per: each_team
+        time_window_days: 14
+        max: 1
     home_dates:
       - "2025-09-11"
       - "2025-09-18"

--- a/solve_test.py
+++ b/solve_test.py
@@ -54,8 +54,10 @@ divisions:
 
 club_constraints:
   defaults:
-    max_concurrent_matches:
-      home: 1
+    match_count_limits:
+      - override_key: venue-capacity
+        venue_scope: home
+        max: 1
   albany:
     home_dates: [2025-09-01, 2025-09-29]
   hackney:

--- a/spec-schema.json
+++ b/spec-schema.json
@@ -75,20 +75,18 @@
     },
     "club_constraints": {
       "type": "object",
-      "description": "Every constraint that can vary by club -- home_dates, unavailable_away_dates, min_gap_days, max_concurrent_matches, home_dates_used, latest_match_date, teams and avoid_coscheduling_teams -- keyed by that club's own ID, alongside an optional 'defaults' entry.",
+      "description": "Every constraint that can vary by club -- home_dates, unavailable_away_dates, home_dates_used, latest_match_date, teams and match_count_limits -- keyed by that club's own ID, alongside an optional 'defaults' entry.",
       "additionalProperties": { "$ref": "#/$defs/club_constraints_entry" },
       "properties": {
         "defaults": {
           "type": "object",
           "additionalProperties": false,
-          "description": "Spec-wide defaults for constraint types that support one, applied wherever a club does not set its own. That's max_concurrent_matches (merged per scope -- see its definition) and min_gap_days. All of it is optional.",
+          "description": "Spec-wide defaults, applied wherever a club does not set its own. Only 'match_count_limits' is supported here: a list applied to every club. Every entry carries a unique 'override_key'; a club's own match_count_limits entry that repeats one of those keys replaces that default for the club, and a club entry with no 'override_key' is additive.",
           "properties": {
-            "max_concurrent_matches": { "$ref": "#/$defs/max_concurrent_matches" },
-            "min_gap_days": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 7,
-              "description": "Spec-wide minimum number of days between any two matches involving the same team. 7 (the default when omitted) means a team cannot play twice within a week's spacing -- a gap of exactly 7 days is allowed, fewer is not. A club can override this with its own club_constraints.<club>.min_gap_days."
+            "match_count_limits": {
+              "type": "array",
+              "description": "Spec-wide match_count_limits applied to every club (see the per-club 'match_count_limits' for the mechanism). Entries here cannot name specific 'teams' -- they apply to every team of each club -- and each needs a unique 'override_key'.",
+              "items": { "$ref": "#/$defs/match_count_limit_default_entry" }
             }
           }
         }
@@ -181,51 +179,6 @@
         }
       }
     },
-    "concurrency_limit": {
-      "description": "A limit on how many matches of one scope (see max_concurrent_matches) a club may play on the same date. Either a plain integer, null (no limit imposed by this mechanism -- e.g. for a club whose concurrency is already bounded by another constraint, such as a full set of avoid_coscheduling_teams pairings across its teams, where restating that bound as a number here would be redundant and easy to leave stale), or a mapping giving a default plus per-date overrides. A value that's simply set high enough to never bind -- i.e. >= the club's number of teams -- needs no special-casing: the solver recognises this case itself and skips adding a constraint for it.",
-      "oneOf": [
-        { "type": "integer" },
-        { "type": "null" },
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["default"],
-          "properties": {
-            "default": {
-              "description": "Applies to any date without its own entry in 'overrides'.",
-              "oneOf": [{ "type": "integer" }, { "type": "null" }]
-            },
-            "overrides": {
-              "type": "object",
-              "description": "Per-date overrides of 'default', keyed by date.",
-              "additionalProperties": {
-                "oneOf": [{ "type": "integer" }, { "type": "null" }]
-              }
-            }
-          }
-        }
-      ]
-    },
-    "max_concurrent_matches": {
-      "type": "object",
-      "additionalProperties": false,
-      "minProperties": 1,
-      "description": "Per-scope limits on how many matches a club's teams may play on the same date. Give any of 'home', 'away', 'any' (at least one). Each is a concurrency_limit (an integer, null, or a default plus per-date overrides). Under club_constraints.defaults it sets spec-wide defaults; a club's own entry is merged with those per scope (its value wins for the scopes it sets, the default applies to the rest). Every scope is optional -- a club, and the spec as a whole, may set no concurrency limits at all.",
-      "properties": {
-        "home": {
-          "description": "Counts only the club's home matches on a date.",
-          "$ref": "#/$defs/concurrency_limit"
-        },
-        "away": {
-          "description": "Counts only the club's away matches on a date.",
-          "$ref": "#/$defs/concurrency_limit"
-        },
-        "any": {
-          "description": "Counts every match the club's teams play on a date (an internal match, both teams the club's, counted once).",
-          "$ref": "#/$defs/concurrency_limit"
-        }
-      }
-    },
     "club_constraints_entry": {
       "type": "object",
       "additionalProperties": false,
@@ -245,12 +198,6 @@
           "items": { "$ref": "#/$defs/date" },
           "uniqueItems": true
         },
-        "min_gap_days": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Overrides club_constraints.defaults.min_gap_days for this club: the minimum number of days between any two matches involving one of this club's teams. Omit to use the default. A gap of exactly this many days is allowed, fewer is not. Independent of the per-group 'avoid_coscheduling_teams' constraints, which are always additive."
-        },
-        "max_concurrent_matches": { "$ref": "#/$defs/max_concurrent_matches" },
         "home_dates_used": {
           "type": "object",
           "additionalProperties": false,
@@ -278,10 +225,10 @@
           "description": "Per-team exclusions, for clubs whose teams don't all share the same availability (e.g. different squads of players). Home dates are always specified at the club level above; per-team variations are supported only via exclusions here. A team not listed here just uses its club's dates as normal.",
           "additionalProperties": { "$ref": "#/$defs/club_team_constraints_entry" }
         },
-        "avoid_coscheduling_teams": {
+        "match_count_limits": {
           "type": "array",
-          "description": "Groups of this club's own teams that shouldn't be scheduled too close together (e.g. adjacent-division teams that draw from the same pool of players). Unlike 'teams' above, entries here are additive -- as many can be given as needed, e.g. one per adjacent pair of teams -- and there's no requirement that every team be covered.",
-          "items": { "$ref": "#/$defs/avoid_coscheduling_entry" }
+          "description": "The sole match-count constraint mechanism: each entry caps how many matches involving a set of this club's teams may fall within a rolling window of consecutive days. Covers a per-team weekly gap ('apply_per: each_team', 'max: 1', 'time_window_days: 7'), a venue's concurrent-match capacity ('apply_per: across_teams', 'venue_scope: home'), and keeping adjacent-division teams apart ('teams: [...]', 'max: 1'). Additive, with as many entries as needed; combined with any inherited from club_constraints.defaults -- an entry with an 'override_key' replaces the like-keyed default for this club instead.",
+          "items": { "$ref": "#/$defs/match_count_limit_entry" }
         }
       }
     },
@@ -303,29 +250,81 @@
         }
       }
     },
-    "avoid_coscheduling_entry": {
+    "match_count_limit_fields": {
+      "max": {
+        "oneOf": [{ "type": "integer", "minimum": 1 }, { "type": "null" }],
+        "description": "The most matches (of the kind selected by 'venue_scope') allowed within any window of 'time_window_days' consecutive days. The key is required, so an entry is never accidentally a no-op. null means no plain cap -- only useful with 'overrides', or (on a club entry with an 'override_key') to cancel a default. 'max: 1' forbids a second match in a window; a higher value caps density."
+      },
+      "apply_per": {
+        "type": "string",
+        "enum": ["across_teams", "each_team"],
+        "default": "across_teams",
+        "description": "'across_teams' (the default): the counted teams share one budget of 'max' per window (a venue capacity, or a keep-apart rule). 'each_team': 'max' is enforced separately for each team -- typically with 'teams' left as every team of the club and 'max: 1', i.e. a per-team gap."
+      },
+      "time_window_days": {
+        "type": "integer",
+        "minimum": 1,
+        "default": 1,
+        "description": "Window length in consecutive calendar days. 1 (the default) limits matches on a single date; 7 limits matches in any seven-consecutive-day period -- two matches exactly a week apart (day N and day N+7) fall in separate windows, so are unrestricted relative to each other. Counts a run of days, not the gap between two endpoints."
+      },
+      "venue_scope": {
+        "type": "string",
+        "enum": ["home", "away", "all"],
+        "default": "all",
+        "description": "Which of the counted teams' matches the cap counts: 'home' only their home matches, 'away' only their away matches, or 'all' (the default) every match they play. E.g. 'away' counts only away fixtures, still allowing one team to play away on a night another is hosting."
+      },
+      "overrides": {
+        "type": "object",
+        "description": "Per-date replacements of 'max', keyed by date; each value an integer >= 1, or null to lift the cap that day. Only allowed when 'time_window_days' is 1 (so each window is a single date).",
+        "additionalProperties": {
+          "oneOf": [{ "type": "integer", "minimum": 1 }, { "type": "null" }]
+        }
+      },
+      "override_key": {
+        "type": "string",
+        "description": "Names a club_constraints.defaults.match_count_limits entry (via its own 'override_key'). On a club entry, replaces that default for the club. Required and unique on every defaults entry; on a club entry it can't be combined with 'teams'."
+      }
+    },
+    "match_count_limit_entry": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["teams"],
+      "required": ["max"],
+      "description": "One per-club match_count_limits entry.",
       "properties": {
+        "max": { "$ref": "#/$defs/match_count_limit_fields/max" },
         "teams": {
           "type": "array",
-          "description": "Two or more of this club's own team IDs.",
+          "description": "This club's own team IDs whose matches are counted. Omit for every team of the club (a whole-club cap, or -- with 'apply_per: each_team' -- a per-team gap). One or more. Not allowed alongside 'override_key'.",
           "items": { "type": "string" },
-          "minItems": 2,
+          "minItems": 1,
           "uniqueItems": true
         },
-        "min_gap_days": {
-          "type": "integer",
-          "default": 1,
-          "minimum": 0,
-          "description": "Minimum number of days required between any two matches involving 'teams' (of the kind selected by 'applies_to'). The per-group counterpart of the spec-wide 'min_gap_days' (club_constraints.defaults.min_gap_days): a gap of exactly this many days is allowed, fewer is not. The default, 1 (0 behaves the same), means no two of them may share a date; 7 keeps them at least a week apart while still permitting matches exactly 7 days apart."
+        "apply_per": { "$ref": "#/$defs/match_count_limit_fields/apply_per" },
+        "time_window_days": {
+          "$ref": "#/$defs/match_count_limit_fields/time_window_days"
         },
-        "applies_to": {
-          "type": "string",
-          "enum": ["home", "away", "both"],
-          "default": "both",
-          "description": "Which of the listed teams' matches the limit counts: 'home' only their home matches, 'away' only their away matches, or 'both' (the default) every match they play. E.g. 'away' keeps these teams' away fixtures on separate dates while still allowing one to play away on a night another is hosting."
+        "venue_scope": { "$ref": "#/$defs/match_count_limit_fields/venue_scope" },
+        "overrides": { "$ref": "#/$defs/match_count_limit_fields/overrides" },
+        "override_key": {
+          "$ref": "#/$defs/match_count_limit_fields/override_key"
+        }
+      }
+    },
+    "match_count_limit_default_entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["max", "override_key"],
+      "description": "A club_constraints.defaults.match_count_limits entry: like a per-club match_count_limits entry but without 'teams' (defaults apply to every team of every club) and with a required, list-unique 'override_key'.",
+      "properties": {
+        "max": { "$ref": "#/$defs/match_count_limit_fields/max" },
+        "apply_per": { "$ref": "#/$defs/match_count_limit_fields/apply_per" },
+        "time_window_days": {
+          "$ref": "#/$defs/match_count_limit_fields/time_window_days"
+        },
+        "venue_scope": { "$ref": "#/$defs/match_count_limit_fields/venue_scope" },
+        "overrides": { "$ref": "#/$defs/match_count_limit_fields/overrides" },
+        "override_key": {
+          "$ref": "#/$defs/match_count_limit_fields/override_key"
         }
       }
     },

--- a/spec_schema_test.py
+++ b/spec_schema_test.py
@@ -78,30 +78,44 @@ divisions:
 
 club_constraints:
   defaults:
-    min_gap_days: 7
-    max_concurrent_matches:
-      home: 2
+    match_count_limits:
+      - override_key: weekly-gap
+        apply_per: each_team
+        time_window_days: 7
+        max: 1
+      - override_key: venue-capacity
+        venue_scope: home
+        max: 2
 
   albany:
     home_dates: [2025-09-01, 2025-09-15, 2025-09-29]
     unavailable_away_dates: [2025-12-25]
-    min_gap_days: 14
     latest_match_date: 2026-04-30
-    max_concurrent_matches:
-      home: 3
+    match_count_limits:
+      - override_key: weekly-gap
+        apply_per: each_team
+        time_window_days: 14
+        max: 1
+      - override_key: venue-capacity
+        venue_scope: home
+        max: 3
 
   hackney:
     home_dates: [2025-09-08, 2025-09-22]
-    max_concurrent_matches:
-      home:
-        default: 2
+    match_count_limits:
+      - override_key: venue-capacity
+        venue_scope: home
+        max: 2
         overrides:
           2025-09-08: 3
-      away: null
-      any:
-        default: null
+      - max: null
+        venue_scope: all
         overrides:
           2025-09-22: 1
+      - teams: [hackney-1, hackney-5]
+        time_window_days: 7
+        max: 1
+        venue_scope: away
     home_dates_used:
       min: 1
       max: 2
@@ -109,10 +123,6 @@ club_constraints:
       hackney-5:
         unavailable_home_dates: [2025-09-08]
         unavailable_away_dates: [2025-09-22]
-    avoid_coscheduling_teams:
-      - teams: [hackney-1, hackney-5]
-        min_gap_days: 7
-        applies_to: away
 
 fixed_fixtures:
   - home: albany-1


### PR DESCRIPTION
Replace min_gap_days, max_concurrent_matches and avoid_coscheduling_teams with one mechanism: a match_count_limits entry caps how many matches involving a set of teams may fall within any window of time_window_days consecutive calendar days (a run of days, not a gap between endpoints, so time_window_days: 7 leaves matches exactly a week apart unrestricted).

Entry fields:
  - max: the cap (required; null only with overrides / an override_key). A "min" may be added later without another rename.
  - venue_scope: home | away | all (VenueScope) - which side counts.
  - apply_per: across_teams | each_team (ApplyPer) - one shared budget for the group vs the cap enforced separately per team.
  - time_window_days: window length in consecutive days (default 1).
  - overrides: per-date replacements of max (time_window_days 1 only).
  - override_key: on a club entry, names the club_constraints.defaults entry it replaces for that club. Every defaults entry needs a unique key; a club entry without one is additive.

fmodel is now the pure engine with no built-in gap; spec-wide defaults live in club_constraints.defaults.match_count_limits. load_spec gains a generic unknown-top-level-key check in place of the ad-hoc removed-key rejection.

runs/example is migrated to the new syntax (solved fixtures unchanged); the 2026-27 draft1 run is migrated separately.


Claude-Session: https://claude.ai/code/session_01J4htEo8rQ8ti1KhG1uCj6v