### PR TITLE
Rename MatchCountLimit per-date overrides to date_max_overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,11 @@ club_constraints:
 `match_count_limits` is the one match-count constraint: each entry caps how many
 matches involving a set of teams may fall in any window of `time_window_days`
 consecutive days. It expresses a per-team gap (`apply_per: each_team`), a venue's
-concurrent-match capacity (`venue_scope: home`, with per-date `overrides`), and a
-keep-these-teams-apart rule (`teams: [...]`) alike. Every spec-wide default entry
-carries a unique `override_key`; a club entry repeating one replaces that default
-for the club, and a club entry with no `override_key` is additive.
+concurrent-match capacity (`venue_scope: home`, with per-date
+`date_max_overrides`), and a keep-these-teams-apart rule (`teams: [...]`) alike.
+Every spec-wide default entry carries a unique `override_key`; a club entry
+repeating one replaces that default for the club, and a club entry with no
+`override_key` is additive.
 
 That's only a fraction of what the format supports -- per-club/per-team date
 exclusions, pinned and withheld fixtures, and more. For the full field-by-field

--- a/fixturespec.py
+++ b/fixturespec.py
@@ -363,7 +363,7 @@ _MATCH_COUNT_LIMIT_FIELD_KEYS = {
     "time_window_days",
     "venue_scope",
     "apply_per",
-    "overrides",
+    "date_max_overrides",
     "override_key",
 }
 
@@ -398,8 +398,8 @@ class _ParsedMatchCountLimit:
     club it applies to"). `override_key`, on a club entry, names the
     club_constraints.defaults entry this one replaces for that club; None means the
     entry is purely additive. Every defaults entry has an `override_key`. `max` is
-    None only for an entry that exists solely to carry `overrides`, or to cancel an
-    inherited default (a club entry with an override_key and nothing else).
+    None only for an entry that exists solely to carry `date_max_overrides`, or to
+    cancel an inherited default (a club entry with an override_key and nothing else).
     """
 
     team_ids: tuple[str, ...] | None
@@ -407,7 +407,7 @@ class _ParsedMatchCountLimit:
     time_window_days: int
     venue_scope: fmodel.VenueScope
     apply_per: fmodel.ApplyPer
-    overrides: Mapping[date, int | None]
+    date_max_overrides: Mapping[date, int | None]
     override_key: str | None
 
 
@@ -631,19 +631,21 @@ def _club_team_ids(club_id: str, teams: Mapping[str, fmodel.Team]) -> list[str]:
     return [tid for tid, team in teams.items() if team.club == club_id]
 
 
-def _parse_match_count_overrides(value: Any, context: str) -> dict[date, int | None]:
-    """Parse a match_count_limits entry's optional 'overrides': a date-keyed mapping
-    of per-date limits (an integer >= 1, or null to lift the limit that day)."""
+def _parse_match_count_date_max_overrides(
+    value: Any, context: str
+) -> dict[date, int | None]:
+    """Parse a match_count_limits entry's optional 'date_max_overrides': a date-keyed
+    mapping of per-date limits (an integer >= 1, or null to lift the limit that day)."""
     if not isinstance(value, dict):
         raise SpecError(f"{context} must be a mapping keyed by date")
-    overrides: dict[date, int | None] = {}
+    date_max_overrides: dict[date, int | None] = {}
     for date_key, count in value.items():
         override_date = _parse_date(date_key, context)
         count = _require_int_or_none(count, f"{context}[{date_key!r}]")
         if count is not None and count < 1:
             raise SpecError(f"{context}[{date_key!r}] must be >= 1 or null")
-        overrides[override_date] = count
-    return overrides
+        date_max_overrides[override_date] = count
+    return date_max_overrides
 
 
 def _parse_match_count_limits(
@@ -658,7 +660,7 @@ def _parse_match_count_limits(
     Each entry:
       - 'max' (required key): an integer >= 1, or null. null on its own is only
         allowed for a club entry carrying an 'override_key' (it cancels that
-        default); otherwise null needs 'overrides' to carry the actual caps.
+        default); otherwise null needs 'date_max_overrides' to carry the actual caps.
       - 'teams' (optional): IDs of this club's teams whose matches are counted.
         Omitted => every team of the club. Not allowed under 'defaults', nor
         alongside 'override_key' (an override replaces a spec-wide, all-teams
@@ -670,8 +672,8 @@ def _parse_match_count_limits(
         calendar days. 7 limits matches in any 7-consecutive-day period -- two
         matches exactly a week apart fall in separate windows.
       - 'venue_scope' (optional, default 'all'): 'home', 'away' or 'all'.
-      - 'overrides' (optional): per-date replacements of 'max'. Only allowed when
-        'time_window_days' is 1.
+      - 'date_max_overrides' (optional): per-date replacements of 'max'. Only allowed
+        when 'time_window_days' is 1.
       - 'override_key': required for a 'defaults' entry (and unique within that
         list); optional for a club entry, where it names the default this one
         replaces for the club.
@@ -792,21 +794,21 @@ def _parse_match_count_limits(
                     f"{entry['venue_scope']!r}"
                 ) from None
 
-        overrides: dict[date, int | None] = {}
-        if "overrides" in entry:
+        date_max_overrides: dict[date, int | None] = {}
+        if "date_max_overrides" in entry:
             if time_window_days != 1:
                 raise SpecError(
-                    f"{entry_context}.overrides is only allowed when "
+                    f"{entry_context}.date_max_overrides is only allowed when "
                     "time_window_days is 1"
                 )
-            overrides = _parse_match_count_overrides(
-                entry["overrides"], f"{entry_context}.overrides"
+            date_max_overrides = _parse_match_count_date_max_overrides(
+                entry["date_max_overrides"], f"{entry_context}.date_max_overrides"
             )
 
-        if max_ is None and not overrides and override_key is None:
+        if max_ is None and not date_max_overrides and override_key is None:
             raise SpecError(
-                f"{entry_context}.max: null needs 'overrides' to carry the actual "
-                "per-date caps (or an 'override_key' to cancel a default)"
+                f"{entry_context}.max: null needs 'date_max_overrides' to carry the "
+                "actual per-date caps (or an 'override_key' to cancel a default)"
             )
 
         limits.append(
@@ -816,7 +818,7 @@ def _parse_match_count_limits(
                 time_window_days=time_window_days,
                 venue_scope=venue_scope,
                 apply_per=apply_per,
-                overrides=overrides,
+                date_max_overrides=date_max_overrides,
                 override_key=override_key,
             )
         )
@@ -837,8 +839,8 @@ def _resolve_match_count_limits(
     A club entry whose 'override_key' names a default entry replaces that default
     for the club (an unknown key, or two club entries sharing one, is an error);
     every other club entry is additive. Entries that carry neither a 'max' nor any
-    'overrides' (a pure cancel-the-default marker) and entries that resolve to no
-    teams are dropped.
+    'date_max_overrides' (a pure cancel-the-default marker) and entries that resolve
+    to no teams are dropped.
     """
     default_keys = {pl.override_key for pl in default_limits}
     resolved: list[fmodel.MatchCountLimit] = []
@@ -867,7 +869,7 @@ def _resolve_match_count_limits(
 
         club_team_objs = [teams[tid] for tid in _club_team_ids(club_id, teams)]
         for pl in effective:
-            if pl.max is None and not pl.overrides:
+            if pl.max is None and not pl.date_max_overrides:
                 continue
             team_objs = (
                 club_team_objs
@@ -883,7 +885,7 @@ def _resolve_match_count_limits(
                     time_window_days=pl.time_window_days,
                     venue_scope=pl.venue_scope,
                     apply_per=pl.apply_per,
-                    overrides=pl.overrides,
+                    date_max_overrides=pl.date_max_overrides,
                 )
             )
     return resolved

--- a/fixturespec_test.py
+++ b/fixturespec_test.py
@@ -372,14 +372,14 @@ class TestLoadSpec(unittest.TestCase):
         )
         self.assertEqual(hackney.max, 1)
 
-    def test_match_count_limits_overrides_parsed(self) -> None:
+    def test_match_count_limits_date_max_overrides_parsed(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
             "        max: 2\n"
-            "        overrides:\n"
+            "        date_max_overrides:\n"
             "          2025-09-01: 3\n"
         )
         spec = fixturespec.load_spec(path)
@@ -390,7 +390,7 @@ class TestLoadSpec(unittest.TestCase):
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
         self.assertEqual(albany.max, 2)
-        self.assertEqual(albany.overrides, {date(2025, 9, 1): 3})
+        self.assertEqual(albany.date_max_overrides, {date(2025, 9, 1): 3})
 
     def test_match_count_limits_override_null_lifts_the_cap_that_day(self) -> None:
         path = self._write(
@@ -399,7 +399,7 @@ class TestLoadSpec(unittest.TestCase):
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
             "        max: null\n"
-            "        overrides:\n"
+            "        date_max_overrides:\n"
             "          2025-09-01: 3\n"
         )
         spec = fixturespec.load_spec(path)
@@ -410,7 +410,7 @@ class TestLoadSpec(unittest.TestCase):
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
         self.assertIsNone(albany.max)
-        self.assertEqual(albany.overrides, {date(2025, 9, 1): 3})
+        self.assertEqual(albany.date_max_overrides, {date(2025, 9, 1): 3})
 
     def test_match_count_limits_null_max_cancels_default_via_override_key(self) -> None:
         path = self._write(
@@ -505,7 +505,7 @@ class TestLoadSpec(unittest.TestCase):
         with self.assertRaisesRegex(fixturespec.SpecError, "override_key"):
             fixturespec.load_spec(path)
 
-    def test_match_count_limits_overrides_require_one_day_window(self) -> None:
+    def test_match_count_limits_date_max_overrides_require_one_day_window(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
@@ -513,10 +513,10 @@ class TestLoadSpec(unittest.TestCase):
             "      - venue_scope: home\n"
             "        max: 2\n"
             "        time_window_days: 7\n"
-            "        overrides:\n"
+            "        date_max_overrides:\n"
             "          2025-09-01: 3\n"
         )
-        with self.assertRaisesRegex(fixturespec.SpecError, "overrides"):
+        with self.assertRaisesRegex(fixturespec.SpecError, "date_max_overrides"):
             fixturespec.load_spec(path)
 
     def test_match_count_limits_missing_max_field_rejected(self) -> None:
@@ -1232,7 +1232,9 @@ club_constraints:
         with self.assertRaisesRegex(fixturespec.SpecError, "max"):
             fixturespec.load_spec(path)
 
-    def test_match_count_limits_null_max_without_overrides_rejected(self) -> None:
+    def test_match_count_limits_null_max_without_date_max_overrides_rejected(
+        self,
+    ) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"

--- a/fmodel.py
+++ b/fmodel.py
@@ -215,9 +215,9 @@ class MatchCountLimit:
     fixtures, still allowing one to play away on a night another is hosting.
 
     `max` may be None, meaning no cap from the plain value -- only useful alongside
-    `overrides`, which replace `max` on specific dates (an int, or None to lift the
-    cap that day). Overrides are only meaningful, and only permitted, when
-    `time_window_days` is 1, so each window is a single date.
+    `date_max_overrides`, which replace `max` on specific dates (an int, or None to
+    lift the cap that day). These per-date overrides are only meaningful, and only
+    permitted, when `time_window_days` is 1, so each window is a single date.
     """
 
     teams: Collection[Team]
@@ -225,18 +225,22 @@ class MatchCountLimit:
     time_window_days: int = 1
     venue_scope: VenueScope = VenueScope.ALL
     apply_per: ApplyPer = ApplyPer.ACROSS_TEAMS
-    overrides: Mapping[date, int | None] = dataclasses.field(default_factory=dict)
+    date_max_overrides: Mapping[date, int | None] = dataclasses.field(
+        default_factory=dict
+    )
 
     def __post_init__(self) -> None:
-        if self.overrides and self.time_window_days != 1:
-            raise ValueError("MatchCountLimit.overrides requires time_window_days == 1")
+        if self.date_max_overrides and self.time_window_days != 1:
+            raise ValueError(
+                "MatchCountLimit.date_max_overrides requires time_window_days == 1"
+            )
 
     def max_for_window(self, window: Collection[date]) -> int | None:
-        """The effective cap for one window: an `overrides` entry when the window
-        is a single overridden date, otherwise `max`."""
-        if self.overrides and len(window) == 1:
+        """The effective cap for one window: a `date_max_overrides` entry when the
+        window is a single overridden date, otherwise `max`."""
+        if self.date_max_overrides and len(window) == 1:
             (d,) = tuple(window)
-            return self.overrides.get(d, self.max)
+            return self.date_max_overrides.get(d, self.max)
         return self.max
 
 

--- a/model_test.py
+++ b/model_test.py
@@ -1626,8 +1626,8 @@ class TestPerClubGap(unittest.TestCase):
 
 
 class TestSharedHomeLimitNullAndOverrides(unittest.TestCase):
-    """A shared home-scope MatchCountLimit with max=None imposes no cap; an
-    `overrides` entry of None lifts it for that one date, an int replaces it.
+    """A shared home-scope MatchCountLimit with max=None imposes no cap; a
+    `date_max_overrides` entry of None lifts it for that one date, an int replaces it.
     """
 
     def test_finite_default_makes_it_infeasible(self) -> None:
@@ -1701,7 +1701,7 @@ class TestSharedHomeLimitNullAndOverrides(unittest.TestCase):
                     teams=[a1, a2],
                     max=1,
                     venue_scope=fmodel.VenueScope.HOME,
-                    overrides={date(2025, 1, 1): None},
+                    date_max_overrides={date(2025, 1, 1): None},
                 ),
             ),
             min_gap_days=7,

--- a/runs/example/solution.yaml
+++ b/runs/example/solution.yaml
@@ -548,7 +548,7 @@ fixtures:
 - home: hendon-1
   away: hackney-1
   date: 2026-05-28
-spec_checksum: sha256:687409765b48c9c643dd647803c104ec058112645fe106af848e06e10b73e4a7
+spec_checksum: sha256:abf1ec6d4f1b5b22ed266e02c0198062e33dbe9760d0d20a806891f1f5557d98
 stats:
   model: |-
     satisfaction model '': (model_fingerprint: 0x7a72f3dd866787a9)

--- a/runs/example/spec.yaml
+++ b/runs/example/spec.yaml
@@ -369,7 +369,7 @@ club_constraints:
       - override_key: venue-capacity
         venue_scope: home
         max: 2
-        overrides:
+        date_max_overrides:
           "2025-11-13": 3
   harrow:
     match_count_limits:

--- a/spec-schema.json
+++ b/spec-schema.json
@@ -253,7 +253,7 @@
     "match_count_limit_fields": {
       "max": {
         "oneOf": [{ "type": "integer", "minimum": 1 }, { "type": "null" }],
-        "description": "The most matches (of the kind selected by 'venue_scope') allowed within any window of 'time_window_days' consecutive days. The key is required, so an entry is never accidentally a no-op. null means no plain cap -- only useful with 'overrides', or (on a club entry with an 'override_key') to cancel a default. 'max: 1' forbids a second match in a window; a higher value caps density."
+        "description": "The most matches (of the kind selected by 'venue_scope') allowed within any window of 'time_window_days' consecutive days. The key is required, so an entry is never accidentally a no-op. null means no plain cap -- only useful with 'date_max_overrides', or (on a club entry with an 'override_key') to cancel a default. 'max: 1' forbids a second match in a window; a higher value caps density."
       },
       "apply_per": {
         "type": "string",
@@ -273,7 +273,7 @@
         "default": "all",
         "description": "Which of the counted teams' matches the cap counts: 'home' only their home matches, 'away' only their away matches, or 'all' (the default) every match they play. E.g. 'away' counts only away fixtures, still allowing one team to play away on a night another is hosting."
       },
-      "overrides": {
+      "date_max_overrides": {
         "type": "object",
         "description": "Per-date replacements of 'max', keyed by date; each value an integer >= 1, or null to lift the cap that day. Only allowed when 'time_window_days' is 1 (so each window is a single date).",
         "additionalProperties": {
@@ -304,7 +304,9 @@
           "$ref": "#/$defs/match_count_limit_fields/time_window_days"
         },
         "venue_scope": { "$ref": "#/$defs/match_count_limit_fields/venue_scope" },
-        "overrides": { "$ref": "#/$defs/match_count_limit_fields/overrides" },
+        "date_max_overrides": {
+          "$ref": "#/$defs/match_count_limit_fields/date_max_overrides"
+        },
         "override_key": {
           "$ref": "#/$defs/match_count_limit_fields/override_key"
         }
@@ -322,7 +324,9 @@
           "$ref": "#/$defs/match_count_limit_fields/time_window_days"
         },
         "venue_scope": { "$ref": "#/$defs/match_count_limit_fields/venue_scope" },
-        "overrides": { "$ref": "#/$defs/match_count_limit_fields/overrides" },
+        "date_max_overrides": {
+          "$ref": "#/$defs/match_count_limit_fields/date_max_overrides"
+        },
         "override_key": {
           "$ref": "#/$defs/match_count_limit_fields/override_key"
         }

--- a/spec_schema_test.py
+++ b/spec_schema_test.py
@@ -106,11 +106,11 @@ club_constraints:
       - override_key: venue-capacity
         venue_scope: home
         max: 2
-        overrides:
+        date_max_overrides:
           2025-09-08: 3
       - max: null
         venue_scope: all
-        overrides:
+        date_max_overrides:
           2025-09-22: 1
       - teams: [hackney-1, hackney-5]
         time_window_days: 7


### PR DESCRIPTION
The per-date map was just called `overrides`, which read as a sibling of `override_key` on the same entry despite being an unrelated mechanism. Rename it to `date_max_overrides` everywhere: the fmodel field, the spec YAML key, the JSON schema, docs, the example run, and tests. The example run's recorded spec_checksum is refreshed to match; the rename is semantically identical, so its solved fixtures are unchanged.


Claude-Session: https://claude.ai/code/session_01WaDqP8XAB3zW3dQN6TpAdR