### PR TITLE
Add date_ranges to match_count_limits; drop avoid_dates; report unsch…

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,14 @@ matches involving a set of teams may fall in any window of `time_window_days`
 consecutive days. It expresses a per-team gap (`apply_per: each_team`), a venue's
 concurrent-match capacity (`venue_scope: home`, with per-date
 `date_max_overrides`), and a keep-these-teams-apart rule (`teams: [...]`) alike.
-Every spec-wide default entry carries a unique `override_key`; a club entry
-repeating one replaces that default for the club, and a club entry with no
-`override_key` is additive.
+An entry can instead set `date_ranges` (a list of `{start_date, end_date}`
+inclusive ranges) to cap matches within specific calendar periods -- a
+school-holiday week, say -- rather than a rolling window, with `max: 0` to bar
+them outright; a whole-club `max: 0` `date_ranges` entry under `defaults` is how
+a spec-wide "nobody plays these dates" block (e.g. Christmas) is expressed. Every
+spec-wide default entry carries a unique `override_key`; a club entry repeating
+one replaces that default for the club, and a club entry
+with no `override_key` is additive.
 
 That's only a fraction of what the format supports -- per-club/per-team date
 exclusions, pinned and withheld fixtures, and more. For the full field-by-field

--- a/fixturespec.py
+++ b/fixturespec.py
@@ -364,6 +364,7 @@ _MATCH_COUNT_LIMIT_FIELD_KEYS = {
     "venue_scope",
     "apply_per",
     "date_max_overrides",
+    "date_ranges",
     "override_key",
 }
 
@@ -380,7 +381,6 @@ _TOP_LEVEL_KEYS = {
     "draft",
     "description",
     "latest_internal_match_date",
-    "avoid_dates",
     "clubs",
     "teams",
     "divisions",
@@ -400,6 +400,8 @@ class _ParsedMatchCountLimit:
     entry is purely additive. Every defaults entry has an `override_key`. `max` is
     None only for an entry that exists solely to carry `date_max_overrides`, or to
     cancel an inherited default (a club entry with an override_key and nothing else).
+    `date_ranges`, when non-empty, restricts the rule to those explicit inclusive
+    calendar ranges instead of every rolling `time_window_days` window.
     """
 
     team_ids: tuple[str, ...] | None
@@ -408,6 +410,7 @@ class _ParsedMatchCountLimit:
     venue_scope: fmodel.VenueScope
     apply_per: fmodel.ApplyPer
     date_max_overrides: Mapping[date, int | None]
+    date_ranges: tuple[fmodel.DateRange, ...]
     override_key: str | None
 
 
@@ -648,6 +651,36 @@ def _parse_match_count_date_max_overrides(
     return date_max_overrides
 
 
+def _parse_match_count_date_ranges(
+    value: Any, context: str
+) -> tuple[fmodel.DateRange, ...]:
+    """Parse a match_count_limits entry's optional 'date_ranges': a non-empty list
+    of {start_date, end_date} mappings, each an inclusive fmodel.DateRange (which
+    enforces start on or before end)."""
+    if not isinstance(value, list) or not value:
+        raise SpecError(f"{context} must be a non-empty list")
+    ranges: list[fmodel.DateRange] = []
+    for i, item in enumerate(value):
+        item_context = f"{context}[{i}]"
+        if not isinstance(item, dict):
+            raise SpecError(f"{item_context} must be a mapping")
+        unsupported = item.keys() - {"start_date", "end_date"}
+        if unsupported:
+            raise SpecError(
+                f"{item_context}.{sorted(unsupported)} not supported (only "
+                "['end_date', 'start_date'] are)"
+            )
+        if "start_date" not in item or "end_date" not in item:
+            raise SpecError(f"{item_context} needs both 'start_date' and 'end_date'")
+        start = _parse_date(item["start_date"], f"{item_context}.start_date")
+        end = _parse_date(item["end_date"], f"{item_context}.end_date")
+        try:
+            ranges.append(fmodel.DateRange(start=start, end=end))
+        except ValueError as e:
+            raise SpecError(f"{item_context}: {e}") from e
+    return tuple(ranges)
+
+
 def _parse_match_count_limits(
     entries_spec: Any,
     club_id: str | None,
@@ -658,9 +691,10 @@ def _parse_match_count_limits(
     None) the club_constraints.defaults list applied to every club.
 
     Each entry:
-      - 'max' (required key): an integer >= 1, or null. null on its own is only
-        allowed for a club entry carrying an 'override_key' (it cancels that
-        default); otherwise null needs 'date_max_overrides' to carry the actual caps.
+      - 'max' (required key): an integer >= 1 (or >= 0 when 'date_ranges' is set),
+        or null. null on its own is only allowed for a club entry carrying an
+        'override_key' (it cancels that default); otherwise null needs
+        'date_max_overrides' to carry the actual caps.
       - 'teams' (optional): IDs of this club's teams whose matches are counted.
         Omitted => every team of the club. Not allowed under 'defaults', nor
         alongside 'override_key' (an override replaces a spec-wide, all-teams
@@ -674,9 +708,17 @@ def _parse_match_count_limits(
       - 'venue_scope' (optional, default 'all'): 'home', 'away' or 'all'.
       - 'date_max_overrides' (optional): per-date replacements of 'max'. Only allowed
         when 'time_window_days' is 1.
+      - 'date_ranges' (optional): a non-empty list of {start_date, end_date}
+        inclusive ranges. When given, the rule applies to exactly those ranges
+        instead of every rolling 'time_window_days' window. Allowed on both club
+        and 'defaults' entries; not combinable with 'time_window_days' or
+        'date_max_overrides', nor (on a club entry) with 'override_key'. 'max'
+        must then be a non-negative integer (0 bars every counted match in the
+        range -- a whole-club, all-teams 'defaults' entry with max 0 is how a
+        spec-wide "nobody plays these dates" block is expressed).
       - 'override_key': required for a 'defaults' entry (and unique within that
         list); optional for a club entry, where it names the default this one
-        replaces for the club.
+        replaces for the club wholesale.
     """
     if entries_spec is None:
         return []
@@ -702,8 +744,12 @@ def _parse_match_count_limits(
         if "max" not in entry:
             raise SpecError(f"{entry_context} missing required field 'max'")
         max_ = _require_int_or_none(entry["max"], f"{entry_context}.max")
-        if max_ is not None and max_ < 1:
-            raise SpecError(f"{entry_context}.max must be >= 1 or null")
+        # 'date_ranges' permits max: 0 (a full blackout of the listed periods);
+        # every other form needs max >= 1 or null.
+        has_date_ranges = "date_ranges" in entry
+        min_max = 0 if has_date_ranges else 1
+        if max_ is not None and max_ < min_max:
+            raise SpecError(f"{entry_context}.max must be >= {min_max} or null")
 
         override_key: str | None = None
         if "override_key" in entry:
@@ -805,7 +851,39 @@ def _parse_match_count_limits(
                 entry["date_max_overrides"], f"{entry_context}.date_max_overrides"
             )
 
-        if max_ is None and not date_max_overrides and override_key is None:
+        date_ranges: tuple[fmodel.DateRange, ...] = ()
+        if has_date_ranges:
+            if not is_defaults and override_key is not None:
+                raise SpecError(
+                    f"{entry_context}: a club entry can't combine 'date_ranges' "
+                    "with 'override_key' (an override_key names a rolling default "
+                    "to replace wholesale; on a defaults entry it is the entry's "
+                    "own key and 'date_ranges' is fine)"
+                )
+            if "time_window_days" in entry:
+                raise SpecError(
+                    f"{entry_context}: 'date_ranges' and 'time_window_days' can't "
+                    "be combined ('date_ranges' replaces the rolling window)"
+                )
+            if date_max_overrides:
+                raise SpecError(
+                    f"{entry_context}: 'date_ranges' and 'date_max_overrides' "
+                    "can't be combined"
+                )
+            if max_ is None:
+                raise SpecError(
+                    f"{entry_context}.date_ranges needs an integer 'max' (>= 0)"
+                )
+            date_ranges = _parse_match_count_date_ranges(
+                entry["date_ranges"], f"{entry_context}.date_ranges"
+            )
+
+        if (
+            max_ is None
+            and not date_max_overrides
+            and not date_ranges
+            and override_key is None
+        ):
             raise SpecError(
                 f"{entry_context}.max: null needs 'date_max_overrides' to carry the "
                 "actual per-date caps (or an 'override_key' to cancel a default)"
@@ -819,6 +897,7 @@ def _parse_match_count_limits(
                 venue_scope=venue_scope,
                 apply_per=apply_per,
                 date_max_overrides=date_max_overrides,
+                date_ranges=date_ranges,
                 override_key=override_key,
             )
         )
@@ -886,6 +965,7 @@ def _resolve_match_count_limits(
                     venue_scope=pl.venue_scope,
                     apply_per=pl.apply_per,
                     date_max_overrides=pl.date_max_overrides,
+                    date_ranges=pl.date_ranges,
                 )
             )
     return resolved
@@ -1150,14 +1230,9 @@ def load_spec(spec_path: str | Path) -> Spec:
         for team_id in divisions.ordered_team_ids
     }
 
-    avoid_dates = _parse_date_list(data.get("avoid_dates"), f"{path}: 'avoid_dates'")
-
     club_constraints = _parse_club_constraints(data, clubs, teams, path)
     home_dates = club_constraints.home_dates
-    unavailable_away_dates = {
-        club_id: sorted(set(dates) | set(avoid_dates))
-        for club_id, dates in club_constraints.unavailable_away_dates.items()
-    }
+    unavailable_away_dates = club_constraints.unavailable_away_dates
     team_home_dates = club_constraints.team_home_dates
     team_unavailable_away_dates = club_constraints.team_unavailable_away_dates
 

--- a/fixturespec_test.py
+++ b/fixturespec_test.py
@@ -283,38 +283,70 @@ class TestLoadSpec(unittest.TestCase):
         with self.assertRaisesRegex(fixturespec.SpecError, "not-a-date"):
             fixturespec.load_spec(path)
 
-    def test_avoid_dates_absent(self) -> None:
-        path = self._write(_MINIMAL_SPEC)
-        spec = fixturespec.load_spec(path)
-        self.assertEqual(
-            spec.parameters.unavailable_away_dates["albany"], [date(2025, 12, 25)]
-        )
-        self.assertEqual(spec.parameters.unavailable_away_dates["hackney"], [])
-
-    def test_avoid_dates_merged_into_every_clubs_unavailable_away_dates(self) -> None:
-        path = self._write(_MINIMAL_SPEC + "avoid_dates: [2025-12-25, 2026-01-01]\n")
-        spec = fixturespec.load_spec(path)
-        # albany already had 2025-12-25 of its own; avoid_dates adds 2026-01-01
-        # without duplicating the date it already had.
-        self.assertEqual(
-            spec.parameters.unavailable_away_dates["albany"],
-            [date(2025, 12, 25), date(2026, 1, 1)],
-        )
-        # hackney had no unavailable_away_dates of its own; picks up both avoid_dates.
-        self.assertEqual(
-            spec.parameters.unavailable_away_dates["hackney"],
-            [date(2025, 12, 25), date(2026, 1, 1)],
-        )
-
-    def test_avoid_dates_invalid_date(self) -> None:
-        path = self._write(_MINIMAL_SPEC + "avoid_dates: [not-a-date]\n")
-        with self.assertRaisesRegex(fixturespec.SpecError, "not-a-date"):
+    def test_avoid_dates_key_no_longer_recognised(self) -> None:
+        # avoid_dates was removed in favour of a defaults max: 0 date_ranges
+        # entry; the old top-level key is now an unknown field.
+        path = self._write(_MINIMAL_SPEC + "avoid_dates: [2025-12-25]\n")
+        with self.assertRaisesRegex(fixturespec.SpecError, "avoid_dates"):
             fixturespec.load_spec(path)
 
-    def test_avoid_dates_duplicate_rejected(self) -> None:
-        path = self._write(_MINIMAL_SPEC + "avoid_dates: [2025-12-25, 2025-12-25]\n")
-        with self.assertRaisesRegex(fixturespec.SpecError, "duplicate date"):
-            fixturespec.load_spec(path)
+    def test_no_play_dates_default_resolves_per_club(self) -> None:
+        # A whole-club max: 0 date_ranges defaults entry (the avoid_dates
+        # replacement): every club gets a resolved limit over all its teams.
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  defaults:\n"
+            "    match_count_limits:\n"
+            "      - override_key: no-play-dates\n"
+            "        max: 0\n"
+            "        date_ranges:\n"
+            "          - start_date: 2025-12-22\n"
+            "            end_date: 2026-01-04\n"
+            "  albany:\n"
+            "    home_dates: [2025-12-15]\n"
+            "  hackney:\n"
+            "    home_dates: [2025-12-08]\n"
+        )
+        spec = fixturespec.load_spec(path)
+        by_club = {}
+        for limit in spec.parameters.match_count_limits:
+            if limit.max == 0:
+                (club,) = {t.club for t in limit.teams}
+                by_club[club] = limit
+        self.assertEqual(set(by_club), {"albany", "hackney"})
+        self.assertEqual(
+            by_club["albany"].date_ranges,
+            (fmodel.DateRange(date(2025, 12, 22), date(2026, 1, 4)),),
+        )
+
+    def test_no_play_dates_default_can_be_overridden_by_a_club(self) -> None:
+        # A club naming the override_key replaces the block wholesale -- here
+        # cancelling it, so that club has no max: 0 limit.
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  defaults:\n"
+            "    match_count_limits:\n"
+            "      - override_key: no-play-dates\n"
+            "        max: 0\n"
+            "        date_ranges:\n"
+            "          - start_date: 2025-12-22\n"
+            "            end_date: 2026-01-04\n"
+            "  albany:\n"
+            "    home_dates: [2025-12-15]\n"
+            "    match_count_limits:\n"
+            "      - override_key: no-play-dates\n"
+            "        max: null\n"
+            "  hackney:\n"
+            "    home_dates: [2025-12-08]\n"
+        )
+        spec = fixturespec.load_spec(path)
+        zero_clubs = {
+            t.club
+            for limit in spec.parameters.match_count_limits
+            if limit.max == 0
+            for t in limit.teams
+        }
+        self.assertEqual(zero_clubs, {"hackney"})
 
     def test_duplicate_top_level_key_rejected(self) -> None:
         path = self._write(_MINIMAL_SPEC + '\nname: "one"\nname: "two"\n')
@@ -641,6 +673,200 @@ class TestLoadSpec(unittest.TestCase):
             t.club for limit in spec.parameters.match_count_limits for t in limit.teams
         }
         self.assertEqual(clubs, {"albany"})
+
+    def test_match_count_limits_date_ranges_parsed(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - max: 1\n"
+            "        date_ranges:\n"
+            "          - start_date: 2025-10-27\n"
+            "            end_date: 2025-11-02\n"
+            "          - start_date: 2026-02-16\n"
+            "            end_date: 2026-02-22\n"
+        )
+        spec = fixturespec.load_spec(path)
+        limit = _find_limit(
+            spec.parameters.match_count_limits,
+            club="albany",
+            venue_scope=fmodel.VenueScope.ALL,
+            apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
+        )
+        self.assertEqual(
+            limit.date_ranges,
+            (
+                fmodel.DateRange(date(2025, 10, 27), date(2025, 11, 2)),
+                fmodel.DateRange(date(2026, 2, 16), date(2026, 2, 22)),
+            ),
+        )
+        self.assertEqual((limit.max, limit.time_window_days), (1, 1))
+
+    def test_match_count_limits_date_ranges_allow_max_zero(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - max: 0\n"
+            "        date_ranges:\n"
+            "          - start_date: 2025-10-27\n"
+            "            end_date: 2025-11-02\n"
+        )
+        spec = fixturespec.load_spec(path)
+        limit = _find_limit(
+            spec.parameters.match_count_limits,
+            club="albany",
+            venue_scope=fmodel.VenueScope.ALL,
+            apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
+        )
+        self.assertEqual(limit.max, 0)
+
+    def test_match_count_limits_max_zero_rejected_without_date_ranges(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        max: 0\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "must be >= 1"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_date_ranges_reject_time_window_days(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - max: 1\n"
+            "        time_window_days: 7\n"
+            "        date_ranges:\n"
+            "          - start_date: 2025-10-27\n"
+            "            end_date: 2025-11-02\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "time_window_days"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_date_ranges_reject_date_max_overrides(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - max: 1\n"
+            "        date_max_overrides:\n"
+            "          2025-10-27: 1\n"
+            "        date_ranges:\n"
+            "          - start_date: 2025-10-27\n"
+            "            end_date: 2025-11-02\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "date_max_overrides"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_date_ranges_reject_override_key(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  defaults:\n"
+            "    match_count_limits:\n"
+            "      - override_key: venue-capacity\n"
+            "        venue_scope: home\n"
+            "        max: 1\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - override_key: venue-capacity\n"
+            "        max: 1\n"
+            "        date_ranges:\n"
+            "          - start_date: 2025-10-27\n"
+            "            end_date: 2025-11-02\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "date_ranges"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_date_ranges_allowed_under_defaults(self) -> None:
+        # A defaults entry may carry date_ranges; its own override_key is the
+        # entry's identity, not a replace-target, so the two coexist.
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  defaults:\n"
+            "    match_count_limits:\n"
+            "      - override_key: k\n"
+            "        max: 1\n"
+            "        date_ranges:\n"
+            "          - start_date: 2025-10-27\n"
+            "            end_date: 2025-11-02\n"
+        )
+        spec = fixturespec.load_spec(path)
+        limit = _find_limit(
+            spec.parameters.match_count_limits,
+            club="albany",
+            venue_scope=fmodel.VenueScope.ALL,
+            apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
+        )
+        self.assertEqual(
+            limit.date_ranges,
+            (fmodel.DateRange(date(2025, 10, 27), date(2025, 11, 2)),),
+        )
+
+    def test_match_count_limits_date_ranges_reject_null_max(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - max: null\n"
+            "        date_ranges:\n"
+            "          - start_date: 2025-10-27\n"
+            "            end_date: 2025-11-02\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "integer 'max'"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_date_ranges_reject_start_after_end(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - max: 1\n"
+            "        date_ranges:\n"
+            "          - start_date: 2025-11-02\n"
+            "            end_date: 2025-10-27\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "is after end"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_date_ranges_reject_missing_end_date(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - max: 1\n"
+            "        date_ranges:\n"
+            "          - start_date: 2025-10-27\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "end_date"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_date_ranges_reject_unknown_key(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - max: 1\n"
+            "        date_ranges:\n"
+            "          - start_date: 2025-10-27\n"
+            "            end_date: 2025-11-02\n"
+            "            note: half term\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "not supported"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_date_ranges_reject_empty_list(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - max: 1\n"
+            "        date_ranges: []\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "non-empty list"):
+            fixturespec.load_spec(path)
 
     def test_match_count_limits_omitted_everywhere_is_allowed(self) -> None:
         # No club_constraints.defaults and no per-club match_count_limits: limits
@@ -1948,19 +2174,34 @@ club_constraints:
             fixturespec.load_spec(path)
 
     def test_club_latest_match_date_solves_end_to_end(self) -> None:
-        """A cutoff before all of hackney's home dates makes every hackney-hosted
-        fixture unschedulable, so (like the other date-cutoff constraints) those are
-        silently left out; the rest of the schedule still solves."""
-        path = self._write(_THREE_TEAM_SPEC + "    latest_match_date: 2025-12-31\n")
+        """A cutoff that still leaves hackney a usable home date solves, with every
+        hackney fixture on or before the cutoff."""
+        path = self._write(_THREE_TEAM_SPEC + "    latest_match_date: 2026-01-15\n")
         spec = fixturespec.load_spec(path)
         self.assertEqual(
-            spec.parameters.club_latest_match_date, {"hackney": date(2025, 12, 31)}
+            spec.parameters.club_latest_match_date, {"hackney": date(2026, 1, 15)}
         )
         fixtures = list(fmodel.solve(spec.parameters).fixtures)
-        self.assertTrue(fixtures)
-        self.assertFalse(
-            [sf for sf in fixtures if sf.fixture.home_team.club == "hackney"]
-        )
+        hackney_fixtures = [
+            sf
+            for sf in fixtures
+            if "hackney" in (sf.fixture.home_team.club, sf.fixture.away_team.club)
+        ]
+        self.assertEqual(
+            len(hackney_fixtures), 4
+        )  # hackney-1 home and away vs each albany
+        for sf in hackney_fixtures:
+            self.assertLessEqual(sf.date, date(2026, 1, 15))
+
+    def test_club_latest_match_date_before_all_its_home_dates_is_infeasible(
+        self,
+    ) -> None:
+        """A cutoff before every hackney home date leaves the hackney-hosted
+        fixtures with no schedulable date -- required, so solve() raises."""
+        path = self._write(_THREE_TEAM_SPEC + "    latest_match_date: 2025-12-31\n")
+        spec = fixturespec.load_spec(path)
+        with self.assertRaisesRegex(ValueError, "no schedulable date"):
+            fmodel.solve(spec.parameters)
 
     def test_solves_end_to_end(self) -> None:
         """A loaded spec's Parameters should be usable directly with fmodel.solve()."""

--- a/fmodel.py
+++ b/fmodel.py
@@ -171,6 +171,29 @@ class Division:
         return [Fixture(home_team=home, away_team=away) for home, away in pairs]
 
 
+@dataclasses.dataclass(frozen=True)
+class DateRange:
+    """An inclusive span of calendar dates, `start` on or before `end`.
+
+    Used by MatchCountLimit.date_ranges to pin a cap to specific calendar periods
+    (a school-holiday week, say) rather than a rolling window. `d in date_range`
+    tests membership.
+    """
+
+    start: date
+    end: date
+
+    def __post_init__(self) -> None:
+        if self.start > self.end:
+            raise ValueError(
+                f"DateRange start {self.start.isoformat()} is after end "
+                f"{self.end.isoformat()}"
+            )
+
+    def __contains__(self, d: object) -> bool:
+        return isinstance(d, date) and self.start <= d <= self.end
+
+
 class VenueScope(enum.Enum):
     """Which of a MatchCountLimit's teams' matches are counted towards its cap:
     only their home matches, only their away matches, or all of them."""
@@ -218,6 +241,14 @@ class MatchCountLimit:
     `date_max_overrides`, which replace `max` on specific dates (an int, or None to
     lift the cap that day). These per-date overrides are only meaningful, and only
     permitted, when `time_window_days` is 1, so each window is a single date.
+
+    `date_ranges`, when non-empty, replaces the rolling-window behaviour entirely:
+    instead of every run of `time_window_days` consecutive days, the cap applies to
+    exactly the given DateRanges, each counted independently. This targets a limit
+    tied to specific weeks -- a school-holiday week, a congress fortnight -- that a
+    rolling window can't express. It requires `time_window_days` left at its default
+    of 1, is mutually exclusive with `date_max_overrides`, and `max` must then be a
+    non-negative integer (`max=0` bars every counted match in the range).
     """
 
     teams: Collection[Team]
@@ -228,12 +259,24 @@ class MatchCountLimit:
     date_max_overrides: Mapping[date, int | None] = dataclasses.field(
         default_factory=dict
     )
+    date_ranges: tuple[DateRange, ...] = ()
 
     def __post_init__(self) -> None:
         if self.date_max_overrides and self.time_window_days != 1:
             raise ValueError(
                 "MatchCountLimit.date_max_overrides requires time_window_days == 1"
             )
+        if self.date_ranges:
+            if self.time_window_days != 1:
+                raise ValueError(
+                    "MatchCountLimit.date_ranges can't be combined with a "
+                    "non-default time_window_days (it replaces the rolling window)"
+                )
+            if self.date_max_overrides:
+                raise ValueError(
+                    "MatchCountLimit.date_ranges and date_max_overrides are "
+                    "mutually exclusive"
+                )
 
     def max_for_window(self, window: Collection[date]) -> int | None:
         """The effective cap for one window: a `date_max_overrides` entry when the
@@ -242,6 +285,31 @@ class MatchCountLimit:
             (d,) = tuple(window)
             return self.date_max_overrides.get(d, self.max)
         return self.max
+
+    def counts_fixture(self, fixture: Fixture) -> bool:
+        """Whether this limit counts `fixture` at all: its home team (for a HOME or
+        ALL scope) or away team (AWAY or ALL) is among `teams`."""
+        teams = set(self.teams)
+        return (
+            self.venue_scope in (VenueScope.HOME, VenueScope.ALL)
+            and fixture.home_team in teams
+        ) or (
+            self.venue_scope in (VenueScope.AWAY, VenueScope.ALL)
+            and fixture.away_team in teams
+        )
+
+    def forbids(self, fixture: Fixture, d: date) -> bool:
+        """Whether this limit makes `fixture` on `d` outright impossible -- an
+        effective cap of 0 over a window that covers `d`. _build_model skips
+        creating a decision variable for such a candidate (it could only ever be
+        0)."""
+        if not self.counts_fixture(fixture):
+            return False
+        if self.date_ranges:
+            return self.max == 0 and any(d in rng for rng in self.date_ranges)
+        if self.max == 0:
+            return True
+        return self.date_max_overrides.get(d) == 0
 
 
 def _check_no_duplicate_teams(teams: Collection[Team]) -> None:
@@ -440,9 +508,12 @@ class _FixtureVars:
         """The master map: the single bool var for each candidate (fixture, date)."""
         return self._by_fixture_date
 
-    def per_fixture(self) -> Iterable[list[cp_model.IntVar]]:
-        """Each fixture's vars over all its candidate dates (exactly one is true)."""
-        return self._by_fixture.values()
+    def vars_for_fixture(self, fixture: Fixture) -> list[cp_model.IntVar]:
+        """`fixture`'s vars over all its candidate dates (exactly one is true in a
+        solved model). Empty if every candidate date was filtered out while
+        building -- the caller must treat that as the schedule being infeasible,
+        since nothing else records that the fixture is still required."""
+        return self._by_fixture.get(fixture, [])
 
     def by_club_home_date(
         self,
@@ -491,10 +562,11 @@ def _add_match_count_limit_constraints(
     fixture_vars: _FixtureVars,
 ) -> None:
     """Apply every MatchCountLimit: no window of `time_window_days` consecutive days
-    may hold more than the rule's effective cap (see max_for_window) matches from
-    the counted set. `venue_scope` selects which of the teams' matches count (home
-    only, away only, or all); `apply_per` decides whether `max` is a shared budget
-    for the whole group or enforced separately per team.
+    -- or, when the rule sets `date_ranges`, no listed calendar range -- may hold
+    more than the rule's effective cap (see max_for_window) matches from the counted
+    set. `venue_scope` selects which of the teams' matches count (home only, away
+    only, or all); `apply_per` decides whether `max` is a shared budget for the
+    whole group or enforced separately per team.
     """
     fixture_date_vars = fixture_vars.fixture_date_vars()
     for rule in limits:
@@ -514,21 +586,31 @@ def _add_match_count_limit_constraints(
                 ):
                     vars_by_date[d].append(var)
 
-            # date_windows groups dates spanning up to its window arg in days, so
-            # pass time_window_days - 1: a window is then any run of
-            # time_window_days consecutive calendar days, and two dates exactly
-            # time_window_days apart (e.g. a week apart when time_window_days=7)
-            # fall in separate windows. time_window_days=1 gives one window per
-            # date.
-            for window in date_windows(vars_by_date.keys(), rule.time_window_days - 1):
+            # With explicit date_ranges the windows are exactly those inclusive
+            # ranges (each counted independently). Otherwise date_windows groups
+            # dates spanning up to its window arg in days, so pass
+            # time_window_days - 1: a window is then any run of time_window_days
+            # consecutive calendar days, and two dates exactly time_window_days
+            # apart (e.g. a week apart when time_window_days=7) fall in separate
+            # windows. time_window_days=1 gives one window per date.
+            windows: Iterable[Collection[date]]
+            if rule.date_ranges:
+                windows = [
+                    [d for d in vars_by_date if d in rng] for rng in rule.date_ranges
+                ]
+            else:
+                windows = date_windows(vars_by_date.keys(), rule.time_window_days - 1)
+            for window in windows:
                 cap = rule.max_for_window(window)
                 if cap is None:
                     continue
                 # A shared-budget cap that is >= the group size can never bind: the
                 # teams can't play more simultaneous matches than there are of them
                 # (this is how a stated venue capacity above a club's team count
-                # stays a no-op).
-                if not each_team and cap >= len(team_set):
+                # stays a no-op). A date range spans many days, in which one team
+                # can play more than once, so the shortcut only holds for the
+                # single-instant rolling-window form.
+                if not each_team and not rule.date_ranges and cap >= len(team_set):
                     continue
                 window_vars = [v for d in window for v in vars_by_date[d]]
                 if len(window_vars) > cap:
@@ -553,10 +635,11 @@ def _add_fixed_fixtures_constraints(
                 f"{scheduled.date.isoformat()} is not schedulable on that date "
                 "(check that the two teams are in the same division, that the date "
                 "is a home date for the home team's club, that it isn't an "
-                "unavailable away date for the away team's club, that the fixture "
-                "isn't also in excluded_fixtures, that the date isn't after either "
-                "club's latest_match_date, and -- if the two teams share a club -- "
-                "that the date isn't after latest_internal_match_date)"
+                "unavailable away date for the away team's club, that no "
+                "match_count_limits entry bars all play on that date, that the "
+                "fixture isn't also in excluded_fixtures, that the date isn't after "
+                "either club's latest_match_date, and -- if the two teams share a "
+                "club -- that the date isn't after latest_internal_match_date)"
             )
         model.add(var == 1)
 
@@ -570,42 +653,82 @@ def _build_model(params: Parameters) -> tuple[cp_model.CpModel, _FixtureVars]:
     excluded = set(params.excluded_fixtures)
     fixed_fixture_keys = {(sf.fixture, sf.date) for sf in params.fixed_fixtures}
 
-    for division in params.divisions:
-        for fixture in division.required_fixtures():
-            if fixture in excluded:
-                continue
-            home_team = fixture.home_team
-            away_team = fixture.away_team
-            is_internal = home_team.club == away_team.club
-            for match_date in params.home_dates_for(home_team):
-                if match_date in params.unavailable_away_dates_for(away_team):
-                    continue
-                if (
-                    is_internal
-                    and params.latest_internal_match_date is not None
-                    and match_date > params.latest_internal_match_date
-                ):
-                    continue
-                home_cutoff = params.latest_match_date_for(home_team)
-                away_cutoff = params.latest_match_date_for(away_team)
-                if home_cutoff is not None and match_date > home_cutoff:
-                    continue
-                if away_cutoff is not None and match_date > away_cutoff:
-                    continue
-                if (
-                    params.earliest_match_date is not None
-                    and match_date < params.earliest_match_date
-                    and (fixture, match_date) not in fixed_fixture_keys
-                ):
-                    continue
-                var = model.new_bool_var(
-                    f"{home_team.name}_vs_{away_team.name}_{match_date.isoformat()}"
-                )
-                fixture_vars.register(fixture, match_date, var)
+    required_fixtures = [
+        fixture
+        for division in params.divisions
+        for fixture in division.required_fixtures()
+        if fixture not in excluded
+    ]
 
-    for scheduled_vars in fixture_vars.per_fixture():
-        # Each fixture must be scheduled exactly once
+    for fixture in required_fixtures:
+        home_team = fixture.home_team
+        away_team = fixture.away_team
+        is_internal = home_team.club == away_team.club
+        for match_date in params.home_dates_for(home_team):
+            if match_date in params.unavailable_away_dates_for(away_team):
+                continue
+            if (
+                is_internal
+                and params.latest_internal_match_date is not None
+                and match_date > params.latest_internal_match_date
+            ):
+                continue
+            home_cutoff = params.latest_match_date_for(home_team)
+            away_cutoff = params.latest_match_date_for(away_team)
+            if home_cutoff is not None and match_date > home_cutoff:
+                continue
+            if away_cutoff is not None and match_date > away_cutoff:
+                continue
+            if (
+                params.earliest_match_date is not None
+                and match_date < params.earliest_match_date
+                and (fixture, match_date) not in fixed_fixture_keys
+            ):
+                continue
+            # A match_count_limits entry with an effective cap of 0 over this date
+            # (e.g. a spec-wide "nobody plays these dates" block) makes the
+            # candidate a certain zero -- don't create a variable for it. Unlike
+            # earliest_match_date this is not waived for fixed_fixtures: a fixture
+            # pinned onto a barred date is a real contradiction, and
+            # _add_fixed_fixtures_constraints reports it clearly.
+            if any(
+                limit.forbids(fixture, match_date)
+                for limit in params.match_count_limits
+            ):
+                continue
+            var = model.new_bool_var(
+                f"{home_team.name}_vs_{away_team.name}_{match_date.isoformat()}"
+            )
+            fixture_vars.register(fixture, match_date, var)
+
+    # Each required fixture must be scheduled exactly once. Drive this off the
+    # required_fixtures list, not the vars actually registered: a fixture whose
+    # every candidate date was filtered out above registers no vars, and iterating
+    # only what registered would silently skip its constraint -- letting the solve
+    # return a schedule quietly missing it. Zero candidates means the spec is
+    # infeasible; collect every such fixture and say so.
+    unschedulable: list[Fixture] = []
+    for fixture in required_fixtures:
+        scheduled_vars = fixture_vars.vars_for_fixture(fixture)
+        if not scheduled_vars:
+            unschedulable.append(fixture)
+            continue
         model.add(cp_model.LinearExpr.Sum(scheduled_vars) == 1)
+
+    if unschedulable:
+        shown = ", ".join(
+            f"{f.home_team.name} vs {f.away_team.name}" for f in unschedulable[:12]
+        )
+        if len(unschedulable) > 12:
+            shown += f", ... (+{len(unschedulable) - 12} more)"
+        raise ValueError(
+            f"{len(unschedulable)} required fixture(s) have no schedulable date: "
+            f"{shown}. For each, every home date of the home team's club is ruled "
+            "out for that fixture -- by the away team's unavailable away dates, a "
+            "latest_match_date / latest_internal_match_date / earliest_match_date "
+            "cutoff, or a match_count_limits entry barring all play on those dates. "
+            "Add a usable date, or exclude the fixture."
+        )
 
     _add_home_dates_used_constraints(model, params.home_dates_used, fixture_vars)
     _add_match_count_limit_constraints(model, params.match_count_limits, fixture_vars)

--- a/model_test.py
+++ b/model_test.py
@@ -258,8 +258,8 @@ class TestSolve(unittest.TestCase):
             )
 
     def test_simple_impossible_constraint(self) -> None:
-        """Test that impossible constraints result in no fixtures being scheduled."""
-        # Create a scenario that's impossible to solve
+        """A required fixture with no schedulable date makes solve() raise, rather
+        than silently returning a schedule that omits it."""
         team1 = fmodel.Team(division=1, club="Test Club A", index=1)
         team2 = fmodel.Team(division=1, club="Test Club B", index=1)
 
@@ -284,15 +284,8 @@ class TestSolve(unittest.TestCase):
             },
         )
 
-        # This should be impossible to schedule any fixtures due to conflicting constraints
-        result = list(fmodel.solve(params).fixtures)
-        # Since constraints make it impossible to schedule required fixtures,
-        # the solver returns an empty list (no feasible schedule)
-        self.assertEqual(
-            len(result),
-            0,
-            "Expected no fixtures to be scheduled due to impossible constraints",
-        )
+        with self.assertRaisesRegex(ValueError, "no schedulable date"):
+            fmodel.solve(params)
 
 
 class TestSolveStats(unittest.TestCase):
@@ -730,24 +723,13 @@ class TestLatestInternalMatchDate(unittest.TestCase):
         )
         self.assertGreater(cross_club.date, date(2025, 2, 15))
 
-    def test_cutoff_before_any_home_date_drops_the_internal_fixture(self) -> None:
-        """No A home date qualifies, so the internal fixture has zero candidate
-        variables: consistent with how a fixture that unavailable_away_dates makes
-        wholly unschedulable is silently omitted (see
-        TestSolve.test_simple_impossible_constraint) rather than erroring, it's simply
-        left out of the result -- other fixtures are unaffected.
-        """
-        a1 = fmodel.Team(division=1, club="A", index=1)
-        a2 = fmodel.Team(division=1, club="A", index=2)
+    def test_cutoff_before_any_home_date_makes_the_solve_infeasible(self) -> None:
+        """A cutoff before every A home date leaves the required A1 v A2 internal
+        fixture (both directions) with no schedulable date, so solve() raises
+        rather than returning a schedule quietly missing those matches."""
         params = self._params(latest_internal_match_date=date(2024, 12, 1))
-        fixtures = list(fmodel.solve(params).fixtures)
-        internal = [
-            sf
-            for sf in fixtures
-            if {sf.fixture.home_team, sf.fixture.away_team} == {a1, a2}
-        ]
-        self.assertEqual(internal, [])
-        self.assertTrue(fixtures)  # the other (non-internal) fixtures still solve
+        with self.assertRaisesRegex(ValueError, "no schedulable date"):
+            fmodel.solve(params)
 
     def test_fixed_internal_fixture_after_cutoff_rejected(self) -> None:
         a1 = fmodel.Team(division=1, club="A", index=1)
@@ -784,7 +766,9 @@ class TestClubLatestMatchDate(unittest.TestCase):
     for a cutoff to remove some and still solve.
     """
 
-    def _params(self, **kwargs: Any) -> fmodel.Parameters:
+    def _params(
+        self, *, b_home_dates: list[date] | None = None, **kwargs: Any
+    ) -> fmodel.Parameters:
         teams = [
             fmodel.Team(division=1, club="A", index=1),
             fmodel.Team(division=1, club="A", index=2),
@@ -799,7 +783,7 @@ class TestClubLatestMatchDate(unittest.TestCase):
                 date(2025, 3, 1),
                 date(2025, 3, 8),
             ],
-            "B": [date(2025, 5, 1), date(2025, 6, 1)],
+            "B": b_home_dates or [date(2025, 5, 1), date(2025, 6, 1)],
         }
         return _params(
             teams=teams,
@@ -810,28 +794,52 @@ class TestClubLatestMatchDate(unittest.TestCase):
             **kwargs,
         )
 
-    def test_cutoff_limits_the_clubs_home_dates(self) -> None:
-        """A cutoff on club A keeps every A-hosted fixture on or before it."""
-        params = self._params(club_latest_match_date={"A": date(2025, 2, 8)})
+    # B offers both early dates (playable within A's cutoff) and late ones, so the
+    # scenario stays feasible and the tests can check that A's cutoff pulls the
+    # B-hosted fixtures against A onto the early dates.
+    _B_EARLY_AND_LATE = [
+        date(2025, 1, 15),
+        date(2025, 1, 22),
+        date(2025, 5, 1),
+        date(2025, 6, 1),
+    ]
+
+    def test_cutoff_limits_every_fixture_the_club_is_in(self) -> None:
+        """A cutoff on club A keeps every fixture involving an A team -- hosted by
+        A or not -- on or before it."""
+        params = self._params(
+            b_home_dates=self._B_EARLY_AND_LATE,
+            club_latest_match_date={"A": date(2025, 2, 8)},
+        )
         fixtures = list(fmodel.solve(params).fixtures)
-        a_hosted = [sf for sf in fixtures if sf.fixture.home_team.club == "A"]
-        self.assertEqual(len(a_hosted), 4)
-        for sf in a_hosted:
+        a_involved = [
+            sf
+            for sf in fixtures
+            if "A" in (sf.fixture.home_team.club, sf.fixture.away_team.club)
+        ]
+        self.assertEqual(len(a_involved), 6)  # 4 A-hosted + B1 v A1 + B1 v A2
+        for sf in a_involved:
             self.assertLessEqual(sf.date, date(2025, 2, 8))
 
     def test_cutoff_also_blocks_the_club_playing_away(self) -> None:
-        """Club B's home dates are all after A's cutoff, so the B-hosted fixtures
-        against A teams (B1 v A1, B1 v A2) have no candidate date and are dropped;
-        the A-hosted fixtures still solve.
-        """
-        params = self._params(club_latest_match_date={"A": date(2025, 2, 8)})
-        fixtures = list(fmodel.solve(params).fixtures)
-        self.assertTrue(fixtures)
-        # B1 v A1 and B1 v A2 are the only B-hosted fixtures; both are dropped.
-        self.assertEqual(
-            [], [sf for sf in fixtures if sf.fixture.home_team.club == "B"]
+        """B1 v A1 and B1 v A2 are hosted by B, which offers May/June dates, but
+        A's cutoff still forces them onto B's early dates."""
+        params = self._params(
+            b_home_dates=self._B_EARLY_AND_LATE,
+            club_latest_match_date={"A": date(2025, 2, 8)},
         )
-        self.assertEqual([], [sf for sf in fixtures if sf.date > date(2025, 2, 8)])
+        fixtures = list(fmodel.solve(params).fixtures)
+        b_hosted = [sf for sf in fixtures if sf.fixture.home_team.club == "B"]
+        self.assertEqual(len(b_hosted), 2)
+        for sf in b_hosted:
+            self.assertLessEqual(sf.date, date(2025, 2, 8))
+
+    def test_cutoff_after_a_needed_away_date_makes_it_infeasible(self) -> None:
+        """With B hosting only after A's cutoff, B1 v A1 / B1 v A2 have no
+        schedulable date -- required fixtures, so solve() raises."""
+        params = self._params(club_latest_match_date={"A": date(2025, 2, 8)})
+        with self.assertRaisesRegex(ValueError, "no schedulable date"):
+            fmodel.solve(params)
 
     def test_other_clubs_unaffected(self) -> None:
         """A cutoff on A doesn't constrain a fixture between two non-A teams."""
@@ -844,8 +852,10 @@ class TestClubLatestMatchDate(unittest.TestCase):
             teams=teams,
             home_dates={
                 "A": [date(2025, 1, 1), date(2025, 1, 15)],
-                "B": [date(2025, 6, 1)],
-                "C": [date(2025, 6, 8)],
+                # Early dates keep A's away legs at B/C schedulable within its
+                # cutoff; the late dates carry the B-C fixtures.
+                "B": [date(2025, 1, 8), date(2025, 6, 1)],
+                "C": [date(2025, 1, 22), date(2025, 6, 8)],
             },
             unavailable_away_dates={"A": [], "B": [], "C": []},
             min_gap_days=7,
@@ -929,18 +939,17 @@ class TestEarliestMatchDate(unittest.TestCase):
         for sf in fixtures:
             self.assertGreaterEqual(sf.date, date(2025, 2, 1))
 
-    def test_cutoff_after_all_of_a_clubs_home_dates_drops_its_fixtures(self) -> None:
-        """A cutoff after all of club A's home dates (but before club B's) makes
-        every A-hosted fixture unschedulable -- each has zero candidate
-        variables, so (consistent with
-        TestLatestInternalMatchDate.test_cutoff_before_any_home_date_drops_the_internal_fixture)
-        it's silently left out of the result rather than erroring. B-hosted
-        fixtures are unaffected since none of B's dates are excluded.
-        """
+    def test_cutoff_after_all_of_a_clubs_home_dates_makes_the_solve_infeasible(
+        self,
+    ) -> None:
+        """A cutoff after all of club A's home dates makes every A-hosted fixture
+        unschedulable. Those fixtures are still required, so solve() raises rather
+        than returning a schedule that silently omits them -- an already-played
+        match belongs in fixed_fixtures (which bypass earliest_match_date), not
+        inferred from a truncated result."""
         params = self._params(earliest_match_date=date(2025, 4, 1))
-        fixtures = list(fmodel.solve(params).fixtures)
-        self.assertFalse([sf for sf in fixtures if sf.fixture.home_team.club == "A"])
-        self.assertTrue([sf for sf in fixtures if sf.fixture.home_team.club == "B"])
+        with self.assertRaisesRegex(ValueError, "no schedulable date"):
+            fmodel.solve(params)
 
     def test_fixed_fixture_before_cutoff_still_solves(self) -> None:
         """Unlike latest_internal_match_date, a fixed fixture dated before the cutoff
@@ -1166,12 +1175,16 @@ class TestTeamConstraints(unittest.TestCase):
 
     def test_team_unavailable_away_dates_is_additive(self) -> None:
         """A1's team-specific unavailable_away_dates blocks it from playing away on
-        B's home date, even though club A has no such club-wide restriction."""
+        one of B's home dates, even though club A has no such club-wide
+        restriction: B1 v A1 must then use B's other home date."""
         a1 = fmodel.Team(division=1, club="A", index=1)
         b1 = fmodel.Team(division=1, club="B", index=1)
         params = _params(
             teams=[a1, b1],
-            home_dates={"A": [date(2025, 1, 1)], "B": [date(2025, 2, 1)]},
+            home_dates={
+                "A": [date(2025, 1, 1)],
+                "B": [date(2025, 2, 1), date(2025, 2, 15)],
+            },
             unavailable_away_dates={"A": [], "B": []},
             max_concurrent_matches={
                 "A": _home_limit(1),
@@ -1181,21 +1194,13 @@ class TestTeamConstraints(unittest.TestCase):
             team_unavailable_away_dates={a1: [date(2025, 2, 1)]},
         )
         fixtures = list(fmodel.solve(params).fixtures)
-        # A1 v B1 (A1 away at B) can't be scheduled: B's only home date is blocked
-        # for A1 specifically, so that fixture is left unschedulable.
-        self.assertFalse(
-            any(
-                sf.fixture.home_team == b1 and sf.fixture.away_team == a1
-                for sf in fixtures
-            )
+        b_hosted = next(
+            sf
+            for sf in fixtures
+            if sf.fixture.home_team == b1 and sf.fixture.away_team == a1
         )
-        # B1 v A1 (A1 at home) is unaffected.
-        self.assertTrue(
-            any(
-                sf.fixture.home_team == a1 and sf.fixture.away_team == b1
-                for sf in fixtures
-            )
-        )
+        # Feb 1 is blocked for A1 specifically, so B1 v A1 falls on Feb 15.
+        self.assertEqual(b_hosted.date, date(2025, 2, 15))
 
     def test_team_without_override_falls_back_to_club(self) -> None:
         a1 = fmodel.Team(division=1, club="A", index=1)
@@ -1571,6 +1576,244 @@ class TestMatchCountLimits(unittest.TestCase):
             fmodel.solve(self._three_a_teams_in_one_window(limit=3)).fixtures
         )
         self.assertEqual(len(fixtures), 3)
+
+
+class TestMatchCountLimitDateRanges(unittest.TestCase):
+    """A MatchCountLimit with explicit `date_ranges` caps matches within each
+    listed inclusive range rather than within every rolling `time_window_days`
+    window; matches outside every range are unaffected.
+    """
+
+    def _three_a_teams(
+        self,
+        *,
+        a_home_dates: list[date],
+        date_ranges: tuple[fmodel.DateRange, ...],
+        limit: int,
+    ) -> fmodel.Parameters:
+        """A1/A2/A3 each have exactly one fixture (their home leg; the reverse
+        legs against X are excluded), and A can host only one match a night. A
+        `date_ranges` cap of `limit` then bounds how many of the three home legs
+        may land inside the listed range(s)."""
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        a2 = fmodel.Team(division=2, club="A", index=2)
+        a3 = fmodel.Team(division=3, club="A", index=3)
+        x1 = fmodel.Team(division=1, club="X", index=1)
+        x2 = fmodel.Team(division=2, club="X", index=2)
+        x3 = fmodel.Team(division=3, club="X", index=3)
+        return _params(
+            teams=[a1, a2, a3, x1, x2, x3],
+            home_dates={"A": a_home_dates, "X": []},
+            unavailable_away_dates={"A": [], "X": []},
+            min_gap_days=7,
+            max_concurrent_matches={"A": _home_limit(1)},
+            excluded_fixtures=[
+                fmodel.Fixture(home_team=x1, away_team=a1),
+                fmodel.Fixture(home_team=x2, away_team=a2),
+                fmodel.Fixture(home_team=x3, away_team=a3),
+            ],
+            match_count_limits=[
+                fmodel.MatchCountLimit(
+                    teams=[a1, a2, a3], max=limit, date_ranges=date_ranges
+                )
+            ],
+        )
+
+    def test_cap_binds_inside_the_range_only(self) -> None:
+        """The range covers January; A also has two February home dates. max=1
+        inside the range forces at least two of the three home legs into
+        February, leaving at most one in January."""
+        params = self._three_a_teams(
+            a_home_dates=[
+                date(2025, 1, 7),
+                date(2025, 1, 14),
+                date(2025, 2, 4),
+                date(2025, 2, 11),
+            ],
+            date_ranges=(fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31)),),
+            limit=1,
+        )
+        fixtures = list(fmodel.solve(params).fixtures)
+        self.assertEqual(len(fixtures), 3)
+        in_january = [sf for sf in fixtures if sf.date.month == 1]
+        self.assertLessEqual(len(in_january), 1)
+
+    def test_infeasible_when_range_cap_leaves_nowhere(self) -> None:
+        """Three in-range home dates plus one outside; with a one-a-night venue
+        and max=1 inside the range, only two of the three required home legs can
+        be placed -> infeasible."""
+        params = self._three_a_teams(
+            a_home_dates=[
+                date(2025, 1, 7),
+                date(2025, 1, 14),
+                date(2025, 1, 21),
+                date(2025, 2, 4),
+            ],
+            date_ranges=(fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31)),),
+            limit=1,
+        )
+        with self.assertRaises(ValueError):
+            fmodel.solve(params)
+
+    def test_second_range_is_enforced_independently(self) -> None:
+        """Two ranges, each capped at 1: A's home dates are two in January and
+        two in March, so at most one leg per range -> the third leg has nowhere
+        to go and the solve is infeasible."""
+        params = self._three_a_teams(
+            a_home_dates=[
+                date(2025, 1, 7),
+                date(2025, 1, 14),
+                date(2025, 3, 4),
+                date(2025, 3, 11),
+            ],
+            date_ranges=(
+                fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31)),
+                fmodel.DateRange(date(2025, 3, 1), date(2025, 3, 31)),
+            ),
+            limit=1,
+        )
+        with self.assertRaises(ValueError):
+            fmodel.solve(params)
+
+    def test_max_zero_forces_matches_out_of_the_range(self) -> None:
+        """max=0 bars every counted match inside the range: A1's one home leg,
+        with an in-range and an out-of-range home date available, is forced onto
+        the out-of-range one."""
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        x1 = fmodel.Team(division=1, club="X", index=1)
+        params = _params(
+            teams=[a1, x1],
+            home_dates={"A": [date(2025, 1, 7), date(2025, 2, 4)], "X": []},
+            unavailable_away_dates={"A": [], "X": []},
+            min_gap_days=7,
+            excluded_fixtures=[fmodel.Fixture(home_team=x1, away_team=a1)],
+            match_count_limits=[
+                fmodel.MatchCountLimit(
+                    teams=[a1],
+                    max=0,
+                    date_ranges=(
+                        fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31)),
+                    ),
+                )
+            ],
+        )
+        fixtures = list(fmodel.solve(params).fixtures)
+        self.assertEqual([sf.date for sf in fixtures], [date(2025, 2, 4)])
+
+    def test_single_team_set_range_cap_still_binds(self) -> None:
+        """The 'a shared cap >= group size can't bind' shortcut must not fire for
+        a date-range rule: one team can play more than once inside a multi-day
+        range. A1 has two required home legs, both home dates inside the range
+        and none outside it, so a cap of 1 makes the solve infeasible."""
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        x1 = fmodel.Team(division=1, club="X", index=1)
+        y1 = fmodel.Team(division=1, club="Y", index=1)
+        params = _params(
+            teams=[a1, x1, y1],
+            home_dates={"A": [date(2025, 1, 7), date(2025, 1, 14)], "X": [], "Y": []},
+            unavailable_away_dates={"A": [], "X": [], "Y": []},
+            min_gap_days=7,
+            excluded_fixtures=[
+                fmodel.Fixture(home_team=x1, away_team=a1),
+                fmodel.Fixture(home_team=y1, away_team=a1),
+                fmodel.Fixture(home_team=x1, away_team=y1),
+                fmodel.Fixture(home_team=y1, away_team=x1),
+            ],
+            match_count_limits=[
+                fmodel.MatchCountLimit(
+                    teams=[a1],
+                    max=1,
+                    date_ranges=(
+                        fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31)),
+                    ),
+                )
+            ],
+        )
+        with self.assertRaises(ValueError):
+            fmodel.solve(params)
+
+    def test_rejects_non_default_time_window_days(self) -> None:
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        with self.assertRaises(ValueError):
+            fmodel.MatchCountLimit(
+                teams=[a1],
+                max=1,
+                time_window_days=7,
+                date_ranges=(fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31)),),
+            )
+
+    def test_rejects_date_max_overrides(self) -> None:
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        with self.assertRaises(ValueError):
+            fmodel.MatchCountLimit(
+                teams=[a1],
+                max=1,
+                date_max_overrides={date(2025, 1, 1): 1},
+                date_ranges=(fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31)),),
+            )
+
+    def test_date_range_rejects_start_after_end(self) -> None:
+        with self.assertRaises(ValueError):
+            fmodel.DateRange(date(2025, 2, 1), date(2025, 1, 1))
+
+    def test_date_range_contains_is_inclusive(self) -> None:
+        rng = fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31))
+        self.assertIn(date(2025, 1, 1), rng)
+        self.assertIn(date(2025, 1, 31), rng)
+        self.assertNotIn(date(2025, 2, 1), rng)
+
+    def test_max_zero_prunes_candidate_var(self) -> None:
+        """A max: 0 limit makes its candidates a certain zero, so _build_model
+        never creates a decision variable for them -- observable because a
+        fixed_fixtures entry pinned onto such a date then fails with the
+        descriptive 'not schedulable on that date' error (the fixture is still
+        placeable on its other, unbarred home date, so this is the fixed-fixture
+        lookup failing, not the whole fixture being unschedulable)."""
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        x1 = fmodel.Team(division=1, club="X", index=1)
+        params = _params(
+            teams=[a1, x1],
+            home_dates={
+                "A": [date(2025, 12, 29), date(2026, 1, 19)],
+                "X": [date(2026, 1, 12)],
+            },
+            unavailable_away_dates={"A": [], "X": []},
+            min_gap_days=7,
+            fixed_fixtures=[
+                fmodel.ScheduledFixture(
+                    fmodel.Fixture(home_team=a1, away_team=x1), date(2025, 12, 29)
+                )
+            ],
+            match_count_limits=[
+                fmodel.MatchCountLimit(
+                    teams=[a1, x1],
+                    max=0,
+                    date_ranges=(
+                        fmodel.DateRange(date(2025, 12, 22), date(2026, 1, 4)),
+                    ),
+                )
+            ],
+        )
+        with self.assertRaisesRegex(ValueError, "not schedulable on that date"):
+            fmodel.solve(params)
+
+    def test_forbids_respects_venue_scope_and_range(self) -> None:
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        x1 = fmodel.Team(division=1, club="X", index=1)
+        home_fix = fmodel.Fixture(home_team=a1, away_team=x1)
+        away_fix = fmodel.Fixture(home_team=x1, away_team=a1)
+        rng = fmodel.DateRange(date(2025, 12, 22), date(2026, 1, 4))
+        away_only = fmodel.MatchCountLimit(
+            teams=[a1], max=0, venue_scope=fmodel.VenueScope.AWAY, date_ranges=(rng,)
+        )
+        # AWAY scope: bars a1's away fixture in the range, not its home one.
+        self.assertTrue(away_only.forbids(away_fix, date(2025, 12, 29)))
+        self.assertFalse(away_only.forbids(home_fix, date(2025, 12, 29)))
+        # Outside the range: not forbidden.
+        self.assertFalse(away_only.forbids(away_fix, date(2026, 1, 5)))
+        # max > 0: never an up-front bar.
+        keep = fmodel.MatchCountLimit(teams=[a1], max=1, date_ranges=(rng,))
+        self.assertFalse(keep.forbids(away_fix, date(2025, 12, 29)))
 
 
 class TestPerClubGap(unittest.TestCase):

--- a/spec-schema.json
+++ b/spec-schema.json
@@ -26,13 +26,6 @@
       "$ref": "#/$defs/date",
       "description": "Latest date allowed for a fixture between two teams of the same club (e.g. Hendon 1 v Hendon 2) -- useful for requiring 'derby' matches to be settled earlier in the season than the rest of the fixture list. Has no effect on fixtures between teams from different clubs. If omitted, no such cutoff is applied. Any 'fixed_fixtures' entry between two teams of the same club must not be dated after it."
     },
-    "avoid_dates": {
-      "type": "array",
-      "items": { "$ref": "#/$defs/date" },
-      "uniqueItems": true,
-      "default": [],
-      "description": "Dates blocked for every club (added to every club's club_constraints.<club>.unavailable_away_dates), so no fixture -- home or away, for any club -- can be scheduled on any of them. Useful for Christmas/New Year or other dates that would otherwise need repeating in every affected club's unavailable_away_dates. A club can still list one of these dates in its own home_dates (e.g. by oversight); it just won't ever be used, since every possible away team is unavailable that day."
-    },
     "clubs": {
       "type": "object",
       "description": "Every club in the season, keyed by club ID (a stable key referenced from teams, club_constraints, fixed_fixtures and exclude_fixtures).",
@@ -194,7 +187,7 @@
         "unavailable_away_dates": {
           "type": "array",
           "default": [],
-          "description": "Dates this club's teams are unavailable to play away. Defaults to empty if omitted. Combined with the spec-wide 'avoid_dates', not replaced by it.",
+          "description": "Dates this club's teams are unavailable to play away. Defaults to empty if omitted. For a contiguous span, or a block that applies to every club, a match_count_limits entry with 'max: 0' and 'date_ranges' is usually tidier.",
           "items": { "$ref": "#/$defs/date" },
           "uniqueItems": true
         },
@@ -227,7 +220,7 @@
         },
         "match_count_limits": {
           "type": "array",
-          "description": "The sole match-count constraint mechanism: each entry caps how many matches involving a set of this club's teams may fall within a rolling window of consecutive days. Covers a per-team weekly gap ('apply_per: each_team', 'max: 1', 'time_window_days: 7'), a venue's concurrent-match capacity ('apply_per: across_teams', 'venue_scope: home'), and keeping adjacent-division teams apart ('teams: [...]', 'max: 1'). Additive, with as many entries as needed; combined with any inherited from club_constraints.defaults -- an entry with an 'override_key' replaces the like-keyed default for this club instead.",
+          "description": "The sole match-count constraint mechanism: each entry caps how many matches involving a set of this club's teams may fall within a rolling window of consecutive days -- or, when the entry sets 'date_ranges', within each of a few explicit calendar ranges. Covers a per-team weekly gap ('apply_per: each_team', 'max: 1', 'time_window_days: 7'), a venue's concurrent-match capacity ('apply_per: across_teams', 'venue_scope: home'), keeping adjacent-division teams apart ('teams: [...]', 'max: 1'), and holding a club's load down over a named holiday week ('date_ranges: [...]', 'max: 1', or 'max: 0' to bar it entirely). Additive, with as many entries as needed; combined with any inherited from club_constraints.defaults -- an entry with an 'override_key' replaces the like-keyed default for this club instead.",
           "items": { "$ref": "#/$defs/match_count_limit_entry" }
         }
       }
@@ -252,8 +245,8 @@
     },
     "match_count_limit_fields": {
       "max": {
-        "oneOf": [{ "type": "integer", "minimum": 1 }, { "type": "null" }],
-        "description": "The most matches (of the kind selected by 'venue_scope') allowed within any window of 'time_window_days' consecutive days. The key is required, so an entry is never accidentally a no-op. null means no plain cap -- only useful with 'date_max_overrides', or (on a club entry with an 'override_key') to cancel a default. 'max: 1' forbids a second match in a window; a higher value caps density."
+        "oneOf": [{ "type": "integer", "minimum": 0 }, { "type": "null" }],
+        "description": "The most matches (of the kind selected by 'venue_scope') allowed within any window of 'time_window_days' consecutive days (or, with 'date_ranges', within each listed range). The key is required, so an entry is never accidentally a no-op. null means no plain cap -- only useful with 'date_max_overrides', or (on a club entry with an 'override_key') to cancel a default. 'max: 1' forbids a second match in a window; a higher value caps density. 'max: 0' is only meaningful together with 'date_ranges' (a full blackout of those ranges); in the rolling-window form use 'max: 1' or higher."
       },
       "apply_per": {
         "type": "string",
@@ -278,6 +271,26 @@
         "description": "Per-date replacements of 'max', keyed by date; each value an integer >= 1, or null to lift the cap that day. Only allowed when 'time_window_days' is 1 (so each window is a single date).",
         "additionalProperties": {
           "oneOf": [{ "type": "integer", "minimum": 1 }, { "type": "null" }]
+        }
+      },
+      "date_ranges": {
+        "type": "array",
+        "minItems": 1,
+        "description": "Restricts this rule to one or more explicit, inclusive calendar ranges instead of every rolling 'time_window_days' window: the cap ('max') then applies to the counted matches whose date falls within each listed range, each range enforced independently. Use for a limit tied to specific weeks -- a school-holiday week, a congress fortnight -- that a rolling window cannot target. Allowed on club and 'defaults' entries alike; not combinable with 'time_window_days' or 'date_max_overrides', nor (on a club entry) with 'override_key'. With 'date_ranges' set, 'max' must be an integer >= 0 ('max: 0' bars every counted match in the range; a whole-club 'defaults' entry with 'max: 0' is the spec-wide 'nobody plays these dates' block).",
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["start_date", "end_date"],
+          "properties": {
+            "start_date": {
+              "$ref": "#/$defs/date",
+              "description": "First day of the range (inclusive)."
+            },
+            "end_date": {
+              "$ref": "#/$defs/date",
+              "description": "Last day of the range (inclusive); must be on or after 'start_date'."
+            }
+          }
         }
       },
       "override_key": {
@@ -307,6 +320,9 @@
         "date_max_overrides": {
           "$ref": "#/$defs/match_count_limit_fields/date_max_overrides"
         },
+        "date_ranges": {
+          "$ref": "#/$defs/match_count_limit_fields/date_ranges"
+        },
         "override_key": {
           "$ref": "#/$defs/match_count_limit_fields/override_key"
         }
@@ -316,7 +332,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["max", "override_key"],
-      "description": "A club_constraints.defaults.match_count_limits entry: like a per-club match_count_limits entry but without 'teams' (defaults apply to every team of every club) and with a required, list-unique 'override_key'.",
+      "description": "A club_constraints.defaults.match_count_limits entry: like a per-club match_count_limits entry but without 'teams' (defaults apply to every team of every club) and with a required, list-unique 'override_key'. A club's own entry naming that 'override_key' replaces this one for the club wholesale. A 'max: 0' entry with 'date_ranges' is the spec-wide way to say no club plays on those dates (a club can opt back in by overriding the key).",
       "properties": {
         "max": { "$ref": "#/$defs/match_count_limit_fields/max" },
         "apply_per": { "$ref": "#/$defs/match_count_limit_fields/apply_per" },
@@ -326,6 +342,9 @@
         "venue_scope": { "$ref": "#/$defs/match_count_limit_fields/venue_scope" },
         "date_max_overrides": {
           "$ref": "#/$defs/match_count_limit_fields/date_max_overrides"
+        },
+        "date_ranges": {
+          "$ref": "#/$defs/match_count_limit_fields/date_ranges"
         },
         "override_key": {
           "$ref": "#/$defs/match_count_limit_fields/override_key"

--- a/spec_schema_test.py
+++ b/spec_schema_test.py
@@ -40,7 +40,6 @@ name: "2025-26 Season"
 draft: false
 description: "Final schedule; refer to ECF LMS for authoritative dates."
 latest_internal_match_date: 2025-12-31
-avoid_dates: [2025-12-25, 2026-01-01]
 
 clubs:
   albany:
@@ -86,6 +85,11 @@ club_constraints:
       - override_key: venue-capacity
         venue_scope: home
         max: 2
+      - override_key: no-play-dates
+        max: 0
+        date_ranges:
+          - start_date: 2025-12-22
+            end_date: 2026-01-04
 
   albany:
     home_dates: [2025-09-01, 2025-09-15, 2025-09-29]
@@ -116,6 +120,13 @@ club_constraints:
         time_window_days: 7
         max: 1
         venue_scope: away
+      - teams: [hackney-1, hackney-5]
+        max: 1
+        date_ranges:
+          - start_date: 2025-10-20
+            end_date: 2025-10-26
+          - start_date: 2026-02-16
+            end_date: 2026-02-22
     home_dates_used:
       min: 1
       max: 2


### PR DESCRIPTION
…edulable fixtures

Three related changes to the match_count_limits mechanism and the model.

date_ranges
  A match_count_limits entry may now set `date_ranges` -- a non-empty list
  of inclusive {start_date, end_date} calendar ranges (a new frozen
  `fmodel.DateRange` value type) -- instead of a rolling `time_window_days`
  window. The cap then applies within each listed range independently,
  targeting a limit tied to specific weeks (a school-holiday week, a
  congress fortnight) that a rolling window can't express. `max` may then
  be 0 to bar every counted match in the range. Allowed on club and
  club_constraints.defaults entries alike; not combinable with
  time_window_days or date_max_overrides, nor (on a club entry) with
  override_key.

avoid_dates removed
  The top-level `avoid_dates` list is gone; a whole-club `max: 0`
  `date_ranges` entry under club_constraints.defaults expresses the same
  spec-wide "nobody plays these dates" block, and a club can opt back in
  by overriding the key. `_build_model` skips creating a decision variable
  for any (fixture, date) a `max: 0` limit forbids, so the model stays the
  same size a `avoid_dates`-style availability exclusion produced.

Unschedulable required fixtures now raise
  Previously a required, non-excluded fixture whose every candidate date
  was filtered out (by unavailable_away_dates, a latest/latest_internal/
  earliest_match_date cutoff, or now a max: 0 limit) registered no
  variables, so its "scheduled exactly once" constraint was silently
  skipped and solve() returned a schedule quietly missing it. _build_model
  now drives that constraint off the explicit required-fixtures list and
  raises ValueError naming every fixture with no schedulable date. Tests
  that documented the old silent-drop behaviour are updated: the ones
  whose scenario is genuinely infeasible now assert the raise; the rest
  are given an alternative valid date and assert the fixture avoids the
  excluded one.


Claude-Session: https://claude.ai/code/session_01TkTh98ddcWRvYz95Sgu3HA