### PR TITLE
Show total match count under each HTML report table

### DIFF
--- a/htmlreport.py
+++ b/htmlreport.py
@@ -57,7 +57,8 @@ _STYLE = """
     nav li { margin-bottom: 0.3rem; }
     nav ul ul { padding-left: 1.2rem; margin-top: 0.3rem; }
     .venue { margin-top: -0.5rem; margin-bottom: 1.5rem; color: #333; }
-    .date-summary { margin-top: -1.5rem; margin-bottom: 2rem; color: #333; }
+    .date-summary, .match-count { margin-top: -1.5rem; margin-bottom: 2rem;
+                                  color: #333; }
     .export-link { margin-top: -1rem; margin-bottom: 2rem; }
     ul.venues { padding-left: 1.2rem; }
     ul.venues li { margin-bottom: 0.3rem; }
@@ -157,8 +158,12 @@ def _table(headers: list[str], rows: list[list[str]]) -> str:
             "<tr>" + "".join(_table_cell(cell) for cell in row) + "</tr>\n"
             for row in rows
         )
+        count_html = (
+            f'<p class="match-count">Total matches: <strong>{len(rows)}</strong></p>\n'
+        )
     else:
         body_html = f'<tr><td colspan="{len(headers)}"><em>No matches</em></td></tr>\n'
+        count_html = ""
     return (
         '<div class="table-scroll">\n'
         "<table>\n"
@@ -166,6 +171,7 @@ def _table(headers: list[str], rows: list[list[str]]) -> str:
         f"<tbody>\n{body_html}</tbody>\n"
         "</table>\n"
         "</div>\n"
+        f"{count_html}"
     )
 
 

--- a/htmlreport_test.py
+++ b/htmlreport_test.py
@@ -152,6 +152,36 @@ class TestGenerateReport(unittest.TestCase):
         # 4 fixtures -> 4 data rows (plus header row)
         self.assertEqual(content.count("<tr>"), 5)
 
+    def test_all_matches_page_shows_total_match_count(self) -> None:
+        content = (self.output_dir / "all-matches.html").read_text()
+        table_part = content.split("<h2>Venues</h2>")[0]
+        self.assertIn(
+            '<p class="match-count">Total matches: <strong>4</strong></p>', table_part
+        )
+
+    def test_division_page_shows_total_match_count(self) -> None:
+        # Division 1 has the 3 Harrow/Ealing fixtures.
+        content = (self.output_dir / "division-1.html").read_text()
+        self.assertIn(
+            '<p class="match-count">Total matches: <strong>3</strong></p>', content
+        )
+
+    def test_club_consolidated_table_shows_total_match_count(self) -> None:
+        harrow_page = (self.output_dir / "club-harrow.html").read_text()
+        consolidated = harrow_page.split("<h2")[0]
+        self.assertIn(
+            '<p class="match-count">Total matches: <strong>3</strong></p>', consolidated
+        )
+
+    def test_empty_table_has_no_match_count_line(self) -> None:
+        lonely_clubs = {"lonely-fc": _club("Lonely FC")}
+        lonely = fmodel.Team(division=3, club="lonely-fc", index=1)
+        out2 = Path(self._tmpdir.name) / "out-empty"
+        _generate(fmodel.SolveResult([]), [lonely], lonely_clubs, out2)
+        content = (out2 / "club-lonely-fc.html").read_text()
+        self.assertIn("No matches", content)
+        self.assertNotIn('<p class="match-count">', content)
+
     def test_match_annotated_with_venue_start_and_time_limit(self) -> None:
         content = (self.output_dir / "all-matches.html").read_text()
         self.assertIn("<th>Venue</th>", content)


### PR DESCRIPTION
Every match table rendered by _table() now gets a "Total matches: N" line directly beneath it (omitted for empty tables, where the existing "No matches" placeholder already conveys it). This covers the All matches page, each division page, and both the consolidated and per-team tables on club pages.


Claude-Session: https://claude.ai/code/session_01BaywyGYzx2WBSFCFCTnzpX