### PR TITLE
Sort the runs index tree alphabetically at each level

### DIFF
--- a/htmlreport.py
+++ b/htmlreport.py
@@ -649,12 +649,12 @@ def _build_run_tree(run_paths: Collection[Path]) -> _RunTreeNode:
 def _render_run_tree(
     node: _RunTreeNode, path_parts: tuple[str, ...], rel_runs_dir: Path
 ) -> str:
-    """Render node's children as a nested <ul>, most recent (reverse alphabetical)
-    first at each level; a name with no report of its own (just a grouping folder
-    for further runs, e.g. a season with several draft sub-folders) is rendered as
-    a plain label rather than a link."""
+    """Render node's children as a nested <ul>, sorted alphabetically by name at
+    each level; a name with no report of its own (just a grouping folder for
+    further runs, e.g. a season with several draft sub-folders) is rendered as a
+    plain label rather than a link."""
     items = []
-    for name in sorted(node.children, reverse=True):
+    for name in sorted(node.children):
         child = node.children[name]
         child_parts = (*path_parts, name)
         label = html.escape(name)

--- a/htmlreport_test.py
+++ b/htmlreport_test.py
@@ -719,9 +719,9 @@ class TestWriteRunsIndex(unittest.TestCase):
         self.assertIn("runs/2025-26-season/index.html", content)
         self.assertNotIn("incomplete-run", content)
 
-        # Most recent (reverse alphabetical) first
+        # Sorted alphabetically by name at each level
         self.assertLess(
-            content.index("2025-26-season"), content.index("2024-25-season")
+            content.index("2024-25-season"), content.index("2025-26-season")
         )
 
     def test_nested_run(self) -> None:
@@ -752,6 +752,18 @@ class TestWriteRunsIndex(unittest.TestCase):
 
         self.assertIn("runs/example/index.html", content)
         self.assertIn("runs/2026-27/draft1/index.html", content)
+
+    def test_siblings_sorted_alphabetically(self) -> None:
+        for name in ["draft2", "draft1", "draft10"]:
+            run_dir = self.runs_dir / "2026-27" / name
+            run_dir.mkdir(parents=True)
+            (run_dir / "all-matches.html").write_text("<html></html>")
+
+        htmlreport.write_runs_index(self.runs_dir, self.index_path)
+        content = self.index_path.read_text()
+
+        self.assertLess(content.index("draft1<"), content.index("draft10<"))
+        self.assertLess(content.index("draft10<"), content.index("draft2<"))
 
 
 class TestFindRunDirs(unittest.TestCase):


### PR DESCRIPTION
The top-level index rendered each level of the runs/ folder tree in reverse-alphabetical order, so e.g. draft2 appeared before draft1. Sort each level in ascending alphabetical order instead.


Claude-Session: https://claude.ai/code/session_01JKjXTPSZASfgz3qpPE3fGD