### PR TITLE
Move earliest_match_date from a solve.py flag into the spec YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,7 @@ details that aren't part of the solution itself. Keeping these as two separate
 steps (rather than one combined command) means the report can be regenerated
 -- e.g. after a formatting change -- without re-running the (comparatively
 slow) solver: just rerun the report build against the existing
-`solution.yaml`. It also keeps solve-only flags (e.g. `--earliest-match-date`,
-which excludes newly scheduled fixtures before a given date, defaulting to
-today) on `solve.py` alone, rather than needing to be added to a combined
-command too.
+`solution.yaml`.
 
 ### Spec format
 

--- a/build_site_test.py
+++ b/build_site_test.py
@@ -25,6 +25,7 @@ import solve
 
 _SPEC = """
 name: "{name}"
+earliest_match_date: 2025-01-01
 
 clubs:
   albany:

--- a/fixturespec.py
+++ b/fixturespec.py
@@ -381,6 +381,7 @@ _TOP_LEVEL_KEYS = {
     "draft",
     "description",
     "latest_internal_match_date",
+    "earliest_match_date",
     "clubs",
     "teams",
     "divisions",
@@ -1283,6 +1284,20 @@ def load_spec(spec_path: str | Path) -> Spec:
                     "latest_internal_match_date"
                 )
         kwargs["latest_internal_match_date"] = latest_internal_match_date
+
+    if "earliest_match_date" in data:
+        earliest_match_date = _parse_date(
+            data["earliest_match_date"], f"{path}: 'earliest_match_date'"
+        )
+    else:
+        earliest_match_date = date.today()
+    if earliest_match_date < date.today():
+        logger.warning(
+            "%s: earliest_match_date %s is in the past",
+            path,
+            earliest_match_date.isoformat(),
+        )
+    kwargs["earliest_match_date"] = earliest_match_date
 
     for sf in fixed_fixtures:
         for team in (sf.fixture.home_team, sf.fixture.away_team):

--- a/fixturespec_test.py
+++ b/fixturespec_test.py
@@ -49,7 +49,15 @@ def _find_limit(
 # supply their own version of that section (concatenating a second copy on top of an
 # existing one would create a duplicate top-level YAML key, which PyYAML resolves by
 # silently letting the later one clobber the earlier one).
+#
+# Pins earliest_match_date well before every home_dates entry below, so tests that
+# solve() end-to-end aren't affected by the default (today) cutoff excluding these
+# fixed 2025 dates as time passes; tests of earliest_match_date itself override or
+# strip this line instead of appending a second one (a duplicate top-level key, as
+# above).
 _BOILERPLATE = """
+earliest_match_date: 2025-01-01
+
 clubs:
   albany:
     name: Albany
@@ -101,7 +109,10 @@ _MINIMAL_SPEC = (
 
 # A three-team spec (two Albany teams plus Hackney) for exclude_fixtures tests, which
 # need a division where excluding one team/club still leaves other fixtures behind.
+# See _BOILERPLATE above for why earliest_match_date is pinned here too.
 _THREE_TEAM_SPEC = """
+earliest_match_date: 2025-01-01
+
 clubs:
   albany:
     name: Albany
@@ -281,6 +292,52 @@ class TestLoadSpec(unittest.TestCase):
     def test_latest_internal_match_date_invalid(self) -> None:
         path = self._write(_MINIMAL_SPEC + "latest_internal_match_date: not-a-date\n")
         with self.assertRaisesRegex(fixturespec.SpecError, "not-a-date"):
+            fixturespec.load_spec(path)
+
+    def test_earliest_match_date_defaults_to_today(self) -> None:
+        path = self._write(
+            _MINIMAL_SPEC.replace("earliest_match_date: 2025-01-01\n", "")
+        )
+        spec = fixturespec.load_spec(path)
+        self.assertEqual(spec.parameters.earliest_match_date, date.today())
+
+    def test_earliest_match_date_parsed(self) -> None:
+        path = self._write(
+            _MINIMAL_SPEC.replace(
+                "earliest_match_date: 2025-01-01", "earliest_match_date: 2030-01-01"
+            )
+        )
+        spec = fixturespec.load_spec(path)
+        self.assertEqual(spec.parameters.earliest_match_date, date(2030, 1, 1))
+
+    def test_earliest_match_date_invalid(self) -> None:
+        path = self._write(
+            _MINIMAL_SPEC.replace(
+                "earliest_match_date: 2025-01-01", "earliest_match_date: not-a-date"
+            )
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "not-a-date"):
+            fixturespec.load_spec(path)
+
+    def test_earliest_match_date_in_the_past_logs_a_warning(self) -> None:
+        path = self._write(
+            _MINIMAL_SPEC.replace(
+                "earliest_match_date: 2025-01-01", "earliest_match_date: 2020-01-01"
+            )
+        )
+        with self.assertLogs(fixturespec.logger, level="WARNING") as cm:
+            fixturespec.load_spec(path)
+        self.assertIn("2020-01-01", cm.output[0])
+        self.assertIn("in the past", cm.output[0])
+
+    def test_earliest_match_date_today_does_not_log_a_warning(self) -> None:
+        path = self._write(
+            _MINIMAL_SPEC.replace(
+                "earliest_match_date: 2025-01-01",
+                f"earliest_match_date: {date.today().isoformat()}",
+            )
+        )
+        with self.assertNoLogs(fixturespec.logger, level="WARNING"):
             fixturespec.load_spec(path)
 
     def test_avoid_dates_key_no_longer_recognised(self) -> None:
@@ -1513,6 +1570,32 @@ club_constraints:
                 )
             ],
         )
+
+    def test_fixed_fixture_before_earliest_match_date_still_solves(self) -> None:
+        """A fixed_fixtures entry dated before earliest_match_date is not rejected,
+        and the solver still places it there -- the cutoff only excludes candidate
+        dates for newly scheduled fixtures, not fixtures already pinned down. Albany's
+        other home date (2025-09-29) is on/after the cutoff, so its own (unfixed)
+        fixture against Hackney still has somewhere to land."""
+        path = self._write(
+            _MINIMAL_SPEC.replace(
+                "earliest_match_date: 2025-01-01", "earliest_match_date: 2025-09-20"
+            )
+            + "fixed_fixtures:\n"
+            "  - home: hackney-1\n"
+            "    away: albany-1\n"
+            "    date: 2025-09-15\n"
+        )
+        spec = fixturespec.load_spec(path)
+        self.assertEqual(spec.parameters.earliest_match_date, date(2025, 9, 20))
+        hackney_1 = next(t for t in spec.parameters.teams if t.club == "hackney")
+        albany_1 = next(t for t in spec.parameters.teams if t.club == "albany")
+        fixed = fmodel.ScheduledFixture(
+            fixture=fmodel.Fixture(home_team=hackney_1, away_team=albany_1),
+            date=date(2025, 9, 15),
+        )
+        fixtures = list(fmodel.solve(spec.parameters).fixtures)
+        self.assertIn(fixed, fixtures)
 
     def test_fixed_fixtures_absent(self) -> None:
         path = self._write(_MINIMAL_SPEC)

--- a/report_test.py
+++ b/report_test.py
@@ -23,6 +23,7 @@ import solve
 
 _SPEC = """
 name: "Test Season"
+earliest_match_date: 2025-01-01
 
 clubs:
   albany:

--- a/solve.py
+++ b/solve.py
@@ -29,37 +29,21 @@ needing to re-solve -- any time the report format changes.
 from __future__ import annotations
 
 import argparse
-import dataclasses
 import logging
-from datetime import date
 from pathlib import Path
 
 import fixturesolution
 import fixturespec
 import fmodel
 
-logger = logging.getLogger(__name__)
 
-
-def solve(
-    spec_path: Path, output_dir: Path, earliest_match_date: date | None = None
-) -> Path:
+def solve(spec_path: Path, output_dir: Path) -> Path:
     """Solve the given spec and write its solution.yaml into output_dir. Returns the
     path to the solution file.
-
-    earliest_match_date, if given, overrides the spec's (always-None)
-    Parameters.earliest_match_date -- see fmodel.Parameters for what it does. It's a
-    solve-time argument rather than a spec field since its usual value (today) is
-    tied to when the solver is run, not to the season being modelled.
     """
     spec = fixturespec.load_spec(spec_path)
     team_ids = fixturespec.load_team_ids(spec_path)
     parameters = spec.parameters
-    if earliest_match_date is not None:
-        logger.info("Excluding new fixtures dated before %s", earliest_match_date)
-        parameters = dataclasses.replace(
-            parameters, earliest_match_date=earliest_match_date
-        )
     result = fmodel.solve(parameters)
     output_dir.mkdir(parents=True, exist_ok=True)
     solution_path = output_dir / "solution.yaml"
@@ -78,25 +62,12 @@ def main() -> None:
         nargs="?",
         help="Directory to write solution.yaml into (default: the spec file's own directory)",
     )
-    parser.add_argument(
-        "--earliest-match-date",
-        type=date.fromisoformat,
-        default=None,
-        metavar="YYYY-MM-DD",
-        help="Don't schedule any new fixture before this date (default: today, so "
-        "re-running the solver doesn't place a fixture in the past). Pass a date on "
-        "or before the spec's earliest home date to disable this cutoff, e.g. for an "
-        "old spec being re-solved for reference.",
-    )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
 
     output_dir = args.output_dir if args.output_dir is not None else args.spec.parent
-    earliest_match_date = args.earliest_match_date or date.today()
-    solution_path = solve(
-        args.spec, output_dir, earliest_match_date=earliest_match_date
-    )
+    solution_path = solve(args.spec, output_dir)
 
     print(f"Wrote solution to {solution_path}")
 

--- a/solve_test.py
+++ b/solve_test.py
@@ -25,6 +25,8 @@ import fmodel
 import solve
 
 _MINIMAL_SPEC = """
+earliest_match_date: 2025-01-01
+
 clubs:
   albany:
     name: Albany
@@ -148,10 +150,13 @@ class TestSolve(unittest.TestCase):
     def test_earliest_match_date_excludes_earlier_home_dates(self) -> None:
         """Albany has two candidate home dates (2025-09-01 and 2025-09-29); a cutoff
         that excludes the earlier one should still solve, using the later one."""
-        output_dir = self.dir / "out"
-        solution_path = solve.solve(
-            self.spec_path, output_dir, earliest_match_date=date(2025, 9, 2)
+        self.spec_path.write_text(
+            _MINIMAL_SPEC.replace(
+                "earliest_match_date: 2025-01-01", "earliest_match_date: 2025-09-02"
+            )
         )
+        output_dir = self.dir / "out"
+        solution_path = solve.solve(self.spec_path, output_dir)
         loaded = fixturesolution.load_solution(
             solution_path,
             [
@@ -162,11 +167,6 @@ class TestSolve(unittest.TestCase):
         )
         for sf in loaded.fixtures:
             self.assertGreaterEqual(sf.date, date(2025, 9, 2))
-
-    def test_no_cutoff_by_default(self) -> None:
-        output_dir = self.dir / "out"
-        solution_path = solve.solve(self.spec_path, output_dir)
-        self.assertTrue(solution_path.exists())
 
 
 if __name__ == "__main__":

--- a/spec-schema.json
+++ b/spec-schema.json
@@ -26,6 +26,10 @@
       "$ref": "#/$defs/date",
       "description": "Latest date allowed for a fixture between two teams of the same club (e.g. Hendon 1 v Hendon 2) -- useful for requiring 'derby' matches to be settled earlier in the season than the rest of the fixture list. Has no effect on fixtures between teams from different clubs. If omitted, no such cutoff is applied. Any 'fixed_fixtures' entry between two teams of the same club must not be dated after it."
     },
+    "earliest_match_date": {
+      "$ref": "#/$defs/date",
+      "description": "Excludes candidate dates before this one from newly scheduled fixtures -- e.g. so re-running the solver after some home dates have already passed doesn't place a fixture in the past. If omitted, defaults to today. A 'fixed_fixtures' entry dated before this cutoff is not rejected: fixed_fixtures records matches that are already committed (possibly already played), so an old date there is expected. If this date is in the past, a warning is logged (but solving still proceeds) -- pass a date on or before the spec's earliest home date to disable the cutoff entirely, e.g. for an old spec being re-solved for reference."
+    },
     "clubs": {
       "type": "object",
       "description": "Every club in the season, keyed by club ID (a stable key referenced from teams, club_constraints, fixed_fixtures and exclude_fixtures).",


### PR DESCRIPTION
Previously the earliest-new-fixture cutoff was a solve.py-only --earliest-match-date flag defaulting to today. Moving it into the spec (also defaulting to today when omitted) keeps it alongside the other schedule-affecting spec fields, rather than as solve-time state tied to when the CLI happens to be invoked. An explicit value in the past now just logs a warning instead of silently doing nothing extra.


Claude-Session: https://claude.ai/code/session_012tguL6eUe8enqfeJUVkxsp