### PR TITLE
Add match_count_limits.max_playing_teams, rename max/date_max_overrides

### DIFF
--- a/build_site_test.py
+++ b/build_site_test.py
@@ -59,7 +59,7 @@ club_constraints:
     match_count_limits:
       - override_key: venue-capacity
         venue_scope: home
-        max: 1
+        max_matches: 1
   albany:
     home_dates: [2025-09-01, 2025-09-29]
   hackney:

--- a/fixturespec.py
+++ b/fixturespec.py
@@ -359,11 +359,13 @@ _TEAM_CONSTRAINT_FIELD_KEYS = {"unavailable_home_dates", "unavailable_away_dates
 
 _MATCH_COUNT_LIMIT_FIELD_KEYS = {
     "teams",
-    "max",
+    "max_matches",
+    "max_playing_teams",
     "time_window_days",
     "venue_scope",
     "apply_per",
-    "date_max_overrides",
+    "max_matches_overrides",
+    "max_playing_teams_overrides",
     "date_ranges",
     "override_key",
 }
@@ -398,21 +400,26 @@ class _ParsedMatchCountLimit:
     `team_ids` is None when the entry omitted 'teams' (meaning "every team of the
     club it applies to"). `override_key`, on a club entry, names the
     club_constraints.defaults entry this one replaces for that club; None means the
-    entry is purely additive. Every defaults entry has an `override_key`. `max` is
-    None only for an entry that exists solely to carry `date_max_overrides`, or to
-    cancel an inherited default (a club entry with an override_key and nothing else).
-    `date_ranges`, when non-empty, restricts the rule to those explicit inclusive
-    calendar ranges instead of every rolling `time_window_days` window.
+    entry is purely additive. Every defaults entry has an `override_key`. `max_matches`
+    is None only for an entry that carries `max_playing_teams` and/or
+    `max_matches_overrides` instead, or to cancel an inherited default (a club entry
+    with an override_key and nothing else). `date_ranges`, when non-empty, restricts
+    the rule to those explicit inclusive calendar ranges instead of every rolling
+    `time_window_days` window.
     """
 
     team_ids: tuple[str, ...] | None
-    max: int | None
+    max_matches: int | None
     time_window_days: int
     venue_scope: fmodel.VenueScope
     apply_per: fmodel.ApplyPer
-    date_max_overrides: Mapping[date, int | None]
+    max_matches_overrides: Mapping[date, int | None]
     date_ranges: tuple[fmodel.DateRange, ...]
     override_key: str | None
+    max_playing_teams: int | None = None
+    max_playing_teams_overrides: Mapping[date, int | None] = dataclasses.field(
+        default_factory=dict
+    )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -635,21 +642,22 @@ def _club_team_ids(club_id: str, teams: Mapping[str, fmodel.Team]) -> list[str]:
     return [tid for tid, team in teams.items() if team.club == club_id]
 
 
-def _parse_match_count_date_max_overrides(
-    value: Any, context: str
+def _parse_match_count_overrides(
+    value: Any, context: str, min_value: int = 1
 ) -> dict[date, int | None]:
-    """Parse a match_count_limits entry's optional 'date_max_overrides': a date-keyed
-    mapping of per-date limits (an integer >= 1, or null to lift the limit that day)."""
+    """Parse a match_count_limits entry's optional 'max_matches_overrides' or
+    'max_playing_teams_overrides': a date-keyed mapping of per-date limits (an
+    integer >= min_value, or null to lift the limit that day)."""
     if not isinstance(value, dict):
         raise SpecError(f"{context} must be a mapping keyed by date")
-    date_max_overrides: dict[date, int | None] = {}
+    overrides: dict[date, int | None] = {}
     for date_key, count in value.items():
         override_date = _parse_date(date_key, context)
         count = _require_int_or_none(count, f"{context}[{date_key!r}]")
-        if count is not None and count < 1:
-            raise SpecError(f"{context}[{date_key!r}] must be >= 1 or null")
-        date_max_overrides[override_date] = count
-    return date_max_overrides
+        if count is not None and count < min_value:
+            raise SpecError(f"{context}[{date_key!r}] must be >= {min_value} or null")
+        overrides[override_date] = count
+    return overrides
 
 
 def _parse_match_count_date_ranges(
@@ -691,31 +699,52 @@ def _parse_match_count_limits(
     """Parse a 'match_count_limits' list -- a club's own entry, or (when club_id is
     None) the club_constraints.defaults list applied to every club.
 
-    Each entry:
-      - 'max' (required key): an integer >= 1 (or >= 0 when 'date_ranges' is set),
-        or null. null on its own is only allowed for a club entry carrying an
-        'override_key' (it cancels that default); otherwise null needs
-        'date_max_overrides' to carry the actual caps.
+    Each entry needs at least one of 'max_matches' or 'max_playing_teams' -- either
+    alone is fine (a rule can cap just matches, just distinct playing teams, or
+    both) -- unless it carries 'max_matches_overrides', 'date_ranges', or (for a
+    club entry) an 'override_key' cancelling a default, any of which can supply the
+    actual cap on its own.
+      - 'max_matches' (optional): an integer >= 1 (or >= 0 when 'date_ranges' is
+        set), or null (meaningless on its own -- see above).
+      - 'max_playing_teams' (optional): a non-negative integer cap on how many
+        teams'-worth of players from 'teams' each window asks for, as opposed to
+        'max_matches', which counts matches. Each counted match adds one of 'teams'
+        playing, or two if it's an internal match between two of 'teams' (e.g. a
+        same-club derby counted by that club's own venue-capacity rule): one match
+        towards 'max_matches', but two teams from the set on to play. A venue that
+        can physically host 3 simultaneous matches but only has 3 teams' worth of
+        players to field wants both 'max_matches: 3' and 'max_playing_teams: 3' --
+        otherwise 3 matches, one an internal derby, would need 4 teams' worth of
+        players. Given 'max_playing_teams' alone (no 'max_matches'), the number of
+        matches is left uncapped directly, though it's usually bounded in practice
+        by the same team limit. Over a wider window (a multi-day
+        'time_window_days', or 'date_ranges'), the same pair meeting twice counts
+        twice -- this is a running tally of teams asked to play, not a count of
+        distinct teams touched.
+      - 'max_playing_teams_overrides' (optional): per-date replacements of
+        'max_playing_teams' (an integer >= 0, or null to lift the cap that day),
+        mirroring 'max_matches_overrides'. Only allowed when 'time_window_days' is 1;
+        not combinable with 'date_ranges'.
       - 'teams' (optional): IDs of this club's teams whose matches are counted.
         Omitted => every team of the club. Not allowed under 'defaults', nor
         alongside 'override_key' (an override replaces a spec-wide, all-teams
         default).
       - 'apply_per' (optional, default 'across_teams'): 'across_teams' => the listed
-        teams share one budget of 'max' per window; 'each_team' => 'max' is enforced
-        per team.
+        teams share one budget of 'max_matches'/'max_playing_teams' per window;
+        'each_team' => enforced per team.
       - 'time_window_days' (optional, default 1): window length in consecutive
         calendar days. 7 limits matches in any 7-consecutive-day period -- two
         matches exactly a week apart fall in separate windows.
       - 'venue_scope' (optional, default 'all'): 'home', 'away' or 'all'.
-      - 'date_max_overrides' (optional): per-date replacements of 'max'. Only allowed
-        when 'time_window_days' is 1.
+      - 'max_matches_overrides' (optional): per-date replacements of 'max_matches'.
+        Only allowed when 'time_window_days' is 1.
       - 'date_ranges' (optional): a non-empty list of {start_date, end_date}
         inclusive ranges. When given, the rule applies to exactly those ranges
         instead of every rolling 'time_window_days' window. Allowed on both club
         and 'defaults' entries; not combinable with 'time_window_days' or
-        'date_max_overrides', nor (on a club entry) with 'override_key'. 'max'
+        'max_matches_overrides', nor (on a club entry) with 'override_key'. 'max_matches'
         must then be a non-negative integer (0 bars every counted match in the
-        range -- a whole-club, all-teams 'defaults' entry with max 0 is how a
+        range -- a whole-club, all-teams 'defaults' entry with max_matches 0 is how a
         spec-wide "nobody plays these dates" block is expressed).
       - 'override_key': required for a 'defaults' entry (and unique within that
         list); optional for a club entry, where it names the default this one
@@ -742,15 +771,25 @@ def _parse_match_count_limits(
                 f"{sorted(_MATCH_COUNT_LIMIT_FIELD_KEYS)} are)"
             )
 
-        if "max" not in entry:
-            raise SpecError(f"{entry_context} missing required field 'max'")
-        max_ = _require_int_or_none(entry["max"], f"{entry_context}.max")
-        # 'date_ranges' permits max: 0 (a full blackout of the listed periods);
-        # every other form needs max >= 1 or null.
+        max_ = None
+        if "max_matches" in entry:
+            max_ = _require_int_or_none(
+                entry["max_matches"], f"{entry_context}.max_matches"
+            )
+        # 'date_ranges' permits max_matches: 0 (a full blackout of the listed
+        # periods); every other form needs max_matches >= 1 or null.
         has_date_ranges = "date_ranges" in entry
         min_max = 0 if has_date_ranges else 1
         if max_ is not None and max_ < min_max:
-            raise SpecError(f"{entry_context}.max must be >= {min_max} or null")
+            raise SpecError(f"{entry_context}.max_matches must be >= {min_max} or null")
+
+        max_playing_teams: int | None = None
+        if "max_playing_teams" in entry:
+            max_playing_teams = _require_int_or_none(
+                entry["max_playing_teams"], f"{entry_context}.max_playing_teams"
+            )
+            if max_playing_teams is not None and max_playing_teams < 0:
+                raise SpecError(f"{entry_context}.max_playing_teams must be >= 0")
 
         override_key: str | None = None
         if "override_key" in entry:
@@ -841,15 +880,28 @@ def _parse_match_count_limits(
                     f"{entry['venue_scope']!r}"
                 ) from None
 
-        date_max_overrides: dict[date, int | None] = {}
-        if "date_max_overrides" in entry:
+        max_matches_overrides: dict[date, int | None] = {}
+        if "max_matches_overrides" in entry:
             if time_window_days != 1:
                 raise SpecError(
-                    f"{entry_context}.date_max_overrides is only allowed when "
+                    f"{entry_context}.max_matches_overrides is only allowed when "
                     "time_window_days is 1"
                 )
-            date_max_overrides = _parse_match_count_date_max_overrides(
-                entry["date_max_overrides"], f"{entry_context}.date_max_overrides"
+            max_matches_overrides = _parse_match_count_overrides(
+                entry["max_matches_overrides"], f"{entry_context}.max_matches_overrides"
+            )
+
+        max_playing_teams_overrides: dict[date, int | None] = {}
+        if "max_playing_teams_overrides" in entry:
+            if time_window_days != 1:
+                raise SpecError(
+                    f"{entry_context}.max_playing_teams_overrides is only allowed "
+                    "when time_window_days is 1"
+                )
+            max_playing_teams_overrides = _parse_match_count_overrides(
+                entry["max_playing_teams_overrides"],
+                f"{entry_context}.max_playing_teams_overrides",
+                min_value=0,
             )
 
         date_ranges: tuple[fmodel.DateRange, ...] = ()
@@ -866,14 +918,19 @@ def _parse_match_count_limits(
                     f"{entry_context}: 'date_ranges' and 'time_window_days' can't "
                     "be combined ('date_ranges' replaces the rolling window)"
                 )
-            if date_max_overrides:
+            if max_matches_overrides:
                 raise SpecError(
-                    f"{entry_context}: 'date_ranges' and 'date_max_overrides' "
+                    f"{entry_context}: 'date_ranges' and 'max_matches_overrides' "
                     "can't be combined"
+                )
+            if max_playing_teams_overrides:
+                raise SpecError(
+                    f"{entry_context}: 'date_ranges' and "
+                    "'max_playing_teams_overrides' can't be combined"
                 )
             if max_ is None:
                 raise SpecError(
-                    f"{entry_context}.date_ranges needs an integer 'max' (>= 0)"
+                    f"{entry_context}.date_ranges needs an integer 'max_matches' (>= 0)"
                 )
             date_ranges = _parse_match_count_date_ranges(
                 entry["date_ranges"], f"{entry_context}.date_ranges"
@@ -881,25 +938,29 @@ def _parse_match_count_limits(
 
         if (
             max_ is None
-            and not date_max_overrides
+            and not max_matches_overrides
             and not date_ranges
             and override_key is None
+            and max_playing_teams is None
         ):
             raise SpecError(
-                f"{entry_context}.max: null needs 'date_max_overrides' to carry the "
-                "actual per-date caps (or an 'override_key' to cancel a default)"
+                f"{entry_context} needs 'max_matches' and/or 'max_playing_teams' to "
+                "carry an actual cap (or 'max_matches_overrides', or an "
+                "'override_key' to cancel a default)"
             )
 
         limits.append(
             _ParsedMatchCountLimit(
                 team_ids=team_ids,
-                max=max_,
+                max_matches=max_,
+                max_playing_teams=max_playing_teams,
                 time_window_days=time_window_days,
                 venue_scope=venue_scope,
                 apply_per=apply_per,
-                date_max_overrides=date_max_overrides,
+                max_matches_overrides=max_matches_overrides,
                 date_ranges=date_ranges,
                 override_key=override_key,
+                max_playing_teams_overrides=max_playing_teams_overrides,
             )
         )
 
@@ -918,9 +979,9 @@ def _resolve_match_count_limits(
 
     A club entry whose 'override_key' names a default entry replaces that default
     for the club (an unknown key, or two club entries sharing one, is an error);
-    every other club entry is additive. Entries that carry neither a 'max' nor any
-    'date_max_overrides' (a pure cancel-the-default marker) and entries that resolve
-    to no teams are dropped.
+    every other club entry is additive. Entries that carry none of 'max_matches',
+    'max_matches_overrides' or 'max_playing_teams' (a pure cancel-the-default marker)
+    and entries that resolve to no teams are dropped.
     """
     default_keys = {pl.override_key for pl in default_limits}
     resolved: list[fmodel.MatchCountLimit] = []
@@ -949,7 +1010,12 @@ def _resolve_match_count_limits(
 
         club_team_objs = [teams[tid] for tid in _club_team_ids(club_id, teams)]
         for pl in effective:
-            if pl.max is None and not pl.date_max_overrides:
+            if (
+                pl.max_matches is None
+                and not pl.max_matches_overrides
+                and pl.max_playing_teams is None
+                and not pl.max_playing_teams_overrides
+            ):
                 continue
             team_objs = (
                 club_team_objs
@@ -961,12 +1027,14 @@ def _resolve_match_count_limits(
             resolved.append(
                 fmodel.MatchCountLimit(
                     teams=team_objs,
-                    max=pl.max,
+                    max_matches=pl.max_matches,
                     time_window_days=pl.time_window_days,
                     venue_scope=pl.venue_scope,
                     apply_per=pl.apply_per,
-                    date_max_overrides=pl.date_max_overrides,
+                    max_matches_overrides=pl.max_matches_overrides,
                     date_ranges=pl.date_ranges,
+                    max_playing_teams=pl.max_playing_teams,
+                    max_playing_teams_overrides=pl.max_playing_teams_overrides,
                 )
             )
     return resolved

--- a/fixturespec_test.py
+++ b/fixturespec_test.py
@@ -104,7 +104,7 @@ club_constraints:
 
 _MINIMAL_SPEC = (
     _MINIMAL_SPEC_NO_CONCURRENCY
-    + "  defaults:\n    match_count_limits:\n      - override_key: venue-capacity\n        venue_scope: home\n        max: 1\n"
+    + "  defaults:\n    match_count_limits:\n      - override_key: venue-capacity\n        venue_scope: home\n        max_matches: 1\n"
 )
 
 # A three-team spec (two Albany teams plus Hackney) for exclude_fixtures tests, which
@@ -205,7 +205,7 @@ class TestLoadSpec(unittest.TestCase):
                 venue_scope=fmodel.VenueScope.HOME,
                 apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
             )
-            self.assertEqual(limit.max, 1)
+            self.assertEqual(limit.max_matches, 1)
         self.assertEqual(spec.name, "")
         self.assertFalse(spec.draft)
 
@@ -341,21 +341,21 @@ class TestLoadSpec(unittest.TestCase):
             fixturespec.load_spec(path)
 
     def test_avoid_dates_key_no_longer_recognised(self) -> None:
-        # avoid_dates was removed in favour of a defaults max: 0 date_ranges
+        # avoid_dates was removed in favour of a defaults max_matches: 0 date_ranges
         # entry; the old top-level key is now an unknown field.
         path = self._write(_MINIMAL_SPEC + "avoid_dates: [2025-12-25]\n")
         with self.assertRaisesRegex(fixturespec.SpecError, "avoid_dates"):
             fixturespec.load_spec(path)
 
     def test_no_play_dates_default_resolves_per_club(self) -> None:
-        # A whole-club max: 0 date_ranges defaults entry (the avoid_dates
+        # A whole-club max_matches: 0 date_ranges defaults entry (the avoid_dates
         # replacement): every club gets a resolved limit over all its teams.
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    match_count_limits:\n"
             "      - override_key: no-play-dates\n"
-            "        max: 0\n"
+            "        max_matches: 0\n"
             "        date_ranges:\n"
             "          - start_date: 2025-12-22\n"
             "            end_date: 2026-01-04\n"
@@ -367,7 +367,7 @@ class TestLoadSpec(unittest.TestCase):
         spec = fixturespec.load_spec(path)
         by_club = {}
         for limit in spec.parameters.match_count_limits:
-            if limit.max == 0:
+            if limit.max_matches == 0:
                 (club,) = {t.club for t in limit.teams}
                 by_club[club] = limit
         self.assertEqual(set(by_club), {"albany", "hackney"})
@@ -378,13 +378,13 @@ class TestLoadSpec(unittest.TestCase):
 
     def test_no_play_dates_default_can_be_overridden_by_a_club(self) -> None:
         # A club naming the override_key replaces the block wholesale -- here
-        # cancelling it, so that club has no max: 0 limit.
+        # cancelling it, so that club has no max_matches: 0 limit.
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    match_count_limits:\n"
             "      - override_key: no-play-dates\n"
-            "        max: 0\n"
+            "        max_matches: 0\n"
             "        date_ranges:\n"
             "          - start_date: 2025-12-22\n"
             "            end_date: 2026-01-04\n"
@@ -392,7 +392,7 @@ class TestLoadSpec(unittest.TestCase):
             "    home_dates: [2025-12-15]\n"
             "    match_count_limits:\n"
             "      - override_key: no-play-dates\n"
-            "        max: null\n"
+            "        max_matches: null\n"
             "  hackney:\n"
             "    home_dates: [2025-12-08]\n"
         )
@@ -400,7 +400,7 @@ class TestLoadSpec(unittest.TestCase):
         zero_clubs = {
             t.club
             for limit in spec.parameters.match_count_limits
-            if limit.max == 0
+            if limit.max_matches == 0
             for t in limit.teams
         }
         self.assertEqual(zero_clubs, {"hackney"})
@@ -415,7 +415,7 @@ class TestLoadSpec(unittest.TestCase):
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    match_count_limits:\n"
-            "      - override_key: venue-capacity\n        venue_scope: home\n        max: 1\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        max_matches: 1\n"
             "  albany:\n"
             "    home_dates: [2025-09-01]\n"
             "  albany:\n"
@@ -437,12 +437,12 @@ class TestLoadSpec(unittest.TestCase):
             "    match_count_limits:\n"
             "      - override_key: venue-capacity\n"
             "        venue_scope: home\n"
-            "        max: 1\n"
+            "        max_matches: 1\n"
             "  albany:\n"
             "    match_count_limits:\n"
             "      - override_key: venue-capacity\n"
             "        venue_scope: home\n"
-            "        max: 3\n"
+            "        max_matches: 3\n"
         )
         spec = fixturespec.load_spec(path)
         albany = _find_limit(
@@ -451,7 +451,7 @@ class TestLoadSpec(unittest.TestCase):
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertEqual(albany.max, 3)
+        self.assertEqual(albany.max_matches, 3)
         # hackney has no entry of its own, so it keeps the default home cap 1.
         hackney = _find_limit(
             spec.parameters.match_count_limits,
@@ -459,16 +459,16 @@ class TestLoadSpec(unittest.TestCase):
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertEqual(hackney.max, 1)
+        self.assertEqual(hackney.max_matches, 1)
 
-    def test_match_count_limits_date_max_overrides_parsed(self) -> None:
+    def test_match_count_limits_max_matches_overrides_parsed(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max: 2\n"
-            "        date_max_overrides:\n"
+            "        max_matches: 2\n"
+            "        max_matches_overrides:\n"
             "          2025-09-01: 3\n"
         )
         spec = fixturespec.load_spec(path)
@@ -478,8 +478,8 @@ class TestLoadSpec(unittest.TestCase):
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertEqual(albany.max, 2)
-        self.assertEqual(albany.date_max_overrides, {date(2025, 9, 1): 3})
+        self.assertEqual(albany.max_matches, 2)
+        self.assertEqual(albany.max_matches_overrides, {date(2025, 9, 1): 3})
 
     def test_match_count_limits_override_null_lifts_the_cap_that_day(self) -> None:
         path = self._write(
@@ -487,8 +487,8 @@ class TestLoadSpec(unittest.TestCase):
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max: null\n"
-            "        date_max_overrides:\n"
+            "        max_matches: null\n"
+            "        max_matches_overrides:\n"
             "          2025-09-01: 3\n"
         )
         spec = fixturespec.load_spec(path)
@@ -498,8 +498,8 @@ class TestLoadSpec(unittest.TestCase):
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertIsNone(albany.max)
-        self.assertEqual(albany.date_max_overrides, {date(2025, 9, 1): 3})
+        self.assertIsNone(albany.max_matches)
+        self.assertEqual(albany.max_matches_overrides, {date(2025, 9, 1): 3})
 
     def test_match_count_limits_null_max_cancels_default_via_override_key(self) -> None:
         path = self._write(
@@ -508,12 +508,12 @@ class TestLoadSpec(unittest.TestCase):
             "    match_count_limits:\n"
             "      - override_key: venue-capacity\n"
             "        venue_scope: home\n"
-            "        max: 1\n"
+            "        max_matches: 1\n"
             "  albany:\n"
             "    match_count_limits:\n"
             "      - override_key: venue-capacity\n"
             "        venue_scope: home\n"
-            "        max: null\n"
+            "        max_matches: null\n"
         )
         spec = fixturespec.load_spec(path)
         albany_home = [
@@ -530,7 +530,7 @@ class TestLoadSpec(unittest.TestCase):
                 club="hackney",
                 venue_scope=fmodel.VenueScope.HOME,
                 apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
-            ).max,
+            ).max_matches,
             1,
         )
 
@@ -541,12 +541,12 @@ class TestLoadSpec(unittest.TestCase):
             "    match_count_limits:\n"
             "      - override_key: venue-capacity\n"
             "        venue_scope: home\n"
-            "        max: 1\n"
+            "        max_matches: 1\n"
             "  albany:\n"
             "    match_count_limits:\n"
             "      - override_key: typo\n"
             "        venue_scope: home\n"
-            "        max: 2\n"
+            "        max_matches: 2\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "override_key"):
             fixturespec.load_spec(path)
@@ -557,7 +557,7 @@ class TestLoadSpec(unittest.TestCase):
             "  defaults:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max: 1\n"
+            "        max_matches: 1\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "override_key"):
             fixturespec.load_spec(path)
@@ -569,10 +569,10 @@ class TestLoadSpec(unittest.TestCase):
             "    match_count_limits:\n"
             "      - override_key: cap\n"
             "        venue_scope: home\n"
-            "        max: 1\n"
+            "        max_matches: 1\n"
             "      - override_key: cap\n"
             "        venue_scope: away\n"
-            "        max: 1\n"
+            "        max_matches: 1\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "override_key"):
             fixturespec.load_spec(path)
@@ -584,28 +584,30 @@ class TestLoadSpec(unittest.TestCase):
             "    match_count_limits:\n"
             "      - override_key: cap\n"
             "        venue_scope: home\n"
-            "        max: 1\n"
+            "        max_matches: 1\n"
             "  albany:\n"
             "    match_count_limits:\n"
             "      - override_key: cap\n"
             "        teams: [albany-1]\n"
-            "        max: 1\n"
+            "        max_matches: 1\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "override_key"):
             fixturespec.load_spec(path)
 
-    def test_match_count_limits_date_max_overrides_require_one_day_window(self) -> None:
+    def test_match_count_limits_max_matches_overrides_require_one_day_window(
+        self,
+    ) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max: 2\n"
+            "        max_matches: 2\n"
             "        time_window_days: 7\n"
-            "        date_max_overrides:\n"
+            "        max_matches_overrides:\n"
             "          2025-09-01: 3\n"
         )
-        with self.assertRaisesRegex(fixturespec.SpecError, "date_max_overrides"):
+        with self.assertRaisesRegex(fixturespec.SpecError, "max_matches_overrides"):
             fixturespec.load_spec(path)
 
     def test_match_count_limits_missing_max_field_rejected(self) -> None:
@@ -627,11 +629,11 @@ class TestLoadSpec(unittest.TestCase):
             "    match_count_limits:\n"
             "      - override_key: venue-capacity\n"
             "        venue_scope: home\n"
-            "        max: 2\n"
+            "        max_matches: 2\n"
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: all\n"
-            "        max: 1\n"
+            "        max_matches: 1\n"
         )
         spec = fixturespec.load_spec(path)
         self.assertEqual(
@@ -640,7 +642,7 @@ class TestLoadSpec(unittest.TestCase):
                 club="albany",
                 venue_scope=fmodel.VenueScope.HOME,
                 apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
-            ).max,
+            ).max_matches,
             2,
         )
         self.assertEqual(
@@ -649,7 +651,7 @@ class TestLoadSpec(unittest.TestCase):
                 club="albany",
                 venue_scope=fmodel.VenueScope.ALL,
                 apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
-            ).max,
+            ).max_matches,
             1,
         )
 
@@ -660,7 +662,7 @@ class TestLoadSpec(unittest.TestCase):
             "    match_count_limits:\n"
             "      - override_key: k\n"
             "        teams: [albany-1]\n"
-            "        max: 1\n"
+            "        max_matches: 1\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "teams is not allowed"):
             fixturespec.load_spec(path)
@@ -672,7 +674,7 @@ class TestLoadSpec(unittest.TestCase):
             "    match_count_limits:\n"
             "      - apply_per: each_team\n"
             "        time_window_days: 7\n"
-            "        max: 1\n"
+            "        max_matches: 1\n"
         )
         spec = fixturespec.load_spec(path)
         limit = _find_limit(
@@ -681,7 +683,7 @@ class TestLoadSpec(unittest.TestCase):
             venue_scope=fmodel.VenueScope.ALL,
             apply_per=fmodel.ApplyPer.EACH_TEAM,
         )
-        self.assertEqual((limit.time_window_days, limit.max), (7, 1))
+        self.assertEqual((limit.time_window_days, limit.max_matches), (7, 1))
 
     def test_match_count_limits_unknown_venue_scope_rejected(self) -> None:
         path = self._write(
@@ -689,7 +691,7 @@ class TestLoadSpec(unittest.TestCase):
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: sideways\n"
-            "        max: 1\n"
+            "        max_matches: 1\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "venue_scope"):
             fixturespec.load_spec(path)
@@ -700,7 +702,7 @@ class TestLoadSpec(unittest.TestCase):
             "  albany:\n"
             "    match_count_limits:\n"
             "      - apply_per: sometimes\n"
-            "        max: 1\n"
+            "        max_matches: 1\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "apply_per"):
             fixturespec.load_spec(path)
@@ -723,7 +725,7 @@ class TestLoadSpec(unittest.TestCase):
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max: 1\n"
+            "        max_matches: 1\n"
         )
         spec = fixturespec.load_spec(path)
         clubs = {
@@ -736,7 +738,7 @@ class TestLoadSpec(unittest.TestCase):
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
-            "      - max: 1\n"
+            "      - max_matches: 1\n"
             "        date_ranges:\n"
             "          - start_date: 2025-10-27\n"
             "            end_date: 2025-11-02\n"
@@ -757,14 +759,14 @@ class TestLoadSpec(unittest.TestCase):
                 fmodel.DateRange(date(2026, 2, 16), date(2026, 2, 22)),
             ),
         )
-        self.assertEqual((limit.max, limit.time_window_days), (1, 1))
+        self.assertEqual((limit.max_matches, limit.time_window_days), (1, 1))
 
     def test_match_count_limits_date_ranges_allow_max_zero(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
-            "      - max: 0\n"
+            "      - max_matches: 0\n"
             "        date_ranges:\n"
             "          - start_date: 2025-10-27\n"
             "            end_date: 2025-11-02\n"
@@ -776,7 +778,7 @@ class TestLoadSpec(unittest.TestCase):
             venue_scope=fmodel.VenueScope.ALL,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertEqual(limit.max, 0)
+        self.assertEqual(limit.max_matches, 0)
 
     def test_match_count_limits_max_zero_rejected_without_date_ranges(self) -> None:
         path = self._write(
@@ -784,7 +786,7 @@ class TestLoadSpec(unittest.TestCase):
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max: 0\n"
+            "        max_matches: 0\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "must be >= 1"):
             fixturespec.load_spec(path)
@@ -794,7 +796,7 @@ class TestLoadSpec(unittest.TestCase):
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
-            "      - max: 1\n"
+            "      - max_matches: 1\n"
             "        time_window_days: 7\n"
             "        date_ranges:\n"
             "          - start_date: 2025-10-27\n"
@@ -803,19 +805,19 @@ class TestLoadSpec(unittest.TestCase):
         with self.assertRaisesRegex(fixturespec.SpecError, "time_window_days"):
             fixturespec.load_spec(path)
 
-    def test_match_count_limits_date_ranges_reject_date_max_overrides(self) -> None:
+    def test_match_count_limits_date_ranges_reject_max_matches_overrides(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
-            "      - max: 1\n"
-            "        date_max_overrides:\n"
+            "      - max_matches: 1\n"
+            "        max_matches_overrides:\n"
             "          2025-10-27: 1\n"
             "        date_ranges:\n"
             "          - start_date: 2025-10-27\n"
             "            end_date: 2025-11-02\n"
         )
-        with self.assertRaisesRegex(fixturespec.SpecError, "date_max_overrides"):
+        with self.assertRaisesRegex(fixturespec.SpecError, "max_matches_overrides"):
             fixturespec.load_spec(path)
 
     def test_match_count_limits_date_ranges_reject_override_key(self) -> None:
@@ -825,11 +827,11 @@ class TestLoadSpec(unittest.TestCase):
             "    match_count_limits:\n"
             "      - override_key: venue-capacity\n"
             "        venue_scope: home\n"
-            "        max: 1\n"
+            "        max_matches: 1\n"
             "  albany:\n"
             "    match_count_limits:\n"
             "      - override_key: venue-capacity\n"
-            "        max: 1\n"
+            "        max_matches: 1\n"
             "        date_ranges:\n"
             "          - start_date: 2025-10-27\n"
             "            end_date: 2025-11-02\n"
@@ -845,7 +847,7 @@ class TestLoadSpec(unittest.TestCase):
             "  defaults:\n"
             "    match_count_limits:\n"
             "      - override_key: k\n"
-            "        max: 1\n"
+            "        max_matches: 1\n"
             "        date_ranges:\n"
             "          - start_date: 2025-10-27\n"
             "            end_date: 2025-11-02\n"
@@ -867,12 +869,12 @@ class TestLoadSpec(unittest.TestCase):
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
-            "      - max: null\n"
+            "      - max_matches: null\n"
             "        date_ranges:\n"
             "          - start_date: 2025-10-27\n"
             "            end_date: 2025-11-02\n"
         )
-        with self.assertRaisesRegex(fixturespec.SpecError, "integer 'max'"):
+        with self.assertRaisesRegex(fixturespec.SpecError, "integer 'max_matches'"):
             fixturespec.load_spec(path)
 
     def test_match_count_limits_date_ranges_reject_start_after_end(self) -> None:
@@ -880,7 +882,7 @@ class TestLoadSpec(unittest.TestCase):
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
-            "      - max: 1\n"
+            "      - max_matches: 1\n"
             "        date_ranges:\n"
             "          - start_date: 2025-11-02\n"
             "            end_date: 2025-10-27\n"
@@ -893,7 +895,7 @@ class TestLoadSpec(unittest.TestCase):
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
-            "      - max: 1\n"
+            "      - max_matches: 1\n"
             "        date_ranges:\n"
             "          - start_date: 2025-10-27\n"
         )
@@ -905,7 +907,7 @@ class TestLoadSpec(unittest.TestCase):
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
-            "      - max: 1\n"
+            "      - max_matches: 1\n"
             "        date_ranges:\n"
             "          - start_date: 2025-10-27\n"
             "            end_date: 2025-11-02\n"
@@ -919,7 +921,7 @@ class TestLoadSpec(unittest.TestCase):
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
-            "      - max: 1\n"
+            "      - max_matches: 1\n"
             "        date_ranges: []\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "non-empty list"):
@@ -1126,7 +1128,7 @@ divisions:
     # to load successfully (the failure-path tests don't get this far).
     _SCHEME_SPEC_TAIL = (
         "club_constraints:\n"
-        "  defaults:\n    match_count_limits:\n      - override_key: venue-capacity\n        venue_scope: home\n        max: 1\n"
+        "  defaults:\n    match_count_limits:\n      - override_key: venue-capacity\n        venue_scope: home\n        max_matches: 1\n"
         "  albany:\n    home_dates: [2025-09-01, 2025-09-08, 2025-09-15]\n"
     )
 
@@ -1215,7 +1217,7 @@ club_constraints:
     match_count_limits:
       - override_key: venue-capacity
         venue_scope: home
-        max: 1
+        max_matches: 1
   albany:
     home_dates: [2025-09-01, 2025-09-08, 2025-09-15]
 """)
@@ -1332,7 +1334,7 @@ club_constraints:
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    match_count_limits:\n"
-            "      - override_key: venue-capacity\n        venue_scope: home\n        max: 1\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        max_matches: 1\n"
             "  albany:\n"
             "    home_dates_used:\n"
             "      max: 1\n"
@@ -1356,7 +1358,7 @@ club_constraints:
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    match_count_limits:\n"
-            "      - override_key: venue-capacity\n        venue_scope: home\n        max: 1\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        max_matches: 1\n"
             "  albany:\n"
             "    home_dates_used:\n"
             "      min: 3\n"
@@ -1377,7 +1379,7 @@ club_constraints:
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    match_count_limits:\n"
-            "      - override_key: venue-capacity\n        venue_scope: home\n        max: 1\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        max_matches: 1\n"
             "  unknown-club:\n"
             "    home_dates_used:\n"
             "      max: 1\n"
@@ -1390,7 +1392,7 @@ club_constraints:
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    match_count_limits:\n"
-            "      - override_key: venue-capacity\n        venue_scope: home\n        max: 1\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        max_matches: 1\n"
             "  albany:\n"
             "    home_dates_used:\n"
             "      max: not-an-int\n"
@@ -1403,7 +1405,7 @@ club_constraints:
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    match_count_limits:\n"
-            "      - override_key: venue-capacity\n        venue_scope: home\n        max: 1\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        max_matches: 1\n"
             "  albany:\n"
             "    home_dates_used: 1\n"
         )
@@ -1415,7 +1417,7 @@ club_constraints:
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    match_count_limits:\n"
-            "      - override_key: venue-capacity\n        venue_scope: home\n        max: 1\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        max_matches: 1\n"
             "  albany:\n"
             "    home_dates_used: {}\n"
         )
@@ -1427,7 +1429,7 @@ club_constraints:
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    match_count_limits:\n"
-            "      - override_key: venue-capacity\n        venue_scope: home\n        max: 1\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        max_matches: 1\n"
             "  albany:\n"
             "    home_dates_used:\n"
             "      minimum: 2\n"
@@ -1440,7 +1442,7 @@ club_constraints:
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    match_count_limits:\n"
-            "      - override_key: venue-capacity\n        venue_scope: home\n        max: 1\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        max_matches: 1\n"
             "  albany:\n"
             "    home_dates_used:\n"
             "      min: 0\n"
@@ -1453,7 +1455,7 @@ club_constraints:
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    match_count_limits:\n"
-            "      - override_key: venue-capacity\n        venue_scope: home\n        max: 1\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        max_matches: 1\n"
             "  albany:\n"
             "    home_dates_used:\n"
             "      min: 5\n"
@@ -1473,14 +1475,14 @@ club_constraints:
             "      - override_key: weekly-gap\n"
             "        apply_per: each_team\n"
             "        time_window_days: 7\n"
-            "        max: 1\n"
+            "        max_matches: 1\n"
             "  albany:\n"
             "    home_dates: [2025-09-01]\n"
             "    match_count_limits:\n"
             "      - override_key: weekly-gap\n"
             "        apply_per: each_team\n"
             "        time_window_days: 14\n"
-            "        max: 1\n"
+            "        max_matches: 1\n"
             "  hackney:\n"
             "    home_dates: [2025-09-15]\n"
         )
@@ -1510,12 +1512,12 @@ club_constraints:
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max: -1\n"
+            "        max_matches: -1\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "max"):
             fixturespec.load_spec(path)
 
-    def test_match_count_limits_null_max_without_date_max_overrides_rejected(
+    def test_match_count_limits_null_max_without_max_matches_overrides_rejected(
         self,
     ) -> None:
         path = self._write(
@@ -1523,9 +1525,266 @@ club_constraints:
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max: null\n"
+            "        max_matches: null\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "max"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_max_playing_teams_parsed(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        max_matches: 3\n"
+            "        max_playing_teams: 3\n"
+        )
+        spec = fixturespec.load_spec(path)
+        limit = _find_limit(
+            spec.parameters.match_count_limits,
+            club="albany",
+            venue_scope=fmodel.VenueScope.HOME,
+            apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
+        )
+        self.assertEqual(limit.max_matches, 3)
+        self.assertEqual(limit.max_playing_teams, 3)
+
+    def test_match_count_limits_max_playing_teams_defaults_to_none(self) -> None:
+        path = self._write(_MINIMAL_SPEC)
+        spec = fixturespec.load_spec(path)
+        limit = _find_limit(
+            spec.parameters.match_count_limits,
+            club="albany",
+            venue_scope=fmodel.VenueScope.HOME,
+            apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
+        )
+        self.assertIsNone(limit.max_playing_teams)
+
+    def test_match_count_limits_max_playing_teams_negative_rejected(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        max_matches: 1\n"
+            "        max_playing_teams: -1\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "max_playing_teams"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_max_playing_teams_allows_multi_day_window(
+        self,
+    ) -> None:
+        """Unlike max_playing_teams_overrides (still tied to a single date), a
+        plain max_playing_teams cap is meaningful over a rolling multi-day window
+        too -- see fmodel.MatchCountLimit for what it counts there."""
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        max_matches: 3\n"
+            "        max_playing_teams: 1\n"
+            "        time_window_days: 7\n"
+        )
+        spec = fixturespec.load_spec(path)
+        limit = _find_limit(
+            spec.parameters.match_count_limits,
+            club="albany",
+            venue_scope=fmodel.VenueScope.HOME,
+            apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
+        )
+        self.assertEqual(limit.max_playing_teams, 1)
+        self.assertEqual(limit.time_window_days, 7)
+
+    def test_match_count_limits_max_playing_teams_allows_date_ranges(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        max_matches: 0\n"
+            "        max_playing_teams: 0\n"
+            "        date_ranges:\n"
+            "          - start_date: 2025-09-01\n"
+            "            end_date: 2025-09-07\n"
+        )
+        spec = fixturespec.load_spec(path)
+        limit = _find_limit(
+            spec.parameters.match_count_limits,
+            club="albany",
+            venue_scope=fmodel.VenueScope.HOME,
+            apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
+        )
+        self.assertEqual(limit.max_playing_teams, 0)
+        self.assertEqual(
+            limit.date_ranges,
+            (fmodel.DateRange(date(2025, 9, 1), date(2025, 9, 7)),),
+        )
+
+    def test_match_count_limits_max_playing_teams_alone_is_allowed(self) -> None:
+        """max_playing_teams can carry a rule on its own, with 'max_matches' omitted
+        entirely (no plain match-count cap, just a distinct-teams-playing one)."""
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        max_playing_teams: 2\n"
+        )
+        spec = fixturespec.load_spec(path)
+        limit = _find_limit(
+            spec.parameters.match_count_limits,
+            club="albany",
+            venue_scope=fmodel.VenueScope.HOME,
+            apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
+        )
+        self.assertIsNone(limit.max_matches)
+        self.assertEqual(limit.max_playing_teams, 2)
+
+    def test_match_count_limits_max_playing_teams_alone_with_explicit_null(
+        self,
+    ) -> None:
+        """An explicit 'max_matches: null' alongside 'max_playing_teams' works the
+        same as omitting the key entirely."""
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        max_matches: null\n"
+            "        max_playing_teams: 2\n"
+        )
+        spec = fixturespec.load_spec(path)
+        limit = _find_limit(
+            spec.parameters.match_count_limits,
+            club="albany",
+            venue_scope=fmodel.VenueScope.HOME,
+            apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
+        )
+        self.assertIsNone(limit.max_matches)
+        self.assertEqual(limit.max_playing_teams, 2)
+
+    def test_match_count_limits_max_matches_alone_is_allowed(self) -> None:
+        """max_matches can carry a rule on its own, with 'max_playing_teams'
+        omitted entirely -- the pre-existing, still-supported shape."""
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        max_matches: 3\n"
+        )
+        spec = fixturespec.load_spec(path)
+        limit = _find_limit(
+            spec.parameters.match_count_limits,
+            club="albany",
+            venue_scope=fmodel.VenueScope.HOME,
+            apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
+        )
+        self.assertEqual(limit.max_matches, 3)
+        self.assertIsNone(limit.max_playing_teams)
+
+    def test_match_count_limits_neither_max_field_rejected(self) -> None:
+        """Neither 'max_matches' nor 'max_playing_teams', and no other way to carry
+        a cap (no override_key, max_matches_overrides or date_ranges): rejected."""
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+        )
+        with self.assertRaisesRegex(
+            fixturespec.SpecError, "max_matches.*max_playing_teams"
+        ):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_max_playing_teams_overrides_parsed(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        max_matches: 3\n"
+            "        max_playing_teams: 1\n"
+            "        max_playing_teams_overrides:\n"
+            "          2025-09-01: 2\n"
+            "          2025-09-08: null\n"
+        )
+        spec = fixturespec.load_spec(path)
+        limit = _find_limit(
+            spec.parameters.match_count_limits,
+            club="albany",
+            venue_scope=fmodel.VenueScope.HOME,
+            apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
+        )
+        self.assertEqual(limit.max_playing_teams, 1)
+        self.assertEqual(
+            limit.max_playing_teams_overrides,
+            {date(2025, 9, 1): 2, date(2025, 9, 8): None},
+        )
+
+    def test_match_count_limits_max_playing_teams_overrides_require_one_day_window(
+        self,
+    ) -> None:
+        # max_playing_teams itself is omitted here (it would trigger its own,
+        # broader time_window_days==1 requirement first -- see
+        # test_match_count_limits_max_playing_teams_requires_one_day_window):
+        # max_playing_teams_overrides needs the same restriction independently,
+        # since it's usable on its own (a rule with only override dates, no
+        # everyday cap).
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        max_matches: 3\n"
+            "        time_window_days: 7\n"
+            "        max_playing_teams_overrides:\n"
+            "          2025-09-01: 2\n"
+        )
+        with self.assertRaisesRegex(
+            fixturespec.SpecError, "max_playing_teams_overrides"
+        ):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_max_playing_teams_overrides_reject_negative(
+        self,
+    ) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        max_matches: 3\n"
+            "        max_playing_teams: 1\n"
+            "        max_playing_teams_overrides:\n"
+            "          2025-09-01: -1\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "max_playing_teams"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_max_playing_teams_overrides_reject_date_ranges(
+        self,
+    ) -> None:
+        # max_playing_teams itself is omitted -- see the comment on
+        # test_match_count_limits_max_playing_teams_overrides_require_one_day_window
+        # above.
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        max_matches: 0\n"
+            "        max_playing_teams_overrides:\n"
+            "          2025-09-01: 1\n"
+            "        date_ranges:\n"
+            "          - start_date: 2025-09-01\n"
+            "            end_date: 2025-09-07\n"
+        )
+        with self.assertRaisesRegex(
+            fixturespec.SpecError, "max_playing_teams_overrides"
+        ):
             fixturespec.load_spec(path)
 
     def test_club_latest_match_date_parsed(self) -> None:
@@ -1827,7 +2086,7 @@ club_constraints:
             self._with_albany_match_count_limits(
                 "    match_count_limits:\n"
                 "      - teams: [albany-1, albany-2]\n"
-                "        max: 1\n"
+                "        max_matches: 1\n"
             )
         )
         spec = fixturespec.load_spec(path)
@@ -1841,7 +2100,7 @@ club_constraints:
             list(spec.parameters.match_count_limits),
             [
                 fmodel.MatchCountLimit(
-                    teams=[albany_1, albany_2], max=1, time_window_days=1
+                    teams=[albany_1, albany_2], max_matches=1, time_window_days=1
                 )
             ],
         )
@@ -1849,7 +2108,7 @@ club_constraints:
     def test_match_count_limits_teams_defaults_to_all_of_club(self) -> None:
         path = self._write(
             self._with_albany_match_count_limits(
-                "    match_count_limits:\n      - max: 3\n        time_window_days: 7\n"
+                "    match_count_limits:\n      - max_matches: 3\n        time_window_days: 7\n"
             )
         )
         spec = fixturespec.load_spec(path)
@@ -1861,7 +2120,7 @@ club_constraints:
         )
         constraints = list(spec.parameters.match_count_limits)
         self.assertEqual(list(constraints[0].teams), [albany_1, albany_2])
-        self.assertEqual(constraints[0].max, 3)
+        self.assertEqual(constraints[0].max_matches, 3)
         self.assertEqual(constraints[0].time_window_days, 7)
 
     def test_match_count_limits_time_window_days_parsed(self) -> None:
@@ -1869,7 +2128,7 @@ club_constraints:
             self._with_albany_match_count_limits(
                 "    match_count_limits:\n"
                 "      - teams: [albany-1, albany-2]\n"
-                "        max: 1\n"
+                "        max_matches: 1\n"
                 "        time_window_days: 3\n"
             )
         )
@@ -1882,7 +2141,7 @@ club_constraints:
             self._with_albany_match_count_limits(
                 "    match_count_limits:\n"
                 "      - teams: [albany-1, albany-2]\n"
-                "        max: 1\n"
+                "        max_matches: 1\n"
             )
         )
         spec = fixturespec.load_spec(path)
@@ -1894,7 +2153,7 @@ club_constraints:
             self._with_albany_match_count_limits(
                 "    match_count_limits:\n"
                 "      - teams: [albany-1, albany-2]\n"
-                "        max: 1\n"
+                "        max_matches: 1\n"
             )
         )
         spec = fixturespec.load_spec(path)
@@ -1906,7 +2165,7 @@ club_constraints:
             self._with_albany_match_count_limits(
                 "    match_count_limits:\n"
                 "      - teams: [albany-1, albany-2]\n"
-                "        max: 1\n"
+                "        max_matches: 1\n"
                 "        venue_scope: away\n"
             )
         )
@@ -1919,7 +2178,7 @@ club_constraints:
             self._with_albany_match_count_limits(
                 "    match_count_limits:\n"
                 "      - teams: [albany-1, albany-2]\n"
-                "        max: 1\n"
+                "        max_matches: 1\n"
                 "        venue_scope: sometimes\n"
             )
         )
@@ -1940,7 +2199,7 @@ club_constraints:
             self._with_albany_match_count_limits(
                 "    match_count_limits:\n"
                 "      - teams: [albany-1, albany-2]\n"
-                "        max: 0\n"
+                "        max_matches: 0\n"
             )
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "max"):
@@ -1951,7 +2210,7 @@ club_constraints:
             self._with_albany_match_count_limits(
                 "    match_count_limits:\n"
                 "      - teams: [albany-1, albany-2]\n"
-                "        max: 1\n"
+                "        max_matches: 1\n"
                 "        time_window_days: 0\n"
             )
         )
@@ -1977,7 +2236,7 @@ club_constraints:
     def test_match_count_limits_empty_teams_list(self) -> None:
         path = self._write(
             self._with_albany_match_count_limits(
-                "    match_count_limits:\n      - teams: []\n        max: 1\n"
+                "    match_count_limits:\n      - teams: []\n        max_matches: 1\n"
             )
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "non-empty"):
@@ -1988,7 +2247,7 @@ club_constraints:
             self._with_albany_match_count_limits(
                 "    match_count_limits:\n"
                 "      - teams: [albany-1, albany-1]\n"
-                "        max: 1\n"
+                "        max_matches: 1\n"
             )
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "duplicate"):
@@ -1999,7 +2258,7 @@ club_constraints:
             self._with_albany_match_count_limits(
                 "    match_count_limits:\n"
                 "      - teams: [albany-1, nonexistent]\n"
-                "        max: 1\n"
+                "        max_matches: 1\n"
             )
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "nonexistent"):
@@ -2010,7 +2269,7 @@ club_constraints:
             self._with_albany_match_count_limits(
                 "    match_count_limits:\n"
                 "      - teams: [albany-1, hackney-1]\n"
-                "        max: 1\n"
+                "        max_matches: 1\n"
             )
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "hackney-1"):
@@ -2021,7 +2280,7 @@ club_constraints:
             self._with_albany_match_count_limits(
                 "    match_count_limits:\n"
                 "      - teams: [albany-1, albany-2]\n"
-                "        max: 1\n"
+                "        max_matches: 1\n"
                 "        venue: elsewhere\n"
             )
         )
@@ -2259,7 +2518,16 @@ club_constraints:
     def test_club_latest_match_date_solves_end_to_end(self) -> None:
         """A cutoff that still leaves hackney a usable home date solves, with every
         hackney fixture on or before the cutoff."""
-        path = self._write(_THREE_TEAM_SPEC + "    latest_match_date: 2026-01-15\n")
+        # hackney-1 hosts two required home fixtures (v albany-1 and v albany-2), and
+        # a team may only play once per date, so needs two usable home dates within
+        # the cutoff -- an extra one is added here beyond _THREE_TEAM_SPEC's own.
+        path = self._write(
+            _THREE_TEAM_SPEC.replace(
+                "home_dates: [2026-01-01, 2026-02-01]",
+                "home_dates: [2025-12-18, 2026-01-01, 2026-02-01]",
+            )
+            + "    latest_match_date: 2026-01-15\n"
+        )
         spec = fixturespec.load_spec(path)
         self.assertEqual(
             spec.parameters.club_latest_match_date, {"hackney": date(2026, 1, 15)}

--- a/fmodel.py
+++ b/fmodel.py
@@ -204,10 +204,11 @@ class VenueScope(enum.Enum):
 
 
 class ApplyPer(enum.Enum):
-    """How a MatchCountLimit's `max` applies to its `teams`. ACROSS_TEAMS: one
-    shared budget for the whole set (a venue capacity, or a keep-these-teams-apart
-    rule). EACH_TEAM: the cap is enforced separately for every team in the set (a
-    per-team gap -- `teams` is then typically every team of a club and `max` is 1).
+    """How a MatchCountLimit's `max_matches`/`max_playing_teams` applies to its
+    `teams`. ACROSS_TEAMS: one shared budget for the whole set (a venue capacity, or
+    a keep-these-teams-apart rule). EACH_TEAM: the cap is enforced separately for
+    every team in the set (a per-team gap -- `teams` is then typically every team of
+    a club and `max_matches` is 1).
     """
 
     EACH_TEAM = "each_team"
@@ -216,7 +217,7 @@ class ApplyPer(enum.Enum):
 
 @dataclasses.dataclass(frozen=True)
 class MatchCountLimit:
-    """At most `max` matches involving `teams` may fall within any window of
+    """At most `max_matches` matches involving `teams` may fall within any window of
     `time_window_days` consecutive calendar days. This is the sole match-count
     constraint mechanism -- a per-team gap ("each team plays at most once a week"),
     a venue's concurrent-match capacity ("at most two home matches a night"), and a
@@ -228,43 +229,70 @@ class MatchCountLimit:
     matches exactly a week apart (day N and day N+7) never share a window and are
     unrestricted relative to each other.
 
-    `apply_per` (see ApplyPer) decides whether `max` is one shared budget for the
-    whole `teams` set (ACROSS_TEAMS, the default) or enforced separately per team
-    (EACH_TEAM).
+    `apply_per` (see ApplyPer) decides whether `max_matches` (and `max_playing_teams`)
+    is one shared budget for the whole `teams` set (ACROSS_TEAMS, the default) or
+    enforced separately per team (EACH_TEAM).
 
     `venue_scope` narrows which of those teams' matches count: VenueScope.HOME only
     their home matches, VenueScope.AWAY only their away matches, VenueScope.ALL (the
     default) every match they play. So an AWAY cap counts only the teams' away
     fixtures, still allowing one to play away on a night another is hosting.
 
-    `max` may be None, meaning no cap from the plain value -- only useful alongside
-    `date_max_overrides`, which replace `max` on specific dates (an int, or None to
-    lift the cap that day). These per-date overrides are only meaningful, and only
-    permitted, when `time_window_days` is 1, so each window is a single date.
+    `max_matches` may be None, meaning no cap from the plain value -- only useful
+    alongside `max_matches_overrides`, which replace `max_matches` on specific dates
+    (an int, or None to lift the cap that day). These per-date overrides are only
+    meaningful, and only permitted, when `time_window_days` is 1, so each window is a
+    single date.
 
     `date_ranges`, when non-empty, replaces the rolling-window behaviour entirely:
     instead of every run of `time_window_days` consecutive days, the cap applies to
     exactly the given DateRanges, each counted independently. This targets a limit
     tied to specific weeks -- a school-holiday week, a congress fortnight -- that a
     rolling window can't express. It requires `time_window_days` left at its default
-    of 1, is mutually exclusive with `date_max_overrides`, and `max` must then be a
-    non-negative integer (`max=0` bars every counted match in the range).
+    of 1, is mutually exclusive with `max_matches_overrides`, and `max_matches` must
+    then be a non-negative integer (`max_matches=0` bars every counted match in the
+    range).
+
+    `max_playing_teams`, when not None, caps how many teams'-worth of players from
+    `teams` a window asks for: each counted match adds one of `teams` playing to the
+    total, or two if it's an internal match between two of `teams` (e.g. a same-club
+    derby counted by a club's own venue-capacity rule) -- one entry towards
+    `max_matches`, but two teams from the set on to play. A venue that can physically
+    host 3 simultaneous matches but only has 3 sets of players to field wants
+    `max_matches=3` *and* `max_playing_teams=3` -- otherwise 3 matches, one an
+    internal derby, would need 4 teams' worth of players. Over a wider window (a
+    multi-day `time_window_days`, or `date_ranges`), the same pair meeting twice
+    counts twice: two internal matches between the same two teams still means
+    fielding 4 teams'-worth of players across the window, once per match, not 2 --
+    this is a running tally of teams asked to play, not a count of distinct teams
+    touched. `max_playing_teams_overrides` replaces it on specific dates (an int, or
+    None to lift the cap that day), mirroring `max_matches_overrides` -- only
+    meaningful, and only permitted, when `time_window_days` is 1.
     """
 
     teams: Collection[Team]
-    max: int | None
+    max_matches: int | None
     time_window_days: int = 1
     venue_scope: VenueScope = VenueScope.ALL
     apply_per: ApplyPer = ApplyPer.ACROSS_TEAMS
-    date_max_overrides: Mapping[date, int | None] = dataclasses.field(
+    max_matches_overrides: Mapping[date, int | None] = dataclasses.field(
         default_factory=dict
     )
     date_ranges: tuple[DateRange, ...] = ()
+    max_playing_teams: int | None = None
+    max_playing_teams_overrides: Mapping[date, int | None] = dataclasses.field(
+        default_factory=dict
+    )
 
     def __post_init__(self) -> None:
-        if self.date_max_overrides and self.time_window_days != 1:
+        if self.max_matches_overrides and self.time_window_days != 1:
             raise ValueError(
-                "MatchCountLimit.date_max_overrides requires time_window_days == 1"
+                "MatchCountLimit.max_matches_overrides requires time_window_days == 1"
+            )
+        if self.max_playing_teams_overrides and self.time_window_days != 1:
+            raise ValueError(
+                "MatchCountLimit.max_playing_teams_overrides requires "
+                "time_window_days == 1"
             )
         if self.date_ranges:
             if self.time_window_days != 1:
@@ -272,19 +300,28 @@ class MatchCountLimit:
                     "MatchCountLimit.date_ranges can't be combined with a "
                     "non-default time_window_days (it replaces the rolling window)"
                 )
-            if self.date_max_overrides:
+            if self.max_matches_overrides:
                 raise ValueError(
-                    "MatchCountLimit.date_ranges and date_max_overrides are "
+                    "MatchCountLimit.date_ranges and max_matches_overrides are "
                     "mutually exclusive"
                 )
 
-    def max_for_window(self, window: Collection[date]) -> int | None:
-        """The effective cap for one window: a `date_max_overrides` entry when the
-        window is a single overridden date, otherwise `max`."""
-        if self.date_max_overrides and len(window) == 1:
+    def max_matches_for_window(self, window: Collection[date]) -> int | None:
+        """The effective matches cap for one window: a `max_matches_overrides` entry
+        when the window is a single overridden date, otherwise `max_matches`."""
+        if self.max_matches_overrides and len(window) == 1:
             (d,) = tuple(window)
-            return self.date_max_overrides.get(d, self.max)
-        return self.max
+            return self.max_matches_overrides.get(d, self.max_matches)
+        return self.max_matches
+
+    def max_playing_teams_for_window(self, window: Collection[date]) -> int | None:
+        """The effective playing-teams cap for one window: a
+        `max_playing_teams_overrides` entry when the window is a single overridden
+        date, otherwise `max_playing_teams`."""
+        if self.max_playing_teams_overrides and len(window) == 1:
+            (d,) = tuple(window)
+            return self.max_playing_teams_overrides.get(d, self.max_playing_teams)
+        return self.max_playing_teams
 
     def counts_fixture(self, fixture: Fixture) -> bool:
         """Whether this limit counts `fixture` at all: its home team (for a HOME or
@@ -306,10 +343,15 @@ class MatchCountLimit:
         if not self.counts_fixture(fixture):
             return False
         if self.date_ranges:
-            return self.max == 0 and any(d in rng for rng in self.date_ranges)
-        if self.max == 0:
+            return (self.max_matches == 0 or self.max_playing_teams == 0) and any(
+                d in rng for rng in self.date_ranges
+            )
+        if self.max_matches == 0 or self.max_playing_teams == 0:
             return True
-        return self.date_max_overrides.get(d) == 0
+        return (
+            self.max_matches_overrides.get(d) == 0
+            or self.max_playing_teams_overrides.get(d) == 0
+        )
 
 
 def _check_no_duplicate_teams(teams: Collection[Team]) -> None:
@@ -476,9 +518,12 @@ class _FixtureVars:
         self._by_fixture: MutableMapping[Fixture, list[cp_model.IntVar]] = (
             collections.defaultdict(list)
         )
-        self._by_team_date: MutableMapping[
-            Team, MutableMapping[date, list[cp_model.IntVar]]
-        ] = collections.defaultdict(lambda: collections.defaultdict(list))
+        # (team, date) -> vars for every match -- home or away -- that team could
+        # play on that date (at most one may end up true: see
+        # _add_one_match_per_team_per_date_constraints).
+        self._by_team_date: MutableMapping[tuple[Team, date], list[cp_model.IntVar]] = (
+            collections.defaultdict(list)
+        )
         # (club, date) -> vars for that club's home matches on that date (for the
         # home_dates_used bound).
         self._by_club_home_date: MutableMapping[
@@ -500,8 +545,8 @@ class _FixtureVars:
         home, away = fixture.home_team, fixture.away_team
         self._by_fixture_date[key] = var
         self._by_fixture[fixture].append(var)
-        self._by_team_date[home][match_date].append(var)
-        self._by_team_date[away][match_date].append(var)
+        self._by_team_date[home, match_date].append(var)
+        self._by_team_date[away, match_date].append(var)
         self._by_club_home_date[home.club, match_date].append(var)
 
     def fixture_date_vars(self) -> Mapping[tuple[Fixture, date], cp_model.IntVar]:
@@ -520,6 +565,61 @@ class _FixtureVars:
     ) -> Mapping[tuple[ClubT, date], list[cp_model.IntVar]]:
         """Per (club, date), the vars for that club's home matches on that date."""
         return self._by_club_home_date
+
+    def by_team_date(self) -> Mapping[tuple[Team, date], list[cp_model.IntVar]]:
+        """Per (team, date), the vars for every match -- home or away -- that team
+        could play on that date."""
+        return self._by_team_date
+
+    def teams_playing(
+        self, fixture: Fixture, match_date: date, teams: Collection[Team]
+    ) -> cp_model.LinearExprT:
+        """How many of `teams` play in `fixture` on `match_date`, in terms of that
+        candidate's own decision variable: 0 if neither of the fixture's two teams
+        is in `teams`; the variable itself if exactly one is (an ordinary match,
+        from `teams`' perspective); twice the variable if both are (an internal
+        match between two of `teams`, e.g. a same-club derby -- one candidate, but
+        two of `teams` playing if it's scheduled). Summing this over every counted
+        candidate in a window gives exactly how many teams'-worth of players from
+        `teams` the window asks for -- once per match a team plays in, not just once
+        per team, so the same pair meeting twice in the window counts twice (see
+        MatchCountLimit.max_playing_teams)."""
+        count = (fixture.home_team in teams) + (fixture.away_team in teams)
+        if count == 0:
+            return 0
+        var = self._by_fixture_date[fixture, match_date]
+        return var if count == 1 else 2 * var
+
+
+def _counted_fixtures_by_date(
+    fixture_date_vars: Mapping[tuple[Fixture, date], cp_model.IntVar],
+    teams: Collection[Team],
+    venue_scope: VenueScope,
+) -> Mapping[date, list[Fixture]]:
+    """Every candidate fixture in `fixture_date_vars`, grouped by date, that counts
+    towards a MatchCountLimit over `teams` with the given `venue_scope`: its home
+    team is among `teams` (HOME or ALL scope), or its away team is (AWAY or ALL)."""
+    count_home = venue_scope in (VenueScope.HOME, VenueScope.ALL)
+    count_away = venue_scope in (VenueScope.AWAY, VenueScope.ALL)
+    result: MutableMapping[date, list[Fixture]] = collections.defaultdict(list)
+    for fixture, match_date in fixture_date_vars:
+        if (count_home and fixture.home_team in teams) or (
+            count_away and fixture.away_team in teams
+        ):
+            result[match_date].append(fixture)
+    return result
+
+
+def _add_one_match_per_team_per_date_constraints(
+    model: cp_model.CpModel, fixture_vars: _FixtureVars
+) -> None:
+    """No team -- home or away -- may play more than one match on the same date: a
+    team's players can't be in two places at once. Unconditional, unlike the rest of
+    _build_model's constraints: there's no spec field to turn it off, since no real
+    fixture list should ever want to violate it."""
+    for vars_for_team_date in fixture_vars.by_team_date().values():
+        if len(vars_for_team_date) > 1:
+            model.add(cp_model.LinearExpr.Sum(vars_for_team_date) <= 1)
 
 
 def _add_home_dates_used_constraints(
@@ -563,28 +663,26 @@ def _add_match_count_limit_constraints(
 ) -> None:
     """Apply every MatchCountLimit: no window of `time_window_days` consecutive days
     -- or, when the rule sets `date_ranges`, no listed calendar range -- may hold
-    more than the rule's effective cap (see max_for_window) matches from the counted
-    set. `venue_scope` selects which of the teams' matches count (home only, away
-    only, or all); `apply_per` decides whether `max` is a shared budget for the
-    whole group or enforced separately per team.
+    more than the rule's effective cap (see max_matches_for_window) matches from the
+    counted set, nor (when `max_playing_teams` is set) more teams'-worth of players
+    from the set than that. `venue_scope` selects which of the teams' matches count
+    (home only, away only, or all); `apply_per` decides whether the caps are a
+    shared budget for the whole group or enforced separately per team.
     """
     fixture_date_vars = fixture_vars.fixture_date_vars()
     for rule in limits:
-        count_home = rule.venue_scope in (VenueScope.HOME, VenueScope.ALL)
-        count_away = rule.venue_scope in (VenueScope.AWAY, VenueScope.ALL)
         each_team = rule.apply_per is ApplyPer.EACH_TEAM
         groups = [{team} for team in rule.teams] if each_team else [set(rule.teams)]
         for team_set in groups:
-            # Each (fixture, date) maps to a single variable, visited once here, so
-            # a match between two teams both in `team_set` is counted once.
-            vars_by_date: MutableMapping[date, list[cp_model.IntVar]] = (
-                collections.defaultdict(list)
+            # Every candidate this rule counts (per its venue_scope), grouped by
+            # date. A match between two teams both in `team_set` (e.g. a same-club
+            # derby counted by that club's own rule) appears once here, under one
+            # variable -- counted once towards max_matches below, but twice towards
+            # max_playing_teams (see _FixtureVars.teams_playing), since it puts two of
+            # `team_set` on to play.
+            fixtures_by_date = _counted_fixtures_by_date(
+                fixture_date_vars, team_set, rule.venue_scope
             )
-            for (fixture, d), var in fixture_date_vars.items():
-                if (count_home and fixture.home_team in team_set) or (
-                    count_away and fixture.away_team in team_set
-                ):
-                    vars_by_date[d].append(var)
 
             # With explicit date_ranges the windows are exactly those inclusive
             # ranges (each counted independently). Otherwise date_windows groups
@@ -596,25 +694,50 @@ def _add_match_count_limit_constraints(
             windows: Iterable[Collection[date]]
             if rule.date_ranges:
                 windows = [
-                    [d for d in vars_by_date if d in rng] for rng in rule.date_ranges
+                    [d for d in fixtures_by_date if d in rng]
+                    for rng in rule.date_ranges
                 ]
             else:
-                windows = date_windows(vars_by_date.keys(), rule.time_window_days - 1)
+                windows = date_windows(
+                    fixtures_by_date.keys(), rule.time_window_days - 1
+                )
             for window in windows:
-                cap = rule.max_for_window(window)
-                if cap is None:
-                    continue
+                window_fixture_dates = [
+                    (fixture, d) for d in window for fixture in fixtures_by_date[d]
+                ]
+
+                cap = rule.max_matches_for_window(window)
                 # A shared-budget cap that is >= the group size can never bind: the
                 # teams can't play more simultaneous matches than there are of them
                 # (this is how a stated venue capacity above a club's team count
                 # stays a no-op). A date range spans many days, in which one team
                 # can play more than once, so the shortcut only holds for the
                 # single-instant rolling-window form.
-                if not each_team and not rule.date_ranges and cap >= len(team_set):
-                    continue
-                window_vars = [v for d in window for v in vars_by_date[d]]
-                if len(window_vars) > cap:
-                    model.add(cp_model.LinearExpr.Sum(window_vars) <= cap)
+                if cap is not None and (
+                    each_team or rule.date_ranges or cap < len(team_set)
+                ):
+                    window_vars = [
+                        fixture_date_vars[fixture, d]
+                        for fixture, d in window_fixture_dates
+                    ]
+                    if len(window_vars) > cap:
+                        model.add(cp_model.LinearExpr.Sum(window_vars) <= cap)
+
+                # Unlike max_matches, a shared cap here can still bind even at or
+                # above the group size -- the same two teams meeting twice in the
+                # window already asks for twice their number of teams'-worth of
+                # players -- so there's no equivalent no-op shortcut to check first.
+                playing_cap = rule.max_playing_teams_for_window(window)
+                if playing_cap is not None:
+                    playing_contributions = [
+                        fixture_vars.teams_playing(fixture, d, team_set)
+                        for fixture, d in window_fixture_dates
+                    ]
+                    if playing_contributions:
+                        model.add(
+                            cp_model.LinearExpr.Sum(playing_contributions)
+                            <= playing_cap
+                        )
 
 
 def _add_fixed_fixtures_constraints(
@@ -730,6 +853,7 @@ def _build_model(params: Parameters) -> tuple[cp_model.CpModel, _FixtureVars]:
             "Add a usable date, or exclude the fixture."
         )
 
+    _add_one_match_per_team_per_date_constraints(model, fixture_vars)
     _add_home_dates_used_constraints(model, params.home_dates_used, fixture_vars)
     _add_match_count_limit_constraints(model, params.match_count_limits, fixture_vars)
     _add_fixed_fixtures_constraints(model, params.fixed_fixtures, fixture_vars)

--- a/genfixtures.py
+++ b/genfixtures.py
@@ -164,7 +164,7 @@ for _team in _TEAMS:
 _MATCH_COUNT_LIMITS = [
     fmodel.MatchCountLimit(
         teams=club_teams,
-        max=1,
+        max_matches=1,
         time_window_days=_MIN_MATCH_GAP_DAYS,
         apply_per=fmodel.ApplyPer.EACH_TEAM,
     )
@@ -172,7 +172,7 @@ _MATCH_COUNT_LIMITS = [
 ] + [
     fmodel.MatchCountLimit(
         teams=club_teams,
-        max=2,
+        max_matches=2,
         venue_scope=fmodel.VenueScope.HOME,
     )
     for club_teams in _TEAMS_BY_CLUB.values()

--- a/model_test.py
+++ b/model_test.py
@@ -62,14 +62,16 @@ def _params(
             limits.append(
                 fmodel.MatchCountLimit(
                     teams=club_teams,
-                    max=1,
+                    max_matches=1,
                     time_window_days=min_gap_days,
                     apply_per=fmodel.ApplyPer.EACH_TEAM,
                 )
             )
     for club, (scope, n) in (max_concurrent_matches or {}).items():
         limits.append(
-            fmodel.MatchCountLimit(teams=teams_by_club[club], max=n, venue_scope=scope)
+            fmodel.MatchCountLimit(
+                teams=teams_by_club[club], max_matches=n, venue_scope=scope
+            )
         )
     return fmodel.Parameters(match_count_limits=limits, **kwargs)
 
@@ -323,8 +325,75 @@ class TestSolveStats(unittest.TestCase):
             fmodel.solve(params)
 
 
+class TestOneMatchPerTeamPerDate(unittest.TestCase):
+    """A team -- home or away -- may never be scheduled for more than one match on
+    the same date: physically its players can't be in two places at once. This is
+    unconditional (no MatchCountLimit or other spec field is involved), so it holds
+    even when nothing else in Parameters would otherwise prevent the clash.
+    """
+
+    def test_forbids_a_team_playing_home_and_away_the_same_day(self) -> None:
+        """A1 and X1 (division of just the two of them) share a single common
+        date -- both A1 v X1 (A1 home, X1 away) and X1 v A1 (A1 away, X1 home) only
+        have that one date available, so A1 (and X1) would need to play both there.
+        Forbidden, regardless of home/away sidedness."""
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        x1 = fmodel.Team(division=1, club="X", index=1)
+        shared_date = date(2025, 1, 1)
+        params = _params(
+            teams=[a1, x1],
+            home_dates={"A": [shared_date], "X": [shared_date]},
+            unavailable_away_dates={"A": [], "X": []},
+        )
+        with self.assertRaisesRegex(ValueError, "No solution found"):
+            fmodel.solve(params)
+
+    def test_allows_the_same_pair_to_meet_twice_on_different_dates(self) -> None:
+        """The same setup, but with a second date free for one of the two legs --
+        solves, confirming the rule only forbids sharing a date, not meeting twice
+        at all."""
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        x1 = fmodel.Team(division=1, club="X", index=1)
+        params = _params(
+            teams=[a1, x1],
+            home_dates={
+                "A": [date(2025, 1, 1)],
+                "X": [date(2025, 1, 8)],
+            },
+            unavailable_away_dates={"A": [], "X": []},
+        )
+        fixtures = list(fmodel.solve(params).fixtures)
+        self.assertEqual(len(fixtures), 2)
+        self.assertEqual(
+            {sf.date for sf in fixtures}, {date(2025, 1, 1), date(2025, 1, 8)}
+        )
+
+    def test_forbids_two_different_opponents_on_the_same_date(self) -> None:
+        """A1 hosts both X1 and Y1, but only has one home date -- A1 can't play
+        both matches there, even though they're against different opponents (so no
+        MatchCountLimit -- which only ever names A1's own club's teams in a venue
+        capacity/keep-apart rule -- would naturally catch this). X1 and Y1 each get
+        two home dates of their own, so this isolates A1's clash as the only cause
+        of infeasibility."""
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        x1 = fmodel.Team(division=1, club="X", index=1)
+        y1 = fmodel.Team(division=1, club="Y", index=1)
+        shared_date = date(2025, 1, 1)
+        params = _params(
+            teams=[a1, x1, y1],
+            home_dates={
+                "A": [shared_date],
+                "X": [date(2025, 3, 1), date(2025, 3, 8)],
+                "Y": [date(2025, 4, 1), date(2025, 4, 8)],
+            },
+            unavailable_away_dates={"A": [], "X": [], "Y": []},
+        )
+        with self.assertRaisesRegex(ValueError, "No solution found"):
+            fmodel.solve(params)
+
+
 class TestSharedLimitAtOrAboveGroupSize(unittest.TestCase):
-    """A shared-budget MatchCountLimit (apply_per=ACROSS_TEAMS) with max >= the number
+    """A shared-budget MatchCountLimit (apply_per=ACROSS_TEAMS) with max_matches >= the number
     of teams it covers can never bind -- the teams can't play more simultaneous
     matches than there are of them -- so the solver skips it (this is how a
     venue capacity stated above a club's team count stays a no-op). See issue #22.
@@ -336,21 +405,25 @@ class TestSharedLimitAtOrAboveGroupSize(unittest.TestCase):
         ]
         params = fmodel.Parameters(
             teams=teams,
-            home_dates={"A": [date(2025, 1, 1)]},
+            # Two home dates, not one: A1 v A2 and A2 v A1 both need A1 to host,
+            # and a team may only play once per date (see
+            # _add_one_match_per_team_per_date_constraints), so with only one date
+            # they couldn't both be scheduled regardless of this test's own limit.
+            home_dates={"A": [date(2025, 1, 1), date(2025, 1, 8)]},
             unavailable_away_dates={"A": []},
             match_count_limits=[
                 fmodel.MatchCountLimit(
-                    teams=teams, max=limit, venue_scope=fmodel.VenueScope.HOME
+                    teams=teams, max_matches=limit, venue_scope=fmodel.VenueScope.HOME
                 )
             ],
         )
         return list(fmodel.solve(params).fixtures)
 
     def test_limit_at_group_size_does_not_bind(self) -> None:
-        # 2 teams, one shared home date, limit 2: both home legs (A1 v A2 and
-        # A2 v A1) land on that date -- the limit is a no-op, so this solves.
+        # 2 teams, limit 2 (== group size): both home legs (A1 v A2 and A2 v A1)
+        # solve -- the limit is a no-op, so it doesn't get in the way of whatever
+        # else (here, the one-match-per-team-per-date rule) decides their dates.
         fixtures = self._solve(num_teams=2, limit=2)
-        self.assertEqual({sf.date for sf in fixtures}, {date(2025, 1, 1)})
         self.assertEqual(len(fixtures), 2)
 
     def test_limit_above_group_size_does_not_bind(self) -> None:
@@ -367,7 +440,7 @@ class TestSharedLimitAtOrAboveGroupSize(unittest.TestCase):
             unavailable_away_dates={"A": []},
             match_count_limits=[
                 fmodel.MatchCountLimit(
-                    teams=teams, max=2, venue_scope=fmodel.VenueScope.HOME
+                    teams=teams, max_matches=2, venue_scope=fmodel.VenueScope.HOME
                 )
             ],
         )
@@ -1226,14 +1299,14 @@ class TestMatchCountLimits(unittest.TestCase):
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=2, club="A", index=2)
         self.assertEqual(
-            fmodel.MatchCountLimit(teams=[a1, a2], max=1).time_window_days, 1
+            fmodel.MatchCountLimit(teams=[a1, a2], max_matches=1).time_window_days, 1
         )
 
     def test_venue_scope_defaults_to_all(self) -> None:
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=2, club="A", index=2)
         self.assertEqual(
-            fmodel.MatchCountLimit(teams=[a1, a2], max=1).venue_scope,
+            fmodel.MatchCountLimit(teams=[a1, a2], max_matches=1).venue_scope,
             fmodel.VenueScope.ALL,
         )
 
@@ -1261,7 +1334,7 @@ class TestMatchCountLimits(unittest.TestCase):
                 "X": _home_limit(2),
             },
             min_gap_days=7,
-            match_count_limits=[fmodel.MatchCountLimit(teams=[a1, a2], max=1)],
+            match_count_limits=[fmodel.MatchCountLimit(teams=[a1, a2], max_matches=1)],
         )
         fixtures = list(fmodel.solve(params).fixtures)
         a1_home_date = next(sf.date for sf in fixtures if sf.fixture.home_team == a1)
@@ -1288,7 +1361,7 @@ class TestMatchCountLimits(unittest.TestCase):
                 "X": _home_limit(2),
             },
             min_gap_days=7,
-            match_count_limits=[fmodel.MatchCountLimit(teams=[a1, a2], max=1)],
+            match_count_limits=[fmodel.MatchCountLimit(teams=[a1, a2], max_matches=1)],
         )
         with self.assertRaises(ValueError):
             fmodel.solve(params)
@@ -1315,13 +1388,13 @@ class TestMatchCountLimits(unittest.TestCase):
                 "X": _home_limit(2),
             },
             min_gap_days=7,
-            match_count_limits=[fmodel.MatchCountLimit(teams=[a1, a2], max=1)],
+            match_count_limits=[fmodel.MatchCountLimit(teams=[a1, a2], max_matches=1)],
         )
         with self.assertRaises(ValueError):
             fmodel.solve(params)
 
     def test_time_window_days_forbids_shorter_gaps(self) -> None:
-        """With time_window_days=3 and max=1, A1 and A2's home matches can't share
+        """With time_window_days=3 and max_matches=1, A1 and A2's home matches can't share
         any 3-consecutive-day window -- of A's three candidate dates (Jan 1, 3, 10),
         the only forbidden pairing is Jan 1 / Jan 3 (2 days apart), so the solver
         must pick a pairing that involves Jan 10. (X's two home dates, for A1/A2's
@@ -1344,7 +1417,9 @@ class TestMatchCountLimits(unittest.TestCase):
             },
             min_gap_days=7,
             match_count_limits=[
-                fmodel.MatchCountLimit(teams=[a1, a2], max=1, time_window_days=3)
+                fmodel.MatchCountLimit(
+                    teams=[a1, a2], max_matches=1, time_window_days=3
+                )
             ],
         )
         fixtures = list(fmodel.solve(params).fixtures)
@@ -1355,7 +1430,7 @@ class TestMatchCountLimits(unittest.TestCase):
     def test_time_window_days_allows_exact_gap(self) -> None:
         """time_window_days=N counts a run of N consecutive days, not a gap between
         endpoints: two dates exactly N days apart fall in separate windows. With
-        time_window_days=7, max=1 and A's only two home dates exactly a week apart
+        time_window_days=7, max_matches=1 and A's only two home dates exactly a week apart
         (Jan 1 and Jan 8), A1 and A2 must take one each -- the schedule stays
         feasible. An off-by-one that put a 7-day span in one window would make this
         infeasible."""
@@ -1376,7 +1451,9 @@ class TestMatchCountLimits(unittest.TestCase):
             },
             min_gap_days=7,
             match_count_limits=[
-                fmodel.MatchCountLimit(teams=[a1, a2], max=1, time_window_days=7)
+                fmodel.MatchCountLimit(
+                    teams=[a1, a2], max_matches=1, time_window_days=7
+                )
             ],
         )
         fixtures = list(fmodel.solve(params).fixtures)
@@ -1401,7 +1478,7 @@ class TestMatchCountLimits(unittest.TestCase):
             max_concurrent_matches={"A": _home_limit(1)},
             min_gap_days=7,
             excluded_fixtures=[fmodel.Fixture(home_team=a2, away_team=a1)],
-            match_count_limits=[fmodel.MatchCountLimit(teams=[a1, a2], max=1)],
+            match_count_limits=[fmodel.MatchCountLimit(teams=[a1, a2], max_matches=1)],
         )
         fixtures = list(fmodel.solve(params).fixtures)
         self.assertEqual(
@@ -1437,7 +1514,7 @@ class TestMatchCountLimits(unittest.TestCase):
             min_gap_days=7,
             match_count_limits=[
                 fmodel.MatchCountLimit(
-                    teams=[a1, a2], max=1, venue_scope=fmodel.VenueScope.AWAY
+                    teams=[a1, a2], max_matches=1, venue_scope=fmodel.VenueScope.AWAY
                 )
             ],
         )
@@ -1467,7 +1544,7 @@ class TestMatchCountLimits(unittest.TestCase):
             min_gap_days=7,
             match_count_limits=[
                 fmodel.MatchCountLimit(
-                    teams=[a1, a2], max=1, venue_scope=fmodel.VenueScope.AWAY
+                    teams=[a1, a2], max_matches=1, venue_scope=fmodel.VenueScope.AWAY
                 )
             ],
         )
@@ -1496,7 +1573,7 @@ class TestMatchCountLimits(unittest.TestCase):
             min_gap_days=7,
             match_count_limits=[
                 fmodel.MatchCountLimit(
-                    teams=[a1, a2], max=1, venue_scope=fmodel.VenueScope.HOME
+                    teams=[a1, a2], max_matches=1, venue_scope=fmodel.VenueScope.HOME
                 )
             ],
         )
@@ -1526,7 +1603,7 @@ class TestMatchCountLimits(unittest.TestCase):
             min_gap_days=7,
             match_count_limits=[
                 fmodel.MatchCountLimit(
-                    teams=[a1, a2], max=1, venue_scope=fmodel.VenueScope.HOME
+                    teams=[a1, a2], max_matches=1, venue_scope=fmodel.VenueScope.HOME
                 )
             ],
         )
@@ -1559,7 +1636,7 @@ class TestMatchCountLimits(unittest.TestCase):
             ],
             match_count_limits=[
                 fmodel.MatchCountLimit(
-                    teams=[a1, a2, a3], max=limit, time_window_days=30
+                    teams=[a1, a2, a3], max_matches=limit, time_window_days=30
                 )
             ],
         )
@@ -1576,6 +1653,226 @@ class TestMatchCountLimits(unittest.TestCase):
             fmodel.solve(self._three_a_teams_in_one_window(limit=3)).fixtures
         )
         self.assertEqual(len(fixtures), 3)
+
+
+class TestMaxPlayingTeams(unittest.TestCase):
+    """Test cases for MatchCountLimit.max_playing_teams: unlike max_matches, which
+    counts matches, this counts the *distinct* teams from `teams` that play (home or
+    away) within a window. A same-club derby is one match (one candidate variable)
+    but puts two of the club's own teams on to play, so it counts as 1 towards
+    max_matches but 2 towards max_playing_teams -- guarding against exactly the case
+    a plain max_matches cap misses: N matches, one of them an internal derby,
+    needing N+1 teams' worth of players.
+    """
+
+    def test_internal_derby_alone_blocked_by_a_playing_teams_cap_of_one(self) -> None:
+        """A single derby match between two of a club's own teams already needs two
+        of them playing -- so a max_playing_teams: 1 cap makes every candidate date
+        infeasible, even though it's only one match (well within max_matches). Unlike
+        a plain max_matches: 0 (which prunes the candidate variables entirely, see
+        MatchCountLimit.forbids), this isn't detectable per-candidate -- it only
+        shows up as a genuine solver infeasibility."""
+        h1 = fmodel.Team(division=1, club="H", index=1)
+        h2 = fmodel.Team(division=1, club="H", index=2)
+        params = _params(
+            teams=[h1, h2],
+            home_dates={"H": [date(2025, 1, 1), date(2025, 1, 8)]},
+            unavailable_away_dates={"H": []},
+            match_count_limits=[
+                fmodel.MatchCountLimit(
+                    teams=[h1, h2],
+                    max_matches=2,
+                    max_playing_teams=1,
+                    venue_scope=fmodel.VenueScope.HOME,
+                )
+            ],
+        )
+        with self.assertRaisesRegex(ValueError, "INFEASIBLE"):
+            fmodel.solve(params)
+
+    def test_venue_capacity_spreads_an_internal_derby_off_a_full_night(self) -> None:
+        """Mirrors the motivating case: a club hosts up to 3 matches a night
+        (max_matches: 3) but only has 3 teams' worth of players to field
+        (max_playing_teams: 3). Two of its teams (H3, H4) are only free to host on
+        one shared date; adding either leg of the H1-v-H2 derby there too would need
+        a 4th team's worth of players, so the solver must push both legs onto H1/H2's
+        other two shared dates instead (one leg per date, since -- regardless of this
+        cap -- a team may only play once per date), even though max_matches alone
+        (2 + 1 = 3) would have allowed combining a leg with H3/H4."""
+        h1 = fmodel.Team(division=1, club="H", index=1)
+        h2 = fmodel.Team(division=1, club="H", index=2)
+        h3 = fmodel.Team(division=2, club="H", index=3)
+        h4 = fmodel.Team(division=3, club="H", index=4)
+        x1 = fmodel.Team(division=2, club="X", index=1)
+        y1 = fmodel.Team(division=3, club="Y", index=1)
+        shared_date = date(2025, 1, 1)
+        params = _params(
+            teams=[h1, h2, h3, h4, x1, y1],
+            home_dates={
+                "H": [shared_date, date(2025, 1, 8), date(2025, 1, 15)],
+                "X": [date(2025, 3, 1)],
+                "Y": [date(2025, 3, 8)],
+            },
+            unavailable_away_dates={"H": [], "X": [], "Y": []},
+            team_home_dates={h3: [shared_date], h4: [shared_date]},
+            match_count_limits=[
+                fmodel.MatchCountLimit(
+                    teams=[h1, h2, h3, h4],
+                    max_matches=3,
+                    max_playing_teams=3,
+                    venue_scope=fmodel.VenueScope.HOME,
+                )
+            ],
+        )
+        fixtures = list(fmodel.solve(params).fixtures)
+        derby_dates = {
+            sf.date
+            for sf in fixtures
+            if {sf.fixture.home_team, sf.fixture.away_team} == {h1, h2}
+        }
+        self.assertNotIn(shared_date, derby_dates)
+
+    def test_cap_at_or_above_group_size_is_a_no_op(self) -> None:
+        """A max_playing_teams cap that can never bind (>= the group size) leaves the
+        derby free to land on either date -- unlike the test above, shared_date is
+        not excluded."""
+        h1 = fmodel.Team(division=1, club="H", index=1)
+        h2 = fmodel.Team(division=1, club="H", index=2)
+        params = _params(
+            teams=[h1, h2],
+            home_dates={"H": [date(2025, 1, 1), date(2025, 1, 8)]},
+            unavailable_away_dates={"H": []},
+            match_count_limits=[
+                fmodel.MatchCountLimit(
+                    teams=[h1, h2],
+                    max_matches=2,
+                    max_playing_teams=2,
+                    venue_scope=fmodel.VenueScope.HOME,
+                )
+            ],
+        )
+        fixtures = list(fmodel.solve(params).fixtures)
+        self.assertEqual(len(fixtures), 2)
+
+    def test_zero_forbids_the_candidate_up_front_like_max_matches_zero(self) -> None:
+        """Unlike a cap of 1 or more, max_playing_teams: 0 is an up-front bar: any
+        counted match puts at least one team from `teams` on to play, so it's
+        detectable per-candidate (see MatchCountLimit.forbids) rather than only
+        showing up as a solver infeasibility."""
+        h1 = fmodel.Team(division=1, club="H", index=1)
+        h2 = fmodel.Team(division=1, club="H", index=2)
+        fix = fmodel.Fixture(home_team=h1, away_team=h2)
+        blocked = fmodel.MatchCountLimit(
+            teams=[h1, h2], max_matches=2, max_playing_teams=0
+        )
+        self.assertTrue(blocked.forbids(fix, date(2025, 1, 1)))
+
+    def test_override_lifts_the_cap_on_a_specific_date(self) -> None:
+        """max_playing_teams_overrides replaces the base cap on that one date only
+        -- mirroring max_matches_overrides. A base cap of 1 blocks either derby leg
+        everywhere on its own (each alone already needs 2 teams playing), but two
+        overridden dates raise it to 2 -- enough for one leg apiece (a team may only
+        play once per date, so the two legs can't share even an overridden date) --
+        while a third, un-overridden date stays governed by the base cap and so is
+        left unused."""
+        h1 = fmodel.Team(division=1, club="H", index=1)
+        h2 = fmodel.Team(division=1, club="H", index=2)
+        overridden_date_1 = date(2025, 1, 1)
+        overridden_date_2 = date(2025, 1, 8)
+        plain_date = date(2025, 1, 15)
+        params = _params(
+            teams=[h1, h2],
+            home_dates={"H": [overridden_date_1, overridden_date_2, plain_date]},
+            unavailable_away_dates={"H": []},
+            match_count_limits=[
+                fmodel.MatchCountLimit(
+                    teams=[h1, h2],
+                    max_matches=2,
+                    max_playing_teams=1,
+                    max_playing_teams_overrides={
+                        overridden_date_1: 2,
+                        overridden_date_2: 2,
+                    },
+                    venue_scope=fmodel.VenueScope.HOME,
+                )
+            ],
+        )
+        fixtures = list(fmodel.solve(params).fixtures)
+        derby_dates = {
+            sf.date
+            for sf in fixtures
+            if {sf.fixture.home_team, sf.fixture.away_team} == {h1, h2}
+        }
+        self.assertEqual(derby_dates, {overridden_date_1, overridden_date_2})
+
+    def test_overrides_reject_non_default_time_window_days(self) -> None:
+        """Unlike max_playing_teams itself (see the multi-day-window tests below,
+        which show it's meaningful over a wider window), max_playing_teams_overrides
+        is still tied to a single date: an override names one specific date, which
+        only lines up with one specific window when time_window_days is 1."""
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        with self.assertRaises(ValueError):
+            fmodel.MatchCountLimit(
+                teams=[a1],
+                max_matches=1,
+                time_window_days=7,
+                max_playing_teams_overrides={date(2025, 1, 1): 1},
+            )
+
+    def test_multi_day_window_counts_a_repeated_pair_twice(self) -> None:
+        """Over a multi-day window, the same pair meeting twice counts towards
+        max_playing_teams once per match, not once per team: two internal H1-v-H2
+        matches within 7 days of each other would need 4 teams'-worth of players in
+        that week (2 matches x 2 teams each), exceeding a cap of 3, even though only
+        2 distinct teams are ever involved. H1 and H2 have two close-together dates
+        and one far-apart one; the solver must use the far one for at least one leg
+        to keep any 7-day window's tally at or under 3."""
+        h1 = fmodel.Team(division=1, club="H", index=1)
+        h2 = fmodel.Team(division=1, club="H", index=2)
+        close_dates = {date(2025, 1, 1), date(2025, 1, 3)}
+        far_date = date(2025, 1, 20)
+        params = _params(
+            teams=[h1, h2],
+            home_dates={"H": sorted(close_dates | {far_date})},
+            unavailable_away_dates={"H": []},
+            match_count_limits=[
+                fmodel.MatchCountLimit(
+                    teams=[h1, h2],
+                    max_matches=None,
+                    max_playing_teams=3,
+                    time_window_days=7,
+                )
+            ],
+        )
+        fixtures = list(fmodel.solve(params).fixtures)
+        derby_dates = {sf.date for sf in fixtures}
+        self.assertEqual(len(fixtures), 2)
+        self.assertFalse(derby_dates <= close_dates)
+
+    def test_date_ranges_counts_a_repeated_pair_twice(self) -> None:
+        """The same property, using an explicit date_ranges window instead of a
+        rolling time_window_days one."""
+        h1 = fmodel.Team(division=1, club="H", index=1)
+        h2 = fmodel.Team(division=1, club="H", index=2)
+        in_range_dates = {date(2025, 1, 1), date(2025, 1, 3)}
+        out_of_range_date = date(2025, 1, 20)
+        params = _params(
+            teams=[h1, h2],
+            home_dates={"H": sorted(in_range_dates | {out_of_range_date})},
+            unavailable_away_dates={"H": []},
+            match_count_limits=[
+                fmodel.MatchCountLimit(
+                    teams=[h1, h2],
+                    max_matches=None,
+                    max_playing_teams=3,
+                    date_ranges=(fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 7)),),
+                )
+            ],
+        )
+        fixtures = list(fmodel.solve(params).fixtures)
+        derby_dates = {sf.date for sf in fixtures}
+        self.assertEqual(len(fixtures), 2)
+        self.assertFalse(derby_dates <= in_range_dates)
 
 
 class TestMatchCountLimitDateRanges(unittest.TestCase):
@@ -1614,13 +1911,13 @@ class TestMatchCountLimitDateRanges(unittest.TestCase):
             ],
             match_count_limits=[
                 fmodel.MatchCountLimit(
-                    teams=[a1, a2, a3], max=limit, date_ranges=date_ranges
+                    teams=[a1, a2, a3], max_matches=limit, date_ranges=date_ranges
                 )
             ],
         )
 
     def test_cap_binds_inside_the_range_only(self) -> None:
-        """The range covers January; A also has two February home dates. max=1
+        """The range covers January; A also has two February home dates. max_matches=1
         inside the range forces at least two of the three home legs into
         February, leaving at most one in January."""
         params = self._three_a_teams(
@@ -1640,7 +1937,7 @@ class TestMatchCountLimitDateRanges(unittest.TestCase):
 
     def test_infeasible_when_range_cap_leaves_nowhere(self) -> None:
         """Three in-range home dates plus one outside; with a one-a-night venue
-        and max=1 inside the range, only two of the three required home legs can
+        and max_matches=1 inside the range, only two of the three required home legs can
         be placed -> infeasible."""
         params = self._three_a_teams(
             a_home_dates=[
@@ -1676,7 +1973,7 @@ class TestMatchCountLimitDateRanges(unittest.TestCase):
             fmodel.solve(params)
 
     def test_max_zero_forces_matches_out_of_the_range(self) -> None:
-        """max=0 bars every counted match inside the range: A1's one home leg,
+        """max_matches=0 bars every counted match inside the range: A1's one home leg,
         with an in-range and an out-of-range home date available, is forced onto
         the out-of-range one."""
         a1 = fmodel.Team(division=1, club="A", index=1)
@@ -1690,7 +1987,7 @@ class TestMatchCountLimitDateRanges(unittest.TestCase):
             match_count_limits=[
                 fmodel.MatchCountLimit(
                     teams=[a1],
-                    max=0,
+                    max_matches=0,
                     date_ranges=(
                         fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31)),
                     ),
@@ -1722,7 +2019,7 @@ class TestMatchCountLimitDateRanges(unittest.TestCase):
             match_count_limits=[
                 fmodel.MatchCountLimit(
                     teams=[a1],
-                    max=1,
+                    max_matches=1,
                     date_ranges=(
                         fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31)),
                     ),
@@ -1737,18 +2034,18 @@ class TestMatchCountLimitDateRanges(unittest.TestCase):
         with self.assertRaises(ValueError):
             fmodel.MatchCountLimit(
                 teams=[a1],
-                max=1,
+                max_matches=1,
                 time_window_days=7,
                 date_ranges=(fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31)),),
             )
 
-    def test_rejects_date_max_overrides(self) -> None:
+    def test_rejects_max_matches_overrides(self) -> None:
         a1 = fmodel.Team(division=1, club="A", index=1)
         with self.assertRaises(ValueError):
             fmodel.MatchCountLimit(
                 teams=[a1],
-                max=1,
-                date_max_overrides={date(2025, 1, 1): 1},
+                max_matches=1,
+                max_matches_overrides={date(2025, 1, 1): 1},
                 date_ranges=(fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31)),),
             )
 
@@ -1763,7 +2060,7 @@ class TestMatchCountLimitDateRanges(unittest.TestCase):
         self.assertNotIn(date(2025, 2, 1), rng)
 
     def test_max_zero_prunes_candidate_var(self) -> None:
-        """A max: 0 limit makes its candidates a certain zero, so _build_model
+        """A max_matches: 0 limit makes its candidates a certain zero, so _build_model
         never creates a decision variable for them -- observable because a
         fixed_fixtures entry pinned onto such a date then fails with the
         descriptive 'not schedulable on that date' error (the fixture is still
@@ -1787,7 +2084,7 @@ class TestMatchCountLimitDateRanges(unittest.TestCase):
             match_count_limits=[
                 fmodel.MatchCountLimit(
                     teams=[a1, x1],
-                    max=0,
+                    max_matches=0,
                     date_ranges=(
                         fmodel.DateRange(date(2025, 12, 22), date(2026, 1, 4)),
                     ),
@@ -1804,15 +2101,18 @@ class TestMatchCountLimitDateRanges(unittest.TestCase):
         away_fix = fmodel.Fixture(home_team=x1, away_team=a1)
         rng = fmodel.DateRange(date(2025, 12, 22), date(2026, 1, 4))
         away_only = fmodel.MatchCountLimit(
-            teams=[a1], max=0, venue_scope=fmodel.VenueScope.AWAY, date_ranges=(rng,)
+            teams=[a1],
+            max_matches=0,
+            venue_scope=fmodel.VenueScope.AWAY,
+            date_ranges=(rng,),
         )
         # AWAY scope: bars a1's away fixture in the range, not its home one.
         self.assertTrue(away_only.forbids(away_fix, date(2025, 12, 29)))
         self.assertFalse(away_only.forbids(home_fix, date(2025, 12, 29)))
         # Outside the range: not forbidden.
         self.assertFalse(away_only.forbids(away_fix, date(2026, 1, 5)))
-        # max > 0: never an up-front bar.
-        keep = fmodel.MatchCountLimit(teams=[a1], max=1, date_ranges=(rng,))
+        # max_matches > 0: never an up-front bar.
+        keep = fmodel.MatchCountLimit(teams=[a1], max_matches=1, date_ranges=(rng,))
         self.assertFalse(keep.forbids(away_fix, date(2025, 12, 29)))
 
 
@@ -1840,7 +2140,7 @@ class TestPerClubGap(unittest.TestCase):
             match_count_limits=[
                 fmodel.MatchCountLimit(
                     teams=teams_by_club[club],
-                    max=1,
+                    max_matches=1,
                     time_window_days=gap,
                     apply_per=fmodel.ApplyPer.EACH_TEAM,
                 )
@@ -1869,8 +2169,8 @@ class TestPerClubGap(unittest.TestCase):
 
 
 class TestSharedHomeLimitNullAndOverrides(unittest.TestCase):
-    """A shared home-scope MatchCountLimit with max=None imposes no cap; a
-    `date_max_overrides` entry of None lifts it for that one date, an int replaces it.
+    """A shared home-scope MatchCountLimit with max_matches=None imposes no cap; a
+    `max_matches_overrides` entry of None lifts it for that one date, an int replaces it.
     """
 
     def test_finite_default_makes_it_infeasible(self) -> None:
@@ -1942,9 +2242,9 @@ class TestSharedHomeLimitNullAndOverrides(unittest.TestCase):
             match_count_limits=(
                 fmodel.MatchCountLimit(
                     teams=[a1, a2],
-                    max=1,
+                    max_matches=1,
                     venue_scope=fmodel.VenueScope.HOME,
-                    date_max_overrides={date(2025, 1, 1): None},
+                    max_matches_overrides={date(2025, 1, 1): None},
                 ),
             ),
             min_gap_days=7,
@@ -1984,12 +2284,12 @@ class TestSharedLimitAwayAndAllScopes(unittest.TestCase):
 
     def _any(self, limit: int | None) -> fmodel.MatchCountLimit:
         return fmodel.MatchCountLimit(
-            teams=[], max=limit, venue_scope=fmodel.VenueScope.ALL
+            teams=[], max_matches=limit, venue_scope=fmodel.VenueScope.ALL
         )
 
     def _away(self, limit: int | None) -> fmodel.MatchCountLimit:
         return fmodel.MatchCountLimit(
-            teams=[], max=limit, venue_scope=fmodel.VenueScope.AWAY
+            teams=[], max_matches=limit, venue_scope=fmodel.VenueScope.AWAY
         )
 
     def test_any_scope_limit_blocks_two_matches_on_one_date(self) -> None:

--- a/report_test.py
+++ b/report_test.py
@@ -57,7 +57,7 @@ club_constraints:
     match_count_limits:
       - override_key: venue-capacity
         venue_scope: home
-        max: 1
+        max_matches: 1
   albany:
     home_dates: [2025-09-01, 2025-09-29]
   hackney:

--- a/runs/2026-27/draft1/solution.yaml
+++ b/runs/2026-27/draft1/solution.yaml
@@ -500,16 +500,16 @@ fixtures:
 - home: metropolitan-1
   away: kings-head-1
   date: 2027-06-10
-spec_checksum: sha256:7fe649793337624a4ce2d700569729d4bdb2e4658f5951305152ad214b498da8
+spec_checksum: sha256:3fbda3975367b2c08bc4c61689004bc4d1df2fcdf22b607f4f91229101aabd4d
 stats:
   model: |-
-    satisfaction model '': (model_fingerprint: 0xb1889413f58d408d)
+    satisfaction model '': (model_fingerprint: 0x975b3c8a13757e13)
     #Variables: 3'176 (3'003 primary variables)
       - 3'176 Booleans in [0,1]
     #kLinear1: 6
-    #kLinear2: 168
-    #kLinear3: 89
-    #kLinearN: 2'307 (#enforced: 50) (#terms: 29'591)
+    #kLinear2: 556
+    #kLinear3: 229
+    #kLinearN: 2'972 (#enforced: 50) (#terms: 33'830)
   solve: |
     CpSolverResponse summary:
     status: OPTIMAL
@@ -518,13 +518,13 @@ stats:
     integers: 1466
     booleans: 3028
     conflicts: 0
-    branches: 4760
-    propagations: 122409
-    integer_propagations: 60695
+    branches: 5838
+    propagations: 149180
+    integer_propagations: 77294
     restarts: 0
     lp_iterations: 0
-    walltime: 0.141716
-    usertime: 0.141716
-    deterministic_time: 0.155467
+    walltime: 0.135616
+    usertime: 0.135616
+    deterministic_time: 0.164457
     gap_integral: 0
     solution_fingerprint: 0xbfb973bb26eeac8c

--- a/runs/2026-27/draft1/solution.yaml
+++ b/runs/2026-27/draft1/solution.yaml
@@ -500,16 +500,16 @@ fixtures:
 - home: metropolitan-1
   away: kings-head-1
   date: 2027-06-10
-spec_checksum: sha256:3fbda3975367b2c08bc4c61689004bc4d1df2fcdf22b607f4f91229101aabd4d
+spec_checksum: sha256:7fe649793337624a4ce2d700569729d4bdb2e4658f5951305152ad214b498da8
 stats:
   model: |-
-    satisfaction model '': (model_fingerprint: 0x975b3c8a13757e13)
+    satisfaction model '': (model_fingerprint: 0xb1889413f58d408d)
     #Variables: 3'176 (3'003 primary variables)
       - 3'176 Booleans in [0,1]
     #kLinear1: 6
-    #kLinear2: 556
-    #kLinear3: 229
-    #kLinearN: 2'972 (#enforced: 50) (#terms: 33'830)
+    #kLinear2: 168
+    #kLinear3: 89
+    #kLinearN: 2'307 (#enforced: 50) (#terms: 29'591)
   solve: |
     CpSolverResponse summary:
     status: OPTIMAL
@@ -518,13 +518,13 @@ stats:
     integers: 1466
     booleans: 3028
     conflicts: 0
-    branches: 5838
-    propagations: 149180
-    integer_propagations: 77294
+    branches: 4760
+    propagations: 122409
+    integer_propagations: 60695
     restarts: 0
     lp_iterations: 0
-    walltime: 0.135616
-    usertime: 0.135616
-    deterministic_time: 0.164457
+    walltime: 0.141716
+    usertime: 0.141716
+    deterministic_time: 0.155467
     gap_integral: 0
     solution_fingerprint: 0xbfb973bb26eeac8c

--- a/runs/2026-27/draft1/spec.yaml
+++ b/runs/2026-27/draft1/spec.yaml
@@ -265,21 +265,21 @@ club_constraints:
       - override_key: weekly-gap
         apply_per: each_team
         time_window_days: 7
-        max: 1
+        max_matches: 1
       # Spec-wide venue capacity: one home match a night. Clubs with a bigger
       # venue replace this via 'override_key: venue-capacity'.
       - override_key: venue-capacity
         venue_scope: home
-        max: 1
+        max_matches: 1
       # Christmas/New Year: no club schedules any fixture - home or away - in the
       # fortnight from Monday 2026-12-21 through Sunday 2027-01-03, on the
-      # assumption nobody wants to play then. A whole-club max: 0 date_ranges
+      # assumption nobody wants to play then. A whole-club max_matches: 0 date_ranges
       # default blocks it everywhere, so individual clubs don't repeat it in
       # their own unavailable_away_dates; a club could opt back in by overriding
       # 'no-play-dates'. (Home dates a club lists inside the range just go
       # unused; the weekend dates in the range never carry fixtures anyway.)
       - override_key: no-play-dates
-        max: 0
+        max_matches: 0
         date_ranges:
           - { start_date: "2026-12-21", end_date: "2027-01-03" }
   hendon:
@@ -327,31 +327,31 @@ club_constraints:
       # the spec-wide one-a-night default).
       - override_key: venue-capacity
         venue_scope: home
-        max: 3
+        max_matches: 3
       # Hendon 1 and Hendon 2 (both division 1) draw on the same players, so keep
       # their matches at least a week apart (matches exactly 7 days apart are
       # still allowed).
       - teams: [hendon-1, hendon-2]
         time_window_days: 7
-        max: 1
+        max_matches: 1
       # London Chess Classic (24 Nov - 7 Dec 2026): no Hendon 1 or Hendon 2
       # match, home or away, during the Classic.
       - teams: [hendon-1, hendon-2]
-        max: 0
+        max_matches: 0
         date_ranges:
           - { start_date: "2026-11-24", end_date: "2026-12-07" }
       # Cap Hendon's overall load: no more than 3 matches (home or away, any
       # team) in any 7-consecutive-day period. teams defaults to all of Hendon's
       # teams.
       - time_window_days: 7
-        max: 3
+        max_matches: 3
       # No matches (even away matches) the week we have a seasonal break for Christmas
-      - max: 0
+      - max_matches: 0
         date_ranges:
           - { start_date: "2026-12-14", end_date: "2026-12-20" }
       # Camden school-holiday weeks - Andrew wants Hendon's fixture load kept
       # down across these.
-      - max: 1
+      - max_matches: 1
         date_ranges:
           - { start_date: "2026-10-26", end_date: "2026-11-01" } # Oct half term
           - { start_date: "2027-02-15", end_date: "2027-02-21" } # Feb half term
@@ -360,7 +360,7 @@ club_constraints:
           - { start_date: "2027-04-05", end_date: "2027-04-11" } # Easter
           - { start_date: "2027-05-31", end_date: "2027-06-06" } # May half term
       # Per-date caps on Hendon's total matches (home + away) on a night, layered
-      # on top of the 7-day cap above (max: null = no cap except on the listed
+      # on top of the 7-day cap above (max_matches: null = no cap except on the listed
       # dates):
       #
       #  - First Thursday of each month (= 1): the date of Hendon's monthly
@@ -375,8 +375,8 @@ club_constraints:
       #    club (many members still renewing), so we keep the load down then.
       #    Add any further September dates here if the reserve ones are ever
       #    uncommented.
-      - max: null
-        date_max_overrides:
+      - max_matches: null
+        max_matches_overrides:
           "2026-09-03": 1
           "2026-09-10": 2
           "2026-09-17": 2
@@ -439,7 +439,7 @@ club_constraints:
       # 24 Nov - 7 Dec; the range starts the Monday of that week (2026-11-23)
       # per Andy's "last week of November" ask. The two Wednesdays in the span
       # (2026-11-25, 2026-12-02) are also dropped from home_dates above.
-      - max: 0
+      - max_matches: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2026-11-23", end_date: "2026-12-07" }
@@ -505,7 +505,7 @@ club_constraints:
       # rundown), and w/c 29 Mar + w/c 5 Apr (Easter, and a club-level ask -
       # adjacent weeks, so one range). The Wednesday of each (2027-01-06,
       # 2027-03-31, 2027-04-07) is likewise dropped from home_dates above.
-      - max: 0
+      - max_matches: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2027-01-04", end_date: "2027-01-10" } # w/c 4 Jan
@@ -569,7 +569,7 @@ club_constraints:
       # Mon-Fri of a blocked week (weekends never carry fixtures), with runs of
       # consecutive blocked weeks merged across the weekend between them. This
       # replaces ~95 individually listed weekday dates.
-      - max: 0
+      - max_matches: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2026-09-28", end_date: "2026-10-09" } # w/c 28 Sep + 5 Oct
@@ -600,8 +600,8 @@ club_constraints:
     # unavailable_home_dates/unavailable_away_dates below) - it's listed here
     # for an accurate record even though every team's own unavailability already
     # makes it unusable. (Any date this early is also excluded from new
-    # scheduling by solve.py's --earliest-match-date cutoff, which defaults to
-    # today.)
+    # scheduling by the spec's earliest_match_date cutoff, which defaults to
+    # today when omitted, as it is here.)
     #
     # Hammersmith run 4 teams across divisions 1-3 out of the same venue, and
     # per their availability spreadsheet (see the 'teams' sub-section below)
@@ -611,7 +611,7 @@ club_constraints:
     # here. But the real limit already comes from the match_count_limits entries
     # below: with adjacent teams (1-2, 2-3, 3-4) barred from sharing a date, at
     # most 2 of the 4 can ever coschedule (e.g. 1+3, 1+4 or 2+4), so the
-    # venue-capacity default is simply cancelled (max: null, see
+    # venue-capacity default is simply cancelled (max_matches: null, see
     # match_count_limits below) rather than restating that bound as a number
     # that would need to stay in sync with it (and would otherwise need updating
     # if Hammersmith confirms their venue's actual concurrent-match capacity
@@ -937,17 +937,17 @@ club_constraints:
       # top of this club's block).
       - override_key: venue-capacity
         venue_scope: home
-        max: null
+        max_matches: null
       # Adjacent Hammersmith teams (by team index: 1-2, 2-3, 3-4) shouldn't play
       # on the same date, per the club's preference (2026-08-24) - they only asked
       # for same-date avoidance, so time_window_days is left at its default of 1
       # rather than keeping them apart by more than that.
       - teams: [hammersmith-1, hammersmith-2]
-        max: 1
+        max_matches: 1
       - teams: [hammersmith-2, hammersmith-3]
-        max: 1
+        max_matches: 1
       - teams: [hammersmith-3, hammersmith-4]
-        max: 1
+        max_matches: 1
   muswell-hill:
     # Club night is Tuesday. Available for home matches October and
     # November 2026, then January to around mid-May 2027 (2026-08-25
@@ -1018,7 +1018,7 @@ club_constraints:
       # one-home-match-a-night default).
       - override_key: venue-capacity
         venue_scope: home
-        max: 2
+        max_matches: 2
     home_dates:
       - "2026-10-06"
       - "2026-10-13"
@@ -1142,7 +1142,7 @@ club_constraints:
       # No away matches in November 2026 or the first week of December (the
       # home side is handled by home_dates above skipping that span). Was 26
       # individually listed weekday dates.
-      - max: 0
+      - max_matches: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2026-11-02", end_date: "2026-12-07" }
@@ -1160,7 +1160,7 @@ club_constraints:
     #
     # Exceptions: on these dates the venue already has another (non-Middlesex)
     # fixture, so only one Middlesex match can be hosted on each - expressed as
-    # per-date 'date_max_overrides' of the limit of 2. Leslie Pringle first gave
+    # per-date 'max_matches_overrides' of the limit of 2. Leslie Pringle first gave
     # 2026-09-21, 2026-10-05 and 2026-10-12 (2026-08-28), then supplied the
     # full list in an update as of Sunday evening 2026-08-30, adding
     # 2026-10-26, 2026-11-02, 2027-02-08 and 2027-04-19 ("most of it clear"
@@ -1168,8 +1168,8 @@ club_constraints:
     match_count_limits:
       - override_key: venue-capacity
         venue_scope: home
-        max: 2
-        date_max_overrides:
+        max_matches: 2
+        max_matches_overrides:
           "2026-09-21": 1
           "2026-10-05": 1
           "2026-10-12": 1
@@ -1483,12 +1483,12 @@ club_constraints:
       # spec-wide one-home-match-a-night default.
       - override_key: venue-capacity
         venue_scope: home
-        max: 5
+        max_matches: 5
       # Away matches only: keep Harrow 1 and Harrow 2 from playing away on
       # the same date, per Surjit, without constraining their home dates.
       - teams: [harrow-1, harrow-2]
         venue_scope: away
-        max: 1
+        max_matches: 1
   kings-head:
     # Per Colin Mackenzie: Kings Head play home matches on Thursday evenings at
     # the Mind Sports Centre (the same venue as Hammersmith), October to May
@@ -1512,7 +1512,7 @@ club_constraints:
     #     that team did not list as playable (home or away).
     #   - Away availability is handled in match_count_limits: each team may play
     #     away only on the Thursdays it listed or inside the away windows it
-    #     gave Colin, so a 'max: 0' / 'venue_scope: away' / 'date_ranges' entry
+    #     gave Colin, so a 'max_matches: 0' / 'venue_scope: away' / 'date_ranges' entry
     #     per team bars every other weekday (same idiom as Metropolitan and West
     #     London). Ranges are Mon-Fri spans with consecutive blocked weeks
     #     merged across the weekend between them, and run through June so the
@@ -1722,14 +1722,14 @@ club_constraints:
       # as it stands.
       - teams: [kings-head-1, kings-head-2]
         time_window_days: 2
-        max: 1
+        max_matches: 1
       # KH2 <-> KH3: at most one match in any 7-day window across the pair (a
       # 7-day cap already forbids same-day / consecutive-day pairings).
       # apply_per defaults to across_teams: the pair shares a single match
       # per window. This one solves comfortably.
       - teams: [kings-head-2, kings-head-3]
         time_window_days: 7
-        max: 1
+        max_matches: 1
       # Per-team away-availability windows (Colin, 2026-08-31). Each team may
       # play away only on the Thursdays it listed or within the away windows
       # it gave; these ranges bar every other weekday. Mon-Fri spans,
@@ -1738,7 +1738,7 @@ club_constraints:
       # 28 Sep) through June (to cover the June away Thursdays if the season
       # overruns).
       - teams: [kings-head-1]
-        max: 0
+        max_matches: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2026-09-01", end_date: "2026-09-25" }
@@ -1763,7 +1763,7 @@ club_constraints:
           - { start_date: "2027-04-13", end_date: "2027-05-07" }
           - { start_date: "2027-06-15", end_date: "2027-06-18" }
       - teams: [kings-head-2]
-        max: 0
+        max_matches: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2026-09-01", end_date: "2026-09-25" }
@@ -1797,7 +1797,7 @@ club_constraints:
           - { start_date: "2027-06-09", end_date: "2027-06-11" }
           - { start_date: "2027-06-15", end_date: "2027-06-18" }
       - teams: [kings-head-3]
-        max: 0
+        max_matches: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2026-09-01", end_date: "2026-09-25" }
@@ -1887,5 +1887,5 @@ fixed_fixtures:
     date: "2026-12-10"
 
 # Christmas/New Year is blocked spec-wide by the 'no-play-dates' entry under
-# club_constraints.defaults.match_count_limits above (a max: 0 date range over
+# club_constraints.defaults.match_count_limits above (a max_matches: 0 date range over
 # 2026-12-21 to 2027-01-03).

--- a/runs/example/solution.yaml
+++ b/runs/example/solution.yaml
@@ -548,14 +548,15 @@ fixtures:
 - home: hendon-1
   away: hackney-1
   date: 2026-05-28
-spec_checksum: sha256:abf1ec6d4f1b5b22ed266e02c0198062e33dbe9760d0d20a806891f1f5557d98
+spec_checksum: sha256:fc221b89fe90f1feb2ffd6daf7d95b9e0fe36f5af4d5f1550eb44894d9f36f3f
 stats:
   model: |-
-    satisfaction model '': (model_fingerprint: 0x7a72f3dd866787a9)
+    satisfaction model '': (model_fingerprint: 0xf871d7678b7eaa1a)
     #Variables: 5'653 (5'470 primary variables)
       - 5'653 Booleans in [0,1]
-    #kLinear3: 4
-    #kLinearN: 3'602 (#terms: 50'418)
+    #kLinear2: 570
+    #kLinear3: 184
+    #kLinearN: 4'596 (#terms: 58'343)
   solve: |
     CpSolverResponse summary:
     status: OPTIMAL
@@ -564,13 +565,13 @@ stats:
     integers: 2215
     booleans: 5639
     conflicts: 0
-    branches: 7600
-    propagations: 269012
-    integer_propagations: 84076
+    branches: 6544
+    propagations: 228386
+    integer_propagations: 72340
     restarts: 0
     lp_iterations: 0
-    walltime: 0.204949
-    usertime: 0.204949
-    deterministic_time: 0.371173
+    walltime: 0.212975
+    usertime: 0.212975
+    deterministic_time: 0.367307
     gap_integral: 0
     solution_fingerprint: 0x5ef51ce980a21f5d

--- a/runs/example/spec.yaml
+++ b/runs/example/spec.yaml
@@ -1,6 +1,9 @@
 # yaml-language-server: $schema=../../spec-schema.json
 name: "2025-26 Season"
 draft: true
+# This is a static reference example, not a live season, so its whole (long past)
+# season window is exempted from the default (today) earliest_match_date cutoff.
+earliest_match_date: "2025-01-01"
 clubs:
   albany:
     name: Albany
@@ -194,11 +197,11 @@ club_constraints:
       - override_key: weekly-gap
         apply_per: each_team
         time_window_days: 7
-        max: 1
+        max_matches: 1
       # Each club hosts at most two home matches a night (shared venue).
       - override_key: venue-capacity
         venue_scope: home
-        max: 2
+        max_matches: 2
   albany:
     home_dates:
       - "2025-09-01"
@@ -368,8 +371,8 @@ club_constraints:
       # take a third on 2025-11-13 only.
       - override_key: venue-capacity
         venue_scope: home
-        max: 2
-        date_max_overrides:
+        max_matches: 2
+        max_matches_overrides:
           "2025-11-13": 3
   harrow:
     match_count_limits:
@@ -377,7 +380,7 @@ club_constraints:
       - override_key: weekly-gap
         apply_per: each_team
         time_window_days: 14
-        max: 1
+        max_matches: 1
     home_dates:
       - "2025-09-11"
       - "2025-09-18"

--- a/solve_test.py
+++ b/solve_test.py
@@ -59,7 +59,7 @@ club_constraints:
     match_count_limits:
       - override_key: venue-capacity
         venue_scope: home
-        max: 1
+        max_matches: 1
   albany:
     home_dates: [2025-09-01, 2025-09-29]
   hackney:

--- a/spec-schema.json
+++ b/spec-schema.json
@@ -191,7 +191,7 @@
         "unavailable_away_dates": {
           "type": "array",
           "default": [],
-          "description": "Dates this club's teams are unavailable to play away. Defaults to empty if omitted. For a contiguous span, or a block that applies to every club, a match_count_limits entry with 'max: 0' and 'date_ranges' is usually tidier.",
+          "description": "Dates this club's teams are unavailable to play away. Defaults to empty if omitted. For a contiguous span, or a block that applies to every club, a match_count_limits entry with 'max_matches: 0' and 'date_ranges' is usually tidier.",
           "items": { "$ref": "#/$defs/date" },
           "uniqueItems": true
         },
@@ -224,7 +224,7 @@
         },
         "match_count_limits": {
           "type": "array",
-          "description": "The sole match-count constraint mechanism: each entry caps how many matches involving a set of this club's teams may fall within a rolling window of consecutive days -- or, when the entry sets 'date_ranges', within each of a few explicit calendar ranges. Covers a per-team weekly gap ('apply_per: each_team', 'max: 1', 'time_window_days: 7'), a venue's concurrent-match capacity ('apply_per: across_teams', 'venue_scope: home'), keeping adjacent-division teams apart ('teams: [...]', 'max: 1'), and holding a club's load down over a named holiday week ('date_ranges: [...]', 'max: 1', or 'max: 0' to bar it entirely). Additive, with as many entries as needed; combined with any inherited from club_constraints.defaults -- an entry with an 'override_key' replaces the like-keyed default for this club instead.",
+          "description": "The sole match-count constraint mechanism: each entry caps how many matches involving a set of this club's teams may fall within a rolling window of consecutive days -- or, when the entry sets 'date_ranges', within each of a few explicit calendar ranges. Covers a per-team weekly gap ('apply_per: each_team', 'max_matches: 1', 'time_window_days: 7'), a venue's concurrent-match capacity ('apply_per: across_teams', 'venue_scope: home', typically paired with 'max_playing_teams' to also cap distinct teams playing -- see 'match_count_limit_fields/max_playing_teams'), keeping adjacent-division teams apart ('teams: [...]', 'max_matches: 1'), and holding a club's load down over a named holiday week ('date_ranges: [...]', 'max_matches: 1', or 'max_matches: 0' to bar it entirely). Additive, with as many entries as needed; combined with any inherited from club_constraints.defaults -- an entry with an 'override_key' replaces the like-keyed default for this club instead.",
           "items": { "$ref": "#/$defs/match_count_limit_entry" }
         }
       }
@@ -248,15 +248,20 @@
       }
     },
     "match_count_limit_fields": {
-      "max": {
+      "max_matches": {
         "oneOf": [{ "type": "integer", "minimum": 0 }, { "type": "null" }],
-        "description": "The most matches (of the kind selected by 'venue_scope') allowed within any window of 'time_window_days' consecutive days (or, with 'date_ranges', within each listed range). The key is required, so an entry is never accidentally a no-op. null means no plain cap -- only useful with 'date_max_overrides', or (on a club entry with an 'override_key') to cancel a default. 'max: 1' forbids a second match in a window; a higher value caps density. 'max: 0' is only meaningful together with 'date_ranges' (a full blackout of those ranges); in the rolling-window form use 'max: 1' or higher."
+        "description": "The most matches (of the kind selected by 'venue_scope') allowed within any window of 'time_window_days' consecutive days (or, with 'date_ranges', within each listed range). At least one of this and 'max_playing_teams' must be given (or another way to supply the cap -- see the entry-level description), so an entry is never accidentally a no-op. Omitted or null means no plain cap -- only useful alongside 'max_matches_overrides' or 'max_playing_teams', or (on a club entry with an 'override_key') to cancel a default. 'max_matches: 1' forbids a second match in a window; a higher value caps density. 'max_matches: 0' is only meaningful together with 'date_ranges' (a full blackout of those ranges); in the rolling-window form use 'max_matches: 1' or higher."
+      },
+      "max_playing_teams": {
+        "type": "integer",
+        "minimum": 0,
+        "description": "A cap on how many teams'-worth of players from 'teams' a window asks for, as opposed to 'max_matches' (a count of matches). Each counted match adds one of 'teams' playing, or two if it's an internal match between two of 'teams' -- e.g. a same-club derby counted by that club's own venue-capacity rule: one match towards 'max_matches', but two teams from the set on to play, both counted towards 'max_playing_teams'. A venue that can physically host 3 simultaneous matches but only has 3 teams' worth of players to field wants both 'max_matches: 3' and 'max_playing_teams: 3' -- otherwise 3 matches, one an internal derby, would need 4 teams' worth of players. Optional; omit for no such cap. Over a wider window (a multi-day 'time_window_days', or 'date_ranges'), the same pair meeting twice counts twice: it's a running tally of teams asked to play, not a count of distinct teams touched. See 'max_playing_teams_overrides' for per-date replacements."
       },
       "apply_per": {
         "type": "string",
         "enum": ["across_teams", "each_team"],
         "default": "across_teams",
-        "description": "'across_teams' (the default): the counted teams share one budget of 'max' per window (a venue capacity, or a keep-apart rule). 'each_team': 'max' is enforced separately for each team -- typically with 'teams' left as every team of the club and 'max: 1', i.e. a per-team gap."
+        "description": "'across_teams' (the default): the counted teams share one budget of 'max_matches'/'max_playing_teams' per window (a venue capacity, or a keep-apart rule). 'each_team': enforced separately for each team -- typically with 'teams' left as every team of the club and 'max_matches: 1', i.e. a per-team gap."
       },
       "time_window_days": {
         "type": "integer",
@@ -270,17 +275,24 @@
         "default": "all",
         "description": "Which of the counted teams' matches the cap counts: 'home' only their home matches, 'away' only their away matches, or 'all' (the default) every match they play. E.g. 'away' counts only away fixtures, still allowing one team to play away on a night another is hosting."
       },
-      "date_max_overrides": {
+      "max_matches_overrides": {
         "type": "object",
-        "description": "Per-date replacements of 'max', keyed by date; each value an integer >= 1, or null to lift the cap that day. Only allowed when 'time_window_days' is 1 (so each window is a single date).",
+        "description": "Per-date replacements of 'max_matches', keyed by date; each value an integer >= 1, or null to lift the cap that day. Only allowed when 'time_window_days' is 1 (so each window is a single date).",
         "additionalProperties": {
           "oneOf": [{ "type": "integer", "minimum": 1 }, { "type": "null" }]
+        }
+      },
+      "max_playing_teams_overrides": {
+        "type": "object",
+        "description": "Per-date replacements of 'max_playing_teams', keyed by date; each value an integer >= 0, or null to lift the cap that day -- mirroring 'max_matches_overrides'. Only allowed when 'time_window_days' is 1 (so each window is a single date); not combinable with 'date_ranges'. Useful for a one-off exception to a standing venue-capacity rule (e.g. a busy week where two derbies must double up, needing more than the usual number of teams playing at once).",
+        "additionalProperties": {
+          "oneOf": [{ "type": "integer", "minimum": 0 }, { "type": "null" }]
         }
       },
       "date_ranges": {
         "type": "array",
         "minItems": 1,
-        "description": "Restricts this rule to one or more explicit, inclusive calendar ranges instead of every rolling 'time_window_days' window: the cap ('max') then applies to the counted matches whose date falls within each listed range, each range enforced independently. Use for a limit tied to specific weeks -- a school-holiday week, a congress fortnight -- that a rolling window cannot target. Allowed on club and 'defaults' entries alike; not combinable with 'time_window_days' or 'date_max_overrides', nor (on a club entry) with 'override_key'. With 'date_ranges' set, 'max' must be an integer >= 0 ('max: 0' bars every counted match in the range; a whole-club 'defaults' entry with 'max: 0' is the spec-wide 'nobody plays these dates' block).",
+        "description": "Restricts this rule to one or more explicit, inclusive calendar ranges instead of every rolling 'time_window_days' window: the caps ('max_matches' and/or 'max_playing_teams') then apply to the counted matches whose date falls within each listed range, each range enforced independently. Use for a limit tied to specific weeks -- a school-holiday week, a congress fortnight -- that a rolling window cannot target. Allowed on club and 'defaults' entries alike; not combinable with 'time_window_days', 'max_matches_overrides' or 'max_playing_teams_overrides' (both tied to a single date), nor (on a club entry) with 'override_key'. With 'date_ranges' set, 'max_matches' must be an integer >= 0 ('max_matches: 0' bars every counted match in the range; a whole-club 'defaults' entry with 'max_matches: 0' is the spec-wide 'nobody plays these dates' block).",
         "items": {
           "type": "object",
           "additionalProperties": false,
@@ -305,10 +317,12 @@
     "match_count_limit_entry": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["max"],
-      "description": "One per-club match_count_limits entry.",
+      "description": "One per-club match_count_limits entry. Needs at least one of 'max_matches' or 'max_playing_teams' -- either alone is fine -- unless 'max_matches_overrides', 'date_ranges', or 'override_key' (cancelling a default) supplies the actual cap instead.",
       "properties": {
-        "max": { "$ref": "#/$defs/match_count_limit_fields/max" },
+        "max_matches": { "$ref": "#/$defs/match_count_limit_fields/max_matches" },
+        "max_playing_teams": {
+          "$ref": "#/$defs/match_count_limit_fields/max_playing_teams"
+        },
         "teams": {
           "type": "array",
           "description": "This club's own team IDs whose matches are counted. Omit for every team of the club (a whole-club cap, or -- with 'apply_per: each_team' -- a per-team gap). One or more. Not allowed alongside 'override_key'.",
@@ -321,8 +335,11 @@
           "$ref": "#/$defs/match_count_limit_fields/time_window_days"
         },
         "venue_scope": { "$ref": "#/$defs/match_count_limit_fields/venue_scope" },
-        "date_max_overrides": {
-          "$ref": "#/$defs/match_count_limit_fields/date_max_overrides"
+        "max_matches_overrides": {
+          "$ref": "#/$defs/match_count_limit_fields/max_matches_overrides"
+        },
+        "max_playing_teams_overrides": {
+          "$ref": "#/$defs/match_count_limit_fields/max_playing_teams_overrides"
         },
         "date_ranges": {
           "$ref": "#/$defs/match_count_limit_fields/date_ranges"
@@ -335,17 +352,23 @@
     "match_count_limit_default_entry": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["max", "override_key"],
-      "description": "A club_constraints.defaults.match_count_limits entry: like a per-club match_count_limits entry but without 'teams' (defaults apply to every team of every club) and with a required, list-unique 'override_key'. A club's own entry naming that 'override_key' replaces this one for the club wholesale. A 'max: 0' entry with 'date_ranges' is the spec-wide way to say no club plays on those dates (a club can opt back in by overriding the key).",
+      "required": ["override_key"],
+      "description": "A club_constraints.defaults.match_count_limits entry: like a per-club match_count_limits entry but without 'teams' (defaults apply to every team of every club) and with a required, list-unique 'override_key'. A club's own entry naming that 'override_key' replaces this one for the club wholesale. A 'max_matches: 0' entry with 'date_ranges' is the spec-wide way to say no club plays on those dates (a club can opt back in by overriding the key). Needs at least one of 'max_matches' or 'max_playing_teams' -- either alone is fine -- unless 'max_matches_overrides', 'date_ranges', or a bare cancelling entry (only 'override_key') is what's meant.",
       "properties": {
-        "max": { "$ref": "#/$defs/match_count_limit_fields/max" },
+        "max_matches": { "$ref": "#/$defs/match_count_limit_fields/max_matches" },
+        "max_playing_teams": {
+          "$ref": "#/$defs/match_count_limit_fields/max_playing_teams"
+        },
         "apply_per": { "$ref": "#/$defs/match_count_limit_fields/apply_per" },
         "time_window_days": {
           "$ref": "#/$defs/match_count_limit_fields/time_window_days"
         },
         "venue_scope": { "$ref": "#/$defs/match_count_limit_fields/venue_scope" },
-        "date_max_overrides": {
-          "$ref": "#/$defs/match_count_limit_fields/date_max_overrides"
+        "max_matches_overrides": {
+          "$ref": "#/$defs/match_count_limit_fields/max_matches_overrides"
+        },
+        "max_playing_teams_overrides": {
+          "$ref": "#/$defs/match_count_limit_fields/max_playing_teams_overrides"
         },
         "date_ranges": {
           "$ref": "#/$defs/match_count_limit_fields/date_ranges"

--- a/spec_schema_test.py
+++ b/spec_schema_test.py
@@ -81,12 +81,12 @@ club_constraints:
       - override_key: weekly-gap
         apply_per: each_team
         time_window_days: 7
-        max: 1
+        max_matches: 1
       - override_key: venue-capacity
         venue_scope: home
-        max: 2
+        max_matches: 2
       - override_key: no-play-dates
-        max: 0
+        max_matches: 0
         date_ranges:
           - start_date: 2025-12-22
             end_date: 2026-01-04
@@ -99,29 +99,29 @@ club_constraints:
       - override_key: weekly-gap
         apply_per: each_team
         time_window_days: 14
-        max: 1
+        max_matches: 1
       - override_key: venue-capacity
         venue_scope: home
-        max: 3
+        max_matches: 3
 
   hackney:
     home_dates: [2025-09-08, 2025-09-22]
     match_count_limits:
       - override_key: venue-capacity
         venue_scope: home
-        max: 2
-        date_max_overrides:
+        max_matches: 2
+        max_matches_overrides:
           2025-09-08: 3
-      - max: null
+      - max_matches: null
         venue_scope: all
-        date_max_overrides:
+        max_matches_overrides:
           2025-09-22: 1
       - teams: [hackney-1, hackney-5]
         time_window_days: 7
-        max: 1
+        max_matches: 1
         venue_scope: away
       - teams: [hackney-1, hackney-5]
-        max: 1
+        max_matches: 1
         date_ranges:
           - start_date: 2025-10-20
             end_date: 2025-10-26


### PR DESCRIPTION
- match_count_limits' 'max' key becomes 'max_matches', and 'date_max_overrides' becomes 'max_matches_overrides', for consistency with the new 'max_playing_teams'/'max_playing_teams_overrides' fields below.
- New 'max_playing_teams' field (plus its own per-date overrides) caps how many teams'-worth of players a window asks for, distinct from 'max_matches'' count of matches: a same-club derby is one match but two of a club's own teams playing, which a plain match-count cap can't see. Either 'max_matches' or 'max_playing_teams' alone is now enough (previously 'max_matches' was mandatory).
- New unconditional solver constraint: a team may never play more than one match on the same date.
- Re-solves draft1 and the example run to match their renamed spec keys (fixtures unchanged), and fixes draft1's stale --earliest-match-date comment now that its checksum is changing anyway.


Claude-Session: https://claude.ai/code/session_012tguL6eUe8enqfeJUVkxsp