### PR TITLE
Add match_count_limits.exclude_dates to exempt dates from a rule

### DIFF
--- a/fixturespec.py
+++ b/fixturespec.py
@@ -367,6 +367,7 @@ _MATCH_COUNT_LIMIT_FIELD_KEYS = {
     "max_matches_overrides",
     "max_playing_teams_overrides",
     "date_ranges",
+    "exclude_dates",
     "override_key",
 }
 
@@ -420,6 +421,7 @@ class _ParsedMatchCountLimit:
     max_playing_teams_overrides: Mapping[date, int | None] = dataclasses.field(
         default_factory=dict
     )
+    exclude_dates: frozenset[date] = frozenset()
 
 
 @dataclasses.dataclass(frozen=True)
@@ -746,6 +748,11 @@ def _parse_match_count_limits(
         must then be a non-negative integer (0 bars every counted match in the
         range -- a whole-club, all-teams 'defaults' entry with max_matches 0 is how a
         spec-wide "nobody plays these dates" block is expressed).
+      - 'exclude_dates' (optional): a non-empty list of dates whose counted
+        matches this rule ignores entirely -- every window is evaluated as if
+        nothing counted falls on them. Unlike the '*_overrides' maps it is not tied
+        to a single-date window, so it can exempt one date from a multi-day rolling
+        cap. Not combinable with 'date_ranges'.
       - 'override_key': required for a 'defaults' entry (and unique within that
         list); optional for a club entry, where it names the default this one
         replaces for the club wholesale.
@@ -936,6 +943,19 @@ def _parse_match_count_limits(
                 entry["date_ranges"], f"{entry_context}.date_ranges"
             )
 
+        exclude_dates: frozenset[date] = frozenset()
+        if "exclude_dates" in entry:
+            if has_date_ranges:
+                raise SpecError(
+                    f"{entry_context}: 'exclude_dates' and 'date_ranges' can't be "
+                    "combined"
+                )
+            exclude_dates = frozenset(
+                _parse_date_list(
+                    entry["exclude_dates"], f"{entry_context}.exclude_dates"
+                )
+            )
+
         if (
             max_ is None
             and not max_matches_overrides
@@ -961,6 +981,7 @@ def _parse_match_count_limits(
                 date_ranges=date_ranges,
                 override_key=override_key,
                 max_playing_teams_overrides=max_playing_teams_overrides,
+                exclude_dates=exclude_dates,
             )
         )
 
@@ -1035,6 +1056,7 @@ def _resolve_match_count_limits(
                     date_ranges=pl.date_ranges,
                     max_playing_teams=pl.max_playing_teams,
                     max_playing_teams_overrides=pl.max_playing_teams_overrides,
+                    exclude_dates=pl.exclude_dates,
                 )
             )
     return resolved

--- a/fixturespec_test.py
+++ b/fixturespec_test.py
@@ -1787,6 +1787,76 @@ club_constraints:
         ):
             fixturespec.load_spec(path)
 
+    def test_match_count_limits_exclude_dates_parsed(self) -> None:
+        """'exclude_dates' lands on the resolved limit as a frozenset of dates
+        whose counted matches the rule ignores -- and, unlike the *_overrides
+        fields, it's allowed alongside a multi-day rolling window."""
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        max_playing_teams: 3\n"
+            "        time_window_days: 7\n"
+            "        exclude_dates:\n"
+            "          - 2025-09-01\n"
+            "          - 2025-09-08\n"
+        )
+        spec = fixturespec.load_spec(path)
+        limit = _find_limit(
+            spec.parameters.match_count_limits,
+            club="albany",
+            venue_scope=fmodel.VenueScope.HOME,
+            apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
+        )
+        self.assertEqual(limit.time_window_days, 7)
+        self.assertEqual(
+            limit.exclude_dates,
+            frozenset({date(2025, 9, 1), date(2025, 9, 8)}),
+        )
+
+    def test_match_count_limits_exclude_dates_defaults_to_empty(self) -> None:
+        path = self._write(_MINIMAL_SPEC)
+        spec = fixturespec.load_spec(path)
+        limit = _find_limit(
+            spec.parameters.match_count_limits,
+            club="albany",
+            venue_scope=fmodel.VenueScope.HOME,
+            apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
+        )
+        self.assertEqual(limit.exclude_dates, frozenset())
+
+    def test_match_count_limits_exclude_dates_invalid_date_rejected(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        max_matches: 3\n"
+            "        exclude_dates:\n"
+            "          - not-a-date\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "exclude_dates"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_exclude_dates_reject_date_ranges(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        max_matches: 0\n"
+            "        exclude_dates:\n"
+            "          - 2025-09-01\n"
+            "        date_ranges:\n"
+            "          - start_date: 2025-09-01\n"
+            "            end_date: 2025-09-07\n"
+        )
+        with self.assertRaisesRegex(
+            fixturespec.SpecError, "exclude_dates.*date_ranges"
+        ):
+            fixturespec.load_spec(path)
+
     def test_club_latest_match_date_parsed(self) -> None:
         """A per-club latest_match_date lands in Parameters.club_latest_match_date,
         keyed by club, and only for the clubs that set one."""

--- a/fmodel.py
+++ b/fmodel.py
@@ -268,6 +268,14 @@ class MatchCountLimit:
     touched. `max_playing_teams_overrides` replaces it on specific dates (an int, or
     None to lift the cap that day), mirroring `max_matches_overrides` -- only
     meaningful, and only permitted, when `time_window_days` is 1.
+
+    `exclude_dates` drops every counted match falling on one of the listed dates
+    from this rule: each window is evaluated as if nothing counted happened then,
+    for both `max_matches` and `max_playing_teams`. Unlike the `*_overrides` maps it
+    is not tied to a single-date window, so it is the way to exempt one date from a
+    multi-day rolling cap -- typically a date whose load is already pinned by
+    `fixed_fixtures` and bounded by its own `max_matches_overrides` entry. Mutually
+    exclusive with `date_ranges` (leave the date out of the ranges instead).
     """
 
     teams: Collection[Team]
@@ -283,6 +291,7 @@ class MatchCountLimit:
     max_playing_teams_overrides: Mapping[date, int | None] = dataclasses.field(
         default_factory=dict
     )
+    exclude_dates: frozenset[date] = frozenset()
 
     def __post_init__(self) -> None:
         if self.max_matches_overrides and self.time_window_days != 1:
@@ -304,6 +313,11 @@ class MatchCountLimit:
                 raise ValueError(
                     "MatchCountLimit.date_ranges and max_matches_overrides are "
                     "mutually exclusive"
+                )
+            if self.exclude_dates:
+                raise ValueError(
+                    "MatchCountLimit.date_ranges and exclude_dates are mutually "
+                    "exclusive (leave the date out of the ranges instead)"
                 )
 
     def max_matches_for_window(self, window: Collection[date]) -> int | None:
@@ -683,6 +697,12 @@ def _add_match_count_limit_constraints(
             fixtures_by_date = _counted_fixtures_by_date(
                 fixture_date_vars, team_set, rule.venue_scope
             )
+            if rule.exclude_dates:
+                fixtures_by_date = {
+                    d: fx
+                    for d, fx in fixtures_by_date.items()
+                    if d not in rule.exclude_dates
+                }
 
             # With explicit date_ranges the windows are exactly those inclusive
             # ranges (each counted independently). Otherwise date_windows groups

--- a/model_test.py
+++ b/model_test.py
@@ -1874,6 +1874,53 @@ class TestMaxPlayingTeams(unittest.TestCase):
         self.assertEqual(len(fixtures), 2)
         self.assertFalse(derby_dates <= in_range_dates)
 
+    def test_exclude_dates_drops_a_date_from_the_window_tally(self) -> None:
+        """`exclude_dates` makes every window ignore whatever counted matches fall
+        on the listed dates -- unlike the *_overrides fields, it works over a
+        multi-day rolling window. H1 and H2 (double_round, so two derby legs) have
+        only two home dates two days apart: both legs land inside one 7-day window,
+        needing 4 teams'-worth of players, over a max_playing_teams cap of 3. That
+        is infeasible as-is; excluding one of the two dates drops its leg from the
+        tally, leaving every window at 2 and letting both legs be scheduled."""
+        h1 = fmodel.Team(division=1, club="H", index=1)
+        h2 = fmodel.Team(division=1, club="H", index=2)
+        d1 = date(2025, 1, 1)
+        d2 = date(2025, 1, 3)
+
+        def params_with(exclude_dates: frozenset[date]) -> fmodel.Parameters:
+            return _params(
+                teams=[h1, h2],
+                home_dates={"H": [d1, d2]},
+                unavailable_away_dates={"H": []},
+                match_count_limits=[
+                    fmodel.MatchCountLimit(
+                        teams=[h1, h2],
+                        max_matches=None,
+                        max_playing_teams=3,
+                        time_window_days=7,
+                        exclude_dates=exclude_dates,
+                    )
+                ],
+            )
+
+        with self.assertRaisesRegex(ValueError, "INFEASIBLE"):
+            fmodel.solve(params_with(frozenset()))
+
+        fixtures = list(fmodel.solve(params_with(frozenset({d1}))).fixtures)
+        self.assertEqual(len(fixtures), 2)
+
+    def test_exclude_dates_rejects_date_ranges(self) -> None:
+        """`exclude_dates` and `date_ranges` are mutually exclusive -- with explicit
+        ranges you simply leave the date out of them."""
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        with self.assertRaises(ValueError):
+            fmodel.MatchCountLimit(
+                teams=[a1],
+                max_matches=1,
+                date_ranges=(fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 7)),),
+                exclude_dates=frozenset({date(2025, 1, 3)}),
+            )
+
 
 class TestMatchCountLimitDateRanges(unittest.TestCase):
     """A MatchCountLimit with explicit `date_ranges` caps matches within each

--- a/spec-schema.json
+++ b/spec-schema.json
@@ -309,6 +309,13 @@
           }
         }
       },
+      "exclude_dates": {
+        "type": "array",
+        "minItems": 1,
+        "description": "Dates whose counted matches this rule ignores entirely -- every window is evaluated as if nothing counted falls on them. Use to exempt a date the rule would otherwise make infeasible, typically one whose load is already pinned by fixed_fixtures and governed by a 'max_matches_overrides' entry (e.g. two pre-season derbies on one night, four teams'-worth, under a rolling 'max_playing_teams: 3'). Applies to both 'max_matches' and 'max_playing_teams'; not combinable with 'date_ranges' (list ranges that skip the date instead).",
+        "items": { "$ref": "#/$defs/date" },
+        "uniqueItems": true
+      },
       "override_key": {
         "type": "string",
         "description": "Names a club_constraints.defaults.match_count_limits entry (via its own 'override_key'). On a club entry, replaces that default for the club. Required and unique on every defaults entry; on a club entry it can't be combined with 'teams'."
@@ -344,6 +351,9 @@
         "date_ranges": {
           "$ref": "#/$defs/match_count_limit_fields/date_ranges"
         },
+        "exclude_dates": {
+          "$ref": "#/$defs/match_count_limit_fields/exclude_dates"
+        },
         "override_key": {
           "$ref": "#/$defs/match_count_limit_fields/override_key"
         }
@@ -372,6 +382,9 @@
         },
         "date_ranges": {
           "$ref": "#/$defs/match_count_limit_fields/date_ranges"
+        },
+        "exclude_dates": {
+          "$ref": "#/$defs/match_count_limit_fields/exclude_dates"
         },
         "override_key": {
           "$ref": "#/$defs/match_count_limit_fields/override_key"

--- a/spec_schema_test.py
+++ b/spec_schema_test.py
@@ -120,6 +120,7 @@ club_constraints:
         time_window_days: 7
         max_matches: 1
         venue_scope: away
+        exclude_dates: [2025-09-08]
       - teams: [hackney-1, hackney-5]
         max_matches: 1
         date_ranges:


### PR DESCRIPTION
A MatchCountLimit entry can now carry an `exclude_dates` list: counted matches falling on those dates are dropped from that rule entirely, so every window is evaluated as if nothing counted happened then, for both `max_matches` and `max_playing_teams`.

Unlike `max_matches_overrides` / `max_playing_teams_overrides`, which are tied to a single-date window, `exclude_dates` works with a multi-day rolling `time_window_days`. This makes it possible to keep a rolling weekly cap (e.g. `max_playing_teams: 3` over 7 days) while grandfathering one date whose load is already pinned by `fixed_fixtures` and bounded by its own `max_matches_overrides` entry -- otherwise such a date can make the spec infeasible. Mutually exclusive with `date_ranges` (leave the date out of the ranges instead).

Threaded through fixturespec parsing/resolution and the JSON schema (both the per-club and defaults entry objects), with parse-time and model-time guards against combining it with `date_ranges`.


Claude-Session: https://claude.ai/code/session_01BYYPbqBT6uh3EDZJSeWzD8