### PR TITLE
Don't count internal matches under AWAY venue_scope

### DIFF
--- a/fixturespec.py
+++ b/fixturespec.py
@@ -713,7 +713,9 @@ def _parse_match_count_limits(
         'max_matches', which counts matches. Each counted match adds one of 'teams'
         playing, or two if it's an internal match between two of 'teams' (e.g. a
         same-club derby counted by that club's own venue-capacity rule): one match
-        towards 'max_matches', but two teams from the set on to play. A venue that
+        towards 'max_matches', but two teams from the set on to play. (Under 'away'
+        venue_scope an internal match is not counted at all, so it adds nothing
+        here either.) A venue that
         can physically host 3 simultaneous matches but only has 3 teams' worth of
         players to field wants both 'max_matches: 3' and 'max_playing_teams: 3' --
         otherwise 3 matches, one an internal derby, would need 4 teams' worth of
@@ -737,7 +739,10 @@ def _parse_match_count_limits(
       - 'time_window_days' (optional, default 1): window length in consecutive
         calendar days. 7 limits matches in any 7-consecutive-day period -- two
         matches exactly a week apart fall in separate windows.
-      - 'venue_scope' (optional, default 'all'): 'home', 'away' or 'all'.
+      - 'venue_scope' (optional, default 'all'): 'home', 'away' or 'all'. An
+        internal match (both teams the same club) is never counted under 'away'
+        scope -- its 'away' team plays at its own club's venue -- but still
+        counts under 'home' and 'all'.
       - 'max_matches_overrides' (optional): per-date replacements of 'max_matches'.
         Only allowed when 'time_window_days' is 1.
       - 'date_ranges' (optional): a non-empty list of {start_date, end_date}

--- a/fmodel.py
+++ b/fmodel.py
@@ -215,6 +215,26 @@ class ApplyPer(enum.Enum):
     ACROSS_TEAMS = "across_teams"
 
 
+def _fixture_counts_for_scope(
+    fixture: Fixture, teams: Collection[Team], venue_scope: VenueScope
+) -> bool:
+    """Whether a MatchCountLimit over `teams` with `venue_scope` counts `fixture`.
+
+    HOME / ALL scope: the fixture's home team is one of `teams`.
+    AWAY / ALL scope: its away team is one of `teams` -- except that under AWAY
+    scope an internal match (both teams the same club) never counts: that "away"
+    team is playing at its own club's venue, so it is not away in the sense an
+    away-load cap is about. Such a match still counts under HOME or ALL scope via
+    the home-team test (its players are committed either way).
+    """
+    if venue_scope in (VenueScope.HOME, VenueScope.ALL) and fixture.home_team in teams:
+        return True
+    if venue_scope in (VenueScope.AWAY, VenueScope.ALL) and fixture.away_team in teams:
+        internal = fixture.home_team.club == fixture.away_team.club
+        return not (venue_scope is VenueScope.AWAY and internal)
+    return False
+
+
 @dataclasses.dataclass(frozen=True)
 class MatchCountLimit:
     """At most `max_matches` matches involving `teams` may fall within any window of
@@ -236,7 +256,11 @@ class MatchCountLimit:
     `venue_scope` narrows which of those teams' matches count: VenueScope.HOME only
     their home matches, VenueScope.AWAY only their away matches, VenueScope.ALL (the
     default) every match they play. So an AWAY cap counts only the teams' away
-    fixtures, still allowing one to play away on a night another is hosting.
+    fixtures, still allowing one to play away on a night another is hosting. An
+    internal match (both teams the same club) is never counted under AWAY scope:
+    its "away" team is playing at its own club's venue, so it isn't away for the
+    purpose of an away-load cap (it still counts under HOME and ALL, where its
+    players are committed either way).
 
     `max_matches` may be None, meaning no cap from the plain value -- only useful
     alongside `max_matches_overrides`, which replace `max_matches` on specific dates
@@ -257,17 +281,19 @@ class MatchCountLimit:
     `teams` a window asks for: each counted match adds one of `teams` playing to the
     total, or two if it's an internal match between two of `teams` (e.g. a same-club
     derby counted by a club's own venue-capacity rule) -- one entry towards
-    `max_matches`, but two teams from the set on to play. A venue that can physically
-    host 3 simultaneous matches but only has 3 sets of players to field wants
-    `max_matches=3` *and* `max_playing_teams=3` -- otherwise 3 matches, one an
-    internal derby, would need 4 teams' worth of players. Over a wider window (a
-    multi-day `time_window_days`, or `date_ranges`), the same pair meeting twice
-    counts twice: two internal matches between the same two teams still means
-    fielding 4 teams'-worth of players across the window, once per match, not 2 --
-    this is a running tally of teams asked to play, not a count of distinct teams
-    touched. `max_playing_teams_overrides` replaces it on specific dates (an int, or
-    None to lift the cap that day), mirroring `max_matches_overrides` -- only
-    meaningful, and only permitted, when `time_window_days` is 1.
+    `max_matches`, but two teams from the set on to play. (Under AWAY `venue_scope`
+    an internal match is not counted at all, so it adds nothing here either.) A
+    venue that can physically host 3 simultaneous matches but only has 3 sets of
+    players to field wants `max_matches=3` *and* `max_playing_teams=3` -- otherwise
+    3 matches, one an internal derby, would need 4 teams' worth of players. Over a
+    wider window (a multi-day `time_window_days`, or `date_ranges`), the same pair
+    meeting twice counts twice: two internal matches between the same two teams
+    still means fielding 4 teams'-worth of players across the window, once per
+    match, not 2 -- this is a running tally of teams asked to play, not a count of
+    distinct teams touched. `max_playing_teams_overrides` replaces it on specific
+    dates (an int, or None to lift the cap that day), mirroring
+    `max_matches_overrides` -- only meaningful, and only permitted, when
+    `time_window_days` is 1.
 
     `exclude_dates` drops every counted match falling on one of the listed dates
     from this rule: each window is evaluated as if nothing counted happened then,
@@ -339,15 +365,10 @@ class MatchCountLimit:
 
     def counts_fixture(self, fixture: Fixture) -> bool:
         """Whether this limit counts `fixture` at all: its home team (for a HOME or
-        ALL scope) or away team (AWAY or ALL) is among `teams`."""
-        teams = set(self.teams)
-        return (
-            self.venue_scope in (VenueScope.HOME, VenueScope.ALL)
-            and fixture.home_team in teams
-        ) or (
-            self.venue_scope in (VenueScope.AWAY, VenueScope.ALL)
-            and fixture.away_team in teams
-        )
+        ALL scope) or away team (AWAY or ALL) is among `teams` -- except that an
+        internal match never counts under AWAY scope (see _fixture_counts_for_scope
+        and the `venue_scope` note above)."""
+        return _fixture_counts_for_scope(fixture, set(self.teams), self.venue_scope)
 
     def forbids(self, fixture: Fixture, d: date) -> bool:
         """Whether this limit makes `fixture` on `d` outright impossible -- an
@@ -611,15 +632,12 @@ def _counted_fixtures_by_date(
     venue_scope: VenueScope,
 ) -> Mapping[date, list[Fixture]]:
     """Every candidate fixture in `fixture_date_vars`, grouped by date, that counts
-    towards a MatchCountLimit over `teams` with the given `venue_scope`: its home
-    team is among `teams` (HOME or ALL scope), or its away team is (AWAY or ALL)."""
-    count_home = venue_scope in (VenueScope.HOME, VenueScope.ALL)
-    count_away = venue_scope in (VenueScope.AWAY, VenueScope.ALL)
+    towards a MatchCountLimit over `teams` with the given `venue_scope` (see
+    _fixture_counts_for_scope: home team among `teams` for HOME/ALL, away team for
+    AWAY/ALL, but an internal match never counts under AWAY scope)."""
     result: MutableMapping[date, list[Fixture]] = collections.defaultdict(list)
     for fixture, match_date in fixture_date_vars:
-        if (count_home and fixture.home_team in teams) or (
-            count_away and fixture.away_team in teams
-        ):
+        if _fixture_counts_for_scope(fixture, teams, venue_scope):
             result[match_date].append(fixture)
     return result
 

--- a/model_test.py
+++ b/model_test.py
@@ -2371,6 +2371,110 @@ class TestSharedLimitAwayAndAllScopes(unittest.TestCase):
         self.assertEqual(away, [date(2025, 1, 1), date(2025, 1, 8)])
 
 
+class TestInternalMatchAwayScope(unittest.TestCase):
+    """An internal match (both teams the same club) is played at that club's venue,
+    so it is never counted under AWAY venue_scope: its "away" team isn't away in the
+    sense an away-load cap is about. It still counts under HOME and ALL scope.
+    """
+
+    h1 = fmodel.Team(division=1, club="H", index=1)
+    h2 = fmodel.Team(division=1, club="H", index=2)
+    x1 = fmodel.Team(division=1, club="X", index=1)
+    derby = fmodel.Fixture(home_team=h1, away_team=h2)
+    away_at_x = fmodel.Fixture(home_team=x1, away_team=h1)
+
+    def test_counts_fixture_skips_internal_derby_under_away_scope(self) -> None:
+        away = fmodel.MatchCountLimit(
+            teams=[self.h1, self.h2],
+            max_matches=1,
+            venue_scope=fmodel.VenueScope.AWAY,
+        )
+        self.assertFalse(away.counts_fixture(self.derby))
+        # A genuine away match for one of the teams is still counted.
+        self.assertTrue(away.counts_fixture(self.away_at_x))
+
+    def test_counts_fixture_keeps_internal_derby_under_home_and_all_scope(self) -> None:
+        for scope in (fmodel.VenueScope.HOME, fmodel.VenueScope.ALL):
+            rule = fmodel.MatchCountLimit(
+                teams=[self.h1, self.h2], max_matches=1, venue_scope=scope
+            )
+            self.assertTrue(rule.counts_fixture(self.derby), scope)
+
+    def test_forbids_ignores_internal_derby_under_away_scope(self) -> None:
+        rng = fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31))
+        away_blackout = fmodel.MatchCountLimit(
+            teams=[self.h1, self.h2],
+            max_matches=0,
+            venue_scope=fmodel.VenueScope.AWAY,
+            date_ranges=(rng,),
+        )
+        self.assertFalse(away_blackout.forbids(self.derby, date(2025, 1, 15)))
+        self.assertTrue(away_blackout.forbids(self.away_at_x, date(2025, 1, 15)))
+
+    def test_two_internal_derbies_share_a_night_under_an_away_playing_teams_cap(
+        self,
+    ) -> None:
+        """The draft3 case in miniature: two of a club's own derbies are pinned to
+        the same night, and the club has an AWAY-scope max_playing_teams: 2 cap. The
+        derbies play at the club's own venue, so they don't count as away and the
+        cap is satisfied. Before internal matches were excluded from AWAY scope each
+        derby put 2 of the club's teams "away" (4 > 2) and this was INFEASIBLE.
+        """
+        h3 = fmodel.Team(division=2, club="H", index=3)
+        h4 = fmodel.Team(division=2, club="H", index=4)
+        night = date(2025, 1, 6)
+        params = _params(
+            teams=[self.h1, self.h2, h3, h4],
+            home_dates={"H": [night, date(2025, 1, 13), date(2025, 1, 20)]},
+            unavailable_away_dates={"H": []},
+            fixed_fixtures=[
+                fmodel.ScheduledFixture(
+                    fmodel.Fixture(home_team=self.h1, away_team=self.h2), night
+                ),
+                fmodel.ScheduledFixture(
+                    fmodel.Fixture(home_team=h3, away_team=h4), night
+                ),
+            ],
+            match_count_limits=[
+                fmodel.MatchCountLimit(
+                    teams=[self.h1, self.h2, h3, h4],
+                    max_matches=None,
+                    max_playing_teams=2,
+                    venue_scope=fmodel.VenueScope.AWAY,
+                )
+            ],
+        )
+        fixtures = list(fmodel.solve(params).fixtures)
+        self.assertEqual(len(fixtures), 4)  # both derbies, both legs
+        on_night = {sf.date for sf in fixtures if sf.date == night}
+        self.assertEqual(on_night, {night})
+
+    def test_away_playing_teams_cap_still_limits_genuine_away_matches(self) -> None:
+        """The same cap still bites when the matches really are away: club A's two
+        teams (different divisions, so no internal match between them) both have to
+        play their away leg on X's single home date, exceeding max_playing_teams: 1.
+        """
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        a2 = fmodel.Team(division=2, club="A", index=2)
+        x1 = fmodel.Team(division=1, club="X", index=1)
+        x2 = fmodel.Team(division=2, club="X", index=2)
+        params = _params(
+            teams=[a1, a2, x1, x2],
+            home_dates={"A": [date(2025, 3, 1)], "X": [date(2025, 1, 6)]},
+            unavailable_away_dates={"A": [], "X": []},
+            match_count_limits=[
+                fmodel.MatchCountLimit(
+                    teams=[a1, a2],
+                    max_matches=None,
+                    max_playing_teams=1,
+                    venue_scope=fmodel.VenueScope.AWAY,
+                )
+            ],
+        )
+        with self.assertRaisesRegex(ValueError, "INFEASIBLE"):
+            fmodel.solve(params)
+
+
 class TestDuplicateRejection(unittest.TestCase):
     """Parameters construction relies on each (Fixture, date) pair mapping to at most
     one solver variable; these are the two ways it could otherwise be violated."""

--- a/spec-schema.json
+++ b/spec-schema.json
@@ -273,7 +273,7 @@
         "type": "string",
         "enum": ["home", "away", "all"],
         "default": "all",
-        "description": "Which of the counted teams' matches the cap counts: 'home' only their home matches, 'away' only their away matches, or 'all' (the default) every match they play. E.g. 'away' counts only away fixtures, still allowing one team to play away on a night another is hosting."
+        "description": "Which of the counted teams' matches the cap counts: 'home' only their home matches, 'away' only their away matches, or 'all' (the default) every match they play. E.g. 'away' counts only away fixtures, still allowing one team to play away on a night another is hosting. An internal match (both teams the same club) is never counted under 'away' scope -- its 'away' team is playing at its own club's venue, so it isn't away for an away-load cap; it still counts under 'home' and 'all'."
       },
       "max_matches_overrides": {
         "type": "object",


### PR DESCRIPTION
A MatchCountLimit with venue_scope: away counted a fixture whenever its away team was in the rule's set -- including an internal match (both teams the same club), whose "away" side is really playing at its own club's venue. For a max_playing_teams cap that made an internal derby cost two of the club's teams towards an away-load limit, so e.g. a "no more than 2 teams away on a night" rule was made infeasible by two pinned same-club derbies on one date.

Add _fixture_counts_for_scope() as the single source of truth for both MatchCountLimit.counts_fixture and _counted_fixtures_by_date, and exclude internal matches under AWAY scope (they still count under HOME and ALL, where the players are committed either way). Update the docstrings, spec-schema.json and the fixturespec parser docs to match.


Claude-Session: https://claude.ai/code/session_018bLDbWpKvsG32ATkGsgDr4