### PR TITLE
Add run-index back-links; drop redundant index.html from run links

### DIFF
--- a/build_site_test.py
+++ b/build_site_test.py
@@ -154,8 +154,8 @@ class TestBuildReports(unittest.TestCase):
         )
 
         root = self.root_index.read_text()
-        self.assertIn("runs/example/index.html", root)
-        self.assertIn("runs/2026-27/draft1/index.html", root)
+        self.assertIn('<a href="runs/example/">', root)
+        self.assertIn('<a href="runs/2026-27/draft1/">', root)
 
     def test_writes_nothing_into_the_source_runs_dir(self) -> None:
         _make_run(self.runs_dir / "example", "Example Season")
@@ -182,7 +182,7 @@ class TestBuildReports(unittest.TestCase):
 
         self.assertFalse((self.out_dir / "runs" / "drop").exists())
         self.assertTrue((self.out_dir / "runs" / "keep" / "index.html").exists())
-        self.assertNotIn("runs/drop/index.html", self.root_index.read_text())
+        self.assertNotIn('href="runs/drop/"', self.root_index.read_text())
 
     def test_does_not_re_solve(self) -> None:
         run_dir = self.runs_dir / "example"

--- a/htmlreport.py
+++ b/htmlreport.py
@@ -56,6 +56,7 @@ _STYLE = """
     nav ul { list-style: none; padding: 0; }
     nav li { margin-bottom: 0.3rem; }
     nav ul ul { padding-left: 1.2rem; margin-top: 0.3rem; }
+    nav.breadcrumb { margin-bottom: 1rem; font-size: 0.9rem; }
     .venue { margin-top: -0.5rem; margin-bottom: 1.5rem; color: #333; }
     .date-summary, .match-count { margin-top: -1.5rem; margin-bottom: 2rem;
                                   color: #333; }
@@ -109,6 +110,7 @@ def _page(
     description: str = "",
     *,
     is_run_home: bool = False,
+    back_link: tuple[str, str] | None = None,
 ) -> str:
     banner_html = ""
     if run_name or draft:
@@ -119,6 +121,12 @@ def _page(
             parts.append(f'<span class="run-name">{html.escape(run_name)}</span>')
         classes = "banner draft" if draft else "banner"
         banner_html = f'<div class="{classes}">{" ".join(parts)}</div>\n'
+    back_link_html = ""
+    if back_link:
+        href, text = back_link
+        back_link_html = (
+            f'<nav class="breadcrumb"><a href="{href}">{html.escape(text)}</a></nav>\n'
+        )
     description_html = ""
     if description:
         description_html = f'<p class="description">{html.escape(description)}</p>\n'
@@ -133,6 +141,7 @@ def _page(
         "</head>\n"
         "<body>\n"
         f"{banner_html}"
+        f"{back_link_html}"
         f"{description_html}"
         f"<h1>{html.escape(title)}</h1>\n"
         f"{body}"
@@ -426,6 +435,11 @@ def _run_index_body(
     )
 
 
+# Sub-pages of a run (all-matches, per-division, per-club) carry this link back to
+# the run's own index. It points at the run directory rather than its index.html
+# so the URL stays clean on a server that serves index.html for a bare directory.
+_RUN_INDEX_BACK_LINK = ("./", "← Back to run index")
+
 _MATCH_HEADERS = ["Date", "Home", "Away", "Venue", "Start", "Time Limit"]
 _TEAM_MATCH_HEADERS = [
     "Date",
@@ -521,6 +535,7 @@ def generate_report(
             name,
             draft,
             description,
+            back_link=_RUN_INDEX_BACK_LINK,
         )
     )
     all_matches_links: list[tuple[str, str]] = [("all-matches.html", "All matches")]
@@ -550,6 +565,7 @@ def generate_report(
                 name,
                 draft,
                 description,
+                back_link=_RUN_INDEX_BACK_LINK,
             )
         )
         division_links.append((f"division-{division}.html", f"Division {division}"))
@@ -597,7 +613,14 @@ def generate_report(
                 body += _csv_link(team_csv, "Download CSV")
         club_slug = reportdata.slugify(club_id)
         (output_dir / f"club-{club_slug}.html").write_text(
-            _page(club_name, body, name, draft, description)
+            _page(
+                club_name,
+                body,
+                name,
+                draft,
+                description,
+                back_link=_RUN_INDEX_BACK_LINK,
+            )
         )
         club_links.append((f"club-{club_slug}.html", club_name))
     club_links.sort()
@@ -659,7 +682,9 @@ def _render_run_tree(
         child_parts = (*path_parts, name)
         label = html.escape(name)
         if child.is_run:
-            href = f"{rel_runs_dir}/{'/'.join(child_parts)}/index.html"
+            # Link the run directory, not its index.html: a server that serves
+            # index.html for a bare directory makes the filename redundant.
+            href = f"{rel_runs_dir}/{'/'.join(child_parts)}/"
             label = f'<a href="{href}">{label}</a>'
         if child.children:
             label += _render_run_tree(child, child_parts, rel_runs_dir)

--- a/htmlreport_test.py
+++ b/htmlreport_test.py
@@ -331,6 +331,18 @@ class TestGenerateReport(unittest.TestCase):
         self.assertIn(">Division 1<", content)
         self.assertIn(">Willesden &amp; Brent<", content)
 
+    def test_sub_pages_link_back_to_the_run_index(self) -> None:
+        for filename in ("all-matches.html", "division-1.html", "club-harrow.html"):
+            content = (self.output_dir / filename).read_text()
+            self.assertIn(
+                '<nav class="breadcrumb"><a href="./">← Back to run index</a></nav>',
+                content,
+                filename,
+            )
+
+    def test_run_index_has_no_back_link_to_itself(self) -> None:
+        self.assertNotIn('class="breadcrumb"', self.index_path.read_text())
+
     def test_run_index_links_to_csv_exports_when_present(self) -> None:
         # generate_report links whichever CSV exports it finds already written
         # into the output dir (csvreport.generate_csv writes them in production).
@@ -715,8 +727,9 @@ class TestWriteRunsIndex(unittest.TestCase):
         htmlreport.write_runs_index(self.runs_dir, self.index_path)
         content = self.index_path.read_text()
 
-        self.assertIn("runs/2024-25-season/index.html", content)
-        self.assertIn("runs/2025-26-season/index.html", content)
+        self.assertIn('<a href="runs/2024-25-season/">', content)
+        self.assertIn('<a href="runs/2025-26-season/">', content)
+        self.assertNotIn("index.html", content)
         self.assertNotIn("incomplete-run", content)
 
         # Sorted alphabetically by name at each level
@@ -735,9 +748,9 @@ class TestWriteRunsIndex(unittest.TestCase):
         htmlreport.write_runs_index(self.runs_dir, self.index_path)
         content = self.index_path.read_text()
 
-        self.assertIn("runs/2026-27/draft1/index.html", content)
+        self.assertIn('<a href="runs/2026-27/draft1/">', content)
         # The grouping folder itself has no report, so isn't a link.
-        self.assertNotIn('<a href="runs/2026-27/index.html"', content)
+        self.assertNotIn('<a href="runs/2026-27/"', content)
         self.assertIn("2026-27", content)
 
     def test_nested_and_flat_runs_combined(self) -> None:
@@ -750,8 +763,21 @@ class TestWriteRunsIndex(unittest.TestCase):
         htmlreport.write_runs_index(self.runs_dir, self.index_path)
         content = self.index_path.read_text()
 
-        self.assertIn("runs/example/index.html", content)
-        self.assertIn("runs/2026-27/draft1/index.html", content)
+        self.assertIn('<a href="runs/example/">', content)
+        self.assertIn('<a href="runs/2026-27/draft1/">', content)
+
+    def test_run_links_omit_redundant_index_html(self) -> None:
+        for name in ("example", "2026-27/draft1"):
+            run_dir = self.runs_dir / name
+            run_dir.mkdir(parents=True)
+            (run_dir / "all-matches.html").write_text("<html></html>")
+
+        htmlreport.write_runs_index(self.runs_dir, self.index_path)
+        content = self.index_path.read_text()
+
+        self.assertIn('<a href="runs/example/">', content)
+        self.assertIn('<a href="runs/2026-27/draft1/">', content)
+        self.assertNotIn("index.html", content)
 
     def test_siblings_sorted_alphabetically(self) -> None:
         for name in ["draft2", "draft1", "draft10"]:


### PR DESCRIPTION
Sub-pages of a run (all-matches, per-division, per-club) now carry a "Back to run index" breadcrumb linking the run directory (#91). The top-level runs index links each run as its directory rather than its index.html, which a server serving index.html for a bare directory makes redundant (#92).


Claude-Session: https://claude.ai/code/session_01LTM5JWFzWnDCp2Wx1v4H2F