### PR TITLE
Split MatchCountLimit into RollingLimit/RangeLimit (closes #93)

### DIFF
--- a/fixturespec.py
+++ b/fixturespec.py
@@ -432,7 +432,7 @@ class _ClubConstraints:
     home_dates_used: dict[str, fmodel.HomeDatesUsedBounds]
     team_home_dates: dict[fmodel.Team, list[date]]
     team_unavailable_away_dates: dict[fmodel.Team, list[date]]
-    match_count_limits: list[fmodel.MatchCountLimit]
+    match_count_limits: list[fmodel.MatchLimit]
 
 
 def _parse_club_constraints(
@@ -940,9 +940,10 @@ def _parse_match_count_limits(
                     f"{entry_context}: 'date_ranges' and "
                     "'max_playing_teams_overrides' can't be combined"
                 )
-            if max_ is None:
+            if max_ is None and max_playing_teams is None:
                 raise SpecError(
-                    f"{entry_context}.date_ranges needs an integer 'max_matches' (>= 0)"
+                    f"{entry_context}.date_ranges needs an integer 'max_matches' "
+                    "(>= 0) and/or a 'max_playing_teams'"
                 )
             date_ranges = _parse_match_count_date_ranges(
                 entry["date_ranges"], f"{entry_context}.date_ranges"
@@ -993,24 +994,38 @@ def _parse_match_count_limits(
     return limits
 
 
+def _resolved_cap(
+    base: int | None, overrides: Mapping[date, int | None]
+) -> fmodel.Cap | None:
+    """A fmodel.Cap for a parsed (base, overrides) pair -- 'max_matches'/
+    'max_matches_overrides' or 'max_playing_teams'/'max_playing_teams_overrides'
+    -- or None when neither carries an actual cap, so that measure is left
+    unconstrained on the resolved MatchLimit."""
+    if base is None and not overrides:
+        return None
+    return fmodel.Cap(base=base, overrides=dict(overrides))
+
+
 def _resolve_match_count_limits(
     default_limits: list[_ParsedMatchCountLimit],
     club_limits: Mapping[str, list[_ParsedMatchCountLimit]],
     clubs: Mapping[str, fmodel.Club],
     teams: Mapping[str, fmodel.Team],
     path: Path,
-) -> list[fmodel.MatchCountLimit]:
+) -> list[fmodel.MatchLimit]:
     """Combine the spec-wide default match_count_limits with each club's own, and
-    resolve every entry to a concrete fmodel.MatchCountLimit.
+    resolve every entry to a concrete fmodel.MatchLimit (a RangeLimit when the
+    entry carries 'date_ranges', otherwise a RollingLimit).
 
     A club entry whose 'override_key' names a default entry replaces that default
     for the club (an unknown key, or two club entries sharing one, is an error);
     every other club entry is additive. Entries that carry none of 'max_matches',
-    'max_matches_overrides' or 'max_playing_teams' (a pure cancel-the-default marker)
-    and entries that resolve to no teams are dropped.
+    'max_matches_overrides', 'max_playing_teams' or 'max_playing_teams_overrides'
+    (a pure cancel-the-default marker) and entries that resolve to no teams are
+    dropped.
     """
     default_keys = {pl.override_key for pl in default_limits}
-    resolved: list[fmodel.MatchCountLimit] = []
+    resolved: list[fmodel.MatchLimit] = []
     for club_id in clubs:
         own = list(club_limits.get(club_id, []))
         overridden: dict[str, _ParsedMatchCountLimit] = {}
@@ -1036,12 +1051,11 @@ def _resolve_match_count_limits(
 
         club_team_objs = [teams[tid] for tid in _club_team_ids(club_id, teams)]
         for pl in effective:
-            if (
-                pl.max_matches is None
-                and not pl.max_matches_overrides
-                and pl.max_playing_teams is None
-                and not pl.max_playing_teams_overrides
-            ):
+            match_cap = _resolved_cap(pl.max_matches, pl.max_matches_overrides)
+            playing_teams_cap = _resolved_cap(
+                pl.max_playing_teams, pl.max_playing_teams_overrides
+            )
+            if match_cap is None and playing_teams_cap is None:
                 continue
             team_objs = (
                 club_team_objs
@@ -1050,20 +1064,29 @@ def _resolve_match_count_limits(
             )
             if not team_objs:
                 continue
-            resolved.append(
-                fmodel.MatchCountLimit(
-                    teams=team_objs,
-                    max_matches=pl.max_matches,
-                    time_window_days=pl.time_window_days,
-                    venue_scope=pl.venue_scope,
-                    apply_per=pl.apply_per,
-                    max_matches_overrides=pl.max_matches_overrides,
-                    date_ranges=pl.date_ranges,
-                    max_playing_teams=pl.max_playing_teams,
-                    max_playing_teams_overrides=pl.max_playing_teams_overrides,
-                    exclude_dates=pl.exclude_dates,
+            if pl.date_ranges:
+                resolved.append(
+                    fmodel.RangeLimit(
+                        teams=team_objs,
+                        match_cap=match_cap,
+                        playing_teams_cap=playing_teams_cap,
+                        venue_scope=pl.venue_scope,
+                        apply_per=pl.apply_per,
+                        ranges=pl.date_ranges,
+                    )
                 )
-            )
+            else:
+                resolved.append(
+                    fmodel.RollingLimit(
+                        teams=team_objs,
+                        match_cap=match_cap,
+                        playing_teams_cap=playing_teams_cap,
+                        venue_scope=pl.venue_scope,
+                        apply_per=pl.apply_per,
+                        window_days=pl.time_window_days,
+                        exclude_dates=pl.exclude_dates,
+                    )
+                )
     return resolved
 
 

--- a/fixturespec_test.py
+++ b/fixturespec_test.py
@@ -17,7 +17,7 @@
 import hashlib
 import tempfile
 import unittest
-from collections.abc import Collection
+from collections.abc import Collection, Mapping
 from datetime import date
 from pathlib import Path
 
@@ -26,13 +26,13 @@ import fmodel
 
 
 def _find_limit(
-    limits: Collection[fmodel.MatchCountLimit],
+    limits: Collection[fmodel.MatchLimit],
     *,
     club: str,
     venue_scope: fmodel.VenueScope,
     apply_per: fmodel.ApplyPer,
-) -> fmodel.MatchCountLimit:
-    """The one resolved MatchCountLimit for `club` with the given venue_scope /
+) -> fmodel.MatchLimit:
+    """The one resolved MatchLimit for `club` with the given venue_scope /
     apply_per (fails the calling assertion if there isn't exactly one)."""
     matches = [
         limit
@@ -43,6 +43,18 @@ def _find_limit(
     ]
     assert len(matches) == 1, f"expected exactly one, got {matches}"
     return matches[0]
+
+
+def _cap_base(cap: fmodel.Cap | None) -> int | None:
+    """`cap.base`, or None if there's no cap at all -- lets a test assert on the
+    effective plain value ('max_matches'/'max_playing_teams' in the old flat
+    shape) without caring whether the whole Cap is absent or just its base."""
+    return cap.base if cap is not None else None
+
+
+def _cap_overrides(cap: fmodel.Cap | None) -> Mapping[date, int | None]:
+    """`cap.overrides`, or {} if there's no cap at all."""
+    return cap.overrides if cap is not None else {}
 
 
 # Clubs/teams/divisions boilerplate, minus 'club_constraints', for tests that need to
@@ -205,7 +217,7 @@ class TestLoadSpec(unittest.TestCase):
                 venue_scope=fmodel.VenueScope.HOME,
                 apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
             )
-            self.assertEqual(limit.max_matches, 1)
+            self.assertEqual(_cap_base(limit.match_cap), 1)
         self.assertEqual(spec.name, "")
         self.assertFalse(spec.draft)
 
@@ -365,14 +377,14 @@ class TestLoadSpec(unittest.TestCase):
             "    home_dates: [2025-12-08]\n"
         )
         spec = fixturespec.load_spec(path)
-        by_club = {}
+        by_club: dict[str, fmodel.RangeLimit] = {}
         for limit in spec.parameters.match_count_limits:
-            if limit.max_matches == 0:
+            if isinstance(limit, fmodel.RangeLimit) and _cap_base(limit.match_cap) == 0:
                 (club,) = {t.club for t in limit.teams}
                 by_club[club] = limit
         self.assertEqual(set(by_club), {"albany", "hackney"})
         self.assertEqual(
-            by_club["albany"].date_ranges,
+            by_club["albany"].ranges,
             (fmodel.DateRange(date(2025, 12, 22), date(2026, 1, 4)),),
         )
 
@@ -400,7 +412,7 @@ class TestLoadSpec(unittest.TestCase):
         zero_clubs = {
             t.club
             for limit in spec.parameters.match_count_limits
-            if limit.max_matches == 0
+            if isinstance(limit, fmodel.RangeLimit) and _cap_base(limit.match_cap) == 0
             for t in limit.teams
         }
         self.assertEqual(zero_clubs, {"hackney"})
@@ -451,7 +463,7 @@ class TestLoadSpec(unittest.TestCase):
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertEqual(albany.max_matches, 3)
+        self.assertEqual(_cap_base(albany.match_cap), 3)
         # hackney has no entry of its own, so it keeps the default home cap 1.
         hackney = _find_limit(
             spec.parameters.match_count_limits,
@@ -459,7 +471,7 @@ class TestLoadSpec(unittest.TestCase):
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertEqual(hackney.max_matches, 1)
+        self.assertEqual(_cap_base(hackney.match_cap), 1)
 
     def test_match_count_limits_max_matches_overrides_parsed(self) -> None:
         path = self._write(
@@ -478,8 +490,8 @@ class TestLoadSpec(unittest.TestCase):
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertEqual(albany.max_matches, 2)
-        self.assertEqual(albany.max_matches_overrides, {date(2025, 9, 1): 3})
+        self.assertEqual(_cap_base(albany.match_cap), 2)
+        self.assertEqual(_cap_overrides(albany.match_cap), {date(2025, 9, 1): 3})
 
     def test_match_count_limits_override_null_lifts_the_cap_that_day(self) -> None:
         path = self._write(
@@ -498,8 +510,8 @@ class TestLoadSpec(unittest.TestCase):
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertIsNone(albany.max_matches)
-        self.assertEqual(albany.max_matches_overrides, {date(2025, 9, 1): 3})
+        self.assertIsNone(_cap_base(albany.match_cap))
+        self.assertEqual(_cap_overrides(albany.match_cap), {date(2025, 9, 1): 3})
 
     def test_match_count_limits_null_max_cancels_default_via_override_key(self) -> None:
         path = self._write(
@@ -524,15 +536,13 @@ class TestLoadSpec(unittest.TestCase):
         ]
         self.assertEqual(albany_home, [])
         # hackney still gets the default.
-        self.assertEqual(
-            _find_limit(
-                spec.parameters.match_count_limits,
-                club="hackney",
-                venue_scope=fmodel.VenueScope.HOME,
-                apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
-            ).max_matches,
-            1,
+        hackney = _find_limit(
+            spec.parameters.match_count_limits,
+            club="hackney",
+            venue_scope=fmodel.VenueScope.HOME,
+            apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
+        self.assertEqual(_cap_base(hackney.match_cap), 1)
 
     def test_match_count_limits_unknown_override_key_rejected(self) -> None:
         path = self._write(
@@ -637,21 +647,25 @@ class TestLoadSpec(unittest.TestCase):
         )
         spec = fixturespec.load_spec(path)
         self.assertEqual(
-            _find_limit(
-                spec.parameters.match_count_limits,
-                club="albany",
-                venue_scope=fmodel.VenueScope.HOME,
-                apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
-            ).max_matches,
+            _cap_base(
+                _find_limit(
+                    spec.parameters.match_count_limits,
+                    club="albany",
+                    venue_scope=fmodel.VenueScope.HOME,
+                    apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
+                ).match_cap
+            ),
             2,
         )
         self.assertEqual(
-            _find_limit(
-                spec.parameters.match_count_limits,
-                club="albany",
-                venue_scope=fmodel.VenueScope.ALL,
-                apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
-            ).max_matches,
+            _cap_base(
+                _find_limit(
+                    spec.parameters.match_count_limits,
+                    club="albany",
+                    venue_scope=fmodel.VenueScope.ALL,
+                    apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
+                ).match_cap
+            ),
             1,
         )
 
@@ -683,7 +697,8 @@ class TestLoadSpec(unittest.TestCase):
             venue_scope=fmodel.VenueScope.ALL,
             apply_per=fmodel.ApplyPer.EACH_TEAM,
         )
-        self.assertEqual((limit.time_window_days, limit.max_matches), (7, 1))
+        assert isinstance(limit, fmodel.RollingLimit)
+        self.assertEqual((limit.window_days, _cap_base(limit.match_cap)), (7, 1))
 
     def test_match_count_limits_unknown_venue_scope_rejected(self) -> None:
         path = self._write(
@@ -752,14 +767,15 @@ class TestLoadSpec(unittest.TestCase):
             venue_scope=fmodel.VenueScope.ALL,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
+        assert isinstance(limit, fmodel.RangeLimit)
         self.assertEqual(
-            limit.date_ranges,
+            limit.ranges,
             (
                 fmodel.DateRange(date(2025, 10, 27), date(2025, 11, 2)),
                 fmodel.DateRange(date(2026, 2, 16), date(2026, 2, 22)),
             ),
         )
-        self.assertEqual((limit.max_matches, limit.time_window_days), (1, 1))
+        self.assertEqual(_cap_base(limit.match_cap), 1)
 
     def test_match_count_limits_date_ranges_allow_max_zero(self) -> None:
         path = self._write(
@@ -778,7 +794,7 @@ class TestLoadSpec(unittest.TestCase):
             venue_scope=fmodel.VenueScope.ALL,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertEqual(limit.max_matches, 0)
+        self.assertEqual(_cap_base(limit.match_cap), 0)
 
     def test_match_count_limits_max_zero_rejected_without_date_ranges(self) -> None:
         path = self._write(
@@ -859,8 +875,9 @@ class TestLoadSpec(unittest.TestCase):
             venue_scope=fmodel.VenueScope.ALL,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
+        assert isinstance(limit, fmodel.RangeLimit)
         self.assertEqual(
-            limit.date_ranges,
+            limit.ranges,
             (fmodel.DateRange(date(2025, 10, 27), date(2025, 11, 2)),),
         )
 
@@ -1487,24 +1504,22 @@ club_constraints:
             "    home_dates: [2025-09-15]\n"
         )
         spec = fixturespec.load_spec(path)
-        self.assertEqual(
-            _find_limit(
-                spec.parameters.match_count_limits,
-                club="albany",
-                venue_scope=fmodel.VenueScope.ALL,
-                apply_per=fmodel.ApplyPer.EACH_TEAM,
-            ).time_window_days,
-            14,
+        albany_gap = _find_limit(
+            spec.parameters.match_count_limits,
+            club="albany",
+            venue_scope=fmodel.VenueScope.ALL,
+            apply_per=fmodel.ApplyPer.EACH_TEAM,
         )
-        self.assertEqual(
-            _find_limit(
-                spec.parameters.match_count_limits,
-                club="hackney",
-                venue_scope=fmodel.VenueScope.ALL,
-                apply_per=fmodel.ApplyPer.EACH_TEAM,
-            ).time_window_days,
-            7,
+        hackney_gap = _find_limit(
+            spec.parameters.match_count_limits,
+            club="hackney",
+            venue_scope=fmodel.VenueScope.ALL,
+            apply_per=fmodel.ApplyPer.EACH_TEAM,
         )
+        assert isinstance(albany_gap, fmodel.RollingLimit)
+        assert isinstance(hackney_gap, fmodel.RollingLimit)
+        self.assertEqual(albany_gap.window_days, 14)
+        self.assertEqual(hackney_gap.window_days, 7)
 
     def test_match_count_limits_negative_max_rejected(self) -> None:
         path = self._write(
@@ -1546,8 +1561,8 @@ club_constraints:
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertEqual(limit.max_matches, 3)
-        self.assertEqual(limit.max_playing_teams, 3)
+        self.assertEqual(_cap_base(limit.match_cap), 3)
+        self.assertEqual(_cap_base(limit.playing_teams_cap), 3)
 
     def test_match_count_limits_max_playing_teams_defaults_to_none(self) -> None:
         path = self._write(_MINIMAL_SPEC)
@@ -1558,7 +1573,7 @@ club_constraints:
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertIsNone(limit.max_playing_teams)
+        self.assertIsNone(_cap_base(limit.playing_teams_cap))
 
     def test_match_count_limits_max_playing_teams_negative_rejected(self) -> None:
         path = self._write(
@@ -1594,8 +1609,9 @@ club_constraints:
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertEqual(limit.max_playing_teams, 1)
-        self.assertEqual(limit.time_window_days, 7)
+        assert isinstance(limit, fmodel.RollingLimit)
+        self.assertEqual(_cap_base(limit.playing_teams_cap), 1)
+        self.assertEqual(limit.window_days, 7)
 
     def test_match_count_limits_max_playing_teams_allows_date_ranges(self) -> None:
         path = self._write(
@@ -1616,9 +1632,10 @@ club_constraints:
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertEqual(limit.max_playing_teams, 0)
+        assert isinstance(limit, fmodel.RangeLimit)
+        self.assertEqual(_cap_base(limit.playing_teams_cap), 0)
         self.assertEqual(
-            limit.date_ranges,
+            limit.ranges,
             (fmodel.DateRange(date(2025, 9, 1), date(2025, 9, 7)),),
         )
 
@@ -1639,8 +1656,8 @@ club_constraints:
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertIsNone(limit.max_matches)
-        self.assertEqual(limit.max_playing_teams, 2)
+        self.assertIsNone(_cap_base(limit.match_cap))
+        self.assertEqual(_cap_base(limit.playing_teams_cap), 2)
 
     def test_match_count_limits_max_playing_teams_alone_with_explicit_null(
         self,
@@ -1662,8 +1679,8 @@ club_constraints:
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertIsNone(limit.max_matches)
-        self.assertEqual(limit.max_playing_teams, 2)
+        self.assertIsNone(_cap_base(limit.match_cap))
+        self.assertEqual(_cap_base(limit.playing_teams_cap), 2)
 
     def test_match_count_limits_max_matches_alone_is_allowed(self) -> None:
         """max_matches can carry a rule on its own, with 'max_playing_teams'
@@ -1682,8 +1699,8 @@ club_constraints:
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertEqual(limit.max_matches, 3)
-        self.assertIsNone(limit.max_playing_teams)
+        self.assertEqual(_cap_base(limit.match_cap), 3)
+        self.assertIsNone(_cap_base(limit.playing_teams_cap))
 
     def test_match_count_limits_neither_max_field_rejected(self) -> None:
         """Neither 'max_matches' nor 'max_playing_teams', and no other way to carry
@@ -1718,9 +1735,9 @@ club_constraints:
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertEqual(limit.max_playing_teams, 1)
+        self.assertEqual(_cap_base(limit.playing_teams_cap), 1)
         self.assertEqual(
-            limit.max_playing_teams_overrides,
+            _cap_overrides(limit.playing_teams_cap),
             {date(2025, 9, 1): 2, date(2025, 9, 8): None},
         )
 
@@ -1809,7 +1826,8 @@ club_constraints:
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertEqual(limit.time_window_days, 7)
+        assert isinstance(limit, fmodel.RollingLimit)
+        self.assertEqual(limit.window_days, 7)
         self.assertEqual(
             limit.exclude_dates,
             frozenset({date(2025, 9, 1), date(2025, 9, 8)}),
@@ -1824,6 +1842,7 @@ club_constraints:
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
+        assert isinstance(limit, fmodel.RollingLimit)
         self.assertEqual(limit.exclude_dates, frozenset())
 
     def test_match_count_limits_exclude_dates_invalid_date_rejected(self) -> None:
@@ -2169,8 +2188,10 @@ club_constraints:
         self.assertEqual(
             list(spec.parameters.match_count_limits),
             [
-                fmodel.MatchCountLimit(
-                    teams=[albany_1, albany_2], max_matches=1, time_window_days=1
+                fmodel.RollingLimit(
+                    teams=[albany_1, albany_2],
+                    match_cap=fmodel.Cap(1),
+                    window_days=1,
                 )
             ],
         )
@@ -2190,8 +2211,9 @@ club_constraints:
         )
         constraints = list(spec.parameters.match_count_limits)
         self.assertEqual(list(constraints[0].teams), [albany_1, albany_2])
-        self.assertEqual(constraints[0].max_matches, 3)
-        self.assertEqual(constraints[0].time_window_days, 7)
+        assert isinstance(constraints[0], fmodel.RollingLimit)
+        self.assertEqual(_cap_base(constraints[0].match_cap), 3)
+        self.assertEqual(constraints[0].window_days, 7)
 
     def test_match_count_limits_time_window_days_parsed(self) -> None:
         path = self._write(
@@ -2204,7 +2226,8 @@ club_constraints:
         )
         spec = fixturespec.load_spec(path)
         constraints = list(spec.parameters.match_count_limits)
-        self.assertEqual(constraints[0].time_window_days, 3)
+        assert isinstance(constraints[0], fmodel.RollingLimit)
+        self.assertEqual(constraints[0].window_days, 3)
 
     def test_match_count_limits_time_window_days_defaults_to_one(self) -> None:
         path = self._write(
@@ -2216,7 +2239,8 @@ club_constraints:
         )
         spec = fixturespec.load_spec(path)
         constraints = list(spec.parameters.match_count_limits)
-        self.assertEqual(constraints[0].time_window_days, 1)
+        assert isinstance(constraints[0], fmodel.RollingLimit)
+        self.assertEqual(constraints[0].window_days, 1)
 
     def test_match_count_limits_venue_scope_defaults_to_all(self) -> None:
         path = self._write(

--- a/fmodel.py
+++ b/fmodel.py
@@ -14,6 +14,7 @@
 
 """Library to model and solve Middlesex League fixtures scheduling."""
 
+import abc
 import collections
 import dataclasses
 import enum
@@ -184,8 +185,8 @@ class Division:
 class DateRange:
     """An inclusive span of calendar dates, `start` on or before `end`.
 
-    Used by MatchCountLimit.date_ranges to pin a cap to specific calendar periods
-    (a school-holiday week, say) rather than a rolling window. `d in date_range`
+    Used by RangeLimit.ranges to pin a cap to specific calendar periods (a
+    school-holiday week, say) rather than a rolling window. `d in date_range`
     tests membership.
     """
 
@@ -213,11 +214,11 @@ class VenueScope(enum.Enum):
 
 
 class ApplyPer(enum.Enum):
-    """How a MatchCountLimit's `max_matches`/`max_playing_teams` applies to its
+    """How a MatchCountLimit's caps (`match_cap`/`playing_teams_cap`) apply to its
     `teams`. ACROSS_TEAMS: one shared budget for the whole set (a venue capacity, or
     a keep-these-teams-apart rule). EACH_TEAM: the cap is enforced separately for
     every team in the set (a per-team gap -- `teams` is then typically every team of
-    a club and `max_matches` is 1).
+    a club and `match_cap` is `Cap(1)`).
     """
 
     EACH_TEAM = "each_team"
@@ -245,132 +246,131 @@ def _fixture_counts_for_scope(
 
 
 @dataclasses.dataclass(frozen=True)
-class MatchCountLimit:
-    """At most `max_matches` matches involving `teams` may fall within any window of
-    `time_window_days` consecutive calendar days. This is the sole match-count
-    constraint mechanism -- a per-team gap ("each team plays at most once a week"),
-    a venue's concurrent-match capacity ("at most two home matches a night"), and a
-    keep-these-teams-apart rule are all expressed as instances of it.
+class Cap:
+    """A per-window integer ceiling: `base` (None = unbounded) together with
+    optional per-date `overrides`.
 
-    `time_window_days` counts a run of consecutive days, not a gap between two
-    endpoints: `time_window_days=1` (the default) limits matches on a single date;
-    `time_window_days=7` limits matches in any seven-consecutive-day period, so two
-    matches exactly a week apart (day N and day N+7) never share a window and are
-    unrestricted relative to each other.
+    An override applies only where a window is a single date (see for_window) --
+    it names that date's replacement ceiling (an int, or None to lift the cap for
+    that date). Overrides are therefore only meaningful, and only accepted, on a
+    RollingLimit with window_days == 1: an override names one date, which lines up
+    with exactly one window only then.
 
-    `apply_per` (see ApplyPer) decides whether `max_matches` (and `max_playing_teams`)
-    is one shared budget for the whole `teams` set (ACROSS_TEAMS, the default) or
-    enforced separately per team (EACH_TEAM).
+    A Cap does the same window/override resolution for both of a MatchCountLimit's
+    measures -- how many matches count, and how many teams'-worth of players they
+    ask for -- rather than each duplicating it.
+    """
 
-    `venue_scope` narrows which of those teams' matches count: VenueScope.HOME only
-    their home matches, VenueScope.AWAY only their away matches, VenueScope.ALL (the
-    default) every match they play. So an AWAY cap counts only the teams' away
-    fixtures, still allowing one to play away on a night another is hosting. An
-    internal match (both teams the same club) is never counted under AWAY scope:
-    its "away" team is playing at its own club's venue, so it isn't away for the
-    purpose of an away-load cap (it still counts under HOME and ALL, where its
-    players are committed either way).
+    base: int | None = None
+    overrides: Mapping[date, int | None] = dataclasses.field(default_factory=dict)
 
-    `max_matches` may be None, meaning no cap from the plain value -- only useful
-    alongside `max_matches_overrides`, which replace `max_matches` on specific dates
-    (an int, or None to lift the cap that day). These per-date overrides are only
-    meaningful, and only permitted, when `time_window_days` is 1, so each window is a
-    single date.
+    def __post_init__(self) -> None:
+        if self.base is not None and self.base < 0:
+            raise ValueError(f"Cap base must be >= 0 or None, got {self.base}")
+        for d, value in self.overrides.items():
+            if value is not None and value < 0:
+                raise ValueError(
+                    f"Cap override for {d.isoformat()} must be >= 0 or None, got "
+                    f"{value}"
+                )
 
-    `date_ranges`, when non-empty, replaces the rolling-window behaviour entirely:
-    instead of every run of `time_window_days` consecutive days, the cap applies to
-    exactly the given DateRanges, each counted independently. This targets a limit
-    tied to specific weeks -- a school-holiday week, a congress fortnight -- that a
-    rolling window can't express. It requires `time_window_days` left at its default
-    of 1, is mutually exclusive with `max_matches_overrides`, and `max_matches` must
-    then be a non-negative integer (`max_matches=0` bars every counted match in the
-    range).
+    def for_window(self, window: Collection[date]) -> int | None:
+        """This cap's effective ceiling for `window`: an `overrides` entry when the
+        window is a single overridden date, otherwise `base`."""
+        if self.overrides and len(window) == 1:
+            (d,) = tuple(window)
+            return self.overrides.get(d, self.base)
+        return self.base
 
-    `max_playing_teams`, when not None, caps how many teams'-worth of players from
-    `teams` a window asks for: each counted match adds one of `teams` playing to the
-    total, or two if it's an internal match between two of `teams` (e.g. a same-club
-    derby counted by a club's own venue-capacity rule) -- one entry towards
-    `max_matches`, but two teams from the set on to play. (Under AWAY `venue_scope`
-    an internal match is not counted at all, so it adds nothing here either.) A
-    venue that can physically host 3 simultaneous matches but only has 3 sets of
-    players to field wants `max_matches=3` *and* `max_playing_teams=3` -- otherwise
-    3 matches, one an internal derby, would need 4 teams' worth of players. Over a
-    wider window (a multi-day `time_window_days`, or `date_ranges`), the same pair
-    meeting twice counts twice: two internal matches between the same two teams
-    still means fielding 4 teams'-worth of players across the window, once per
-    match, not 2 -- this is a running tally of teams asked to play, not a count of
-    distinct teams touched. `max_playing_teams_overrides` replaces it on specific
-    dates (an int, or None to lift the cap that day), mirroring
-    `max_matches_overrides` -- only meaningful, and only permitted, when
-    `time_window_days` is 1.
+    def zero_on(self, d: date) -> bool:
+        """Whether this cap is an effective 0 on `d`: a `base` of 0 (every day), or
+        an `overrides` entry of 0 for `d` specifically. Feeds the up-front
+        candidate pruning in MatchCountLimit.forbids."""
+        return self.base == 0 or self.overrides.get(d) == 0
 
-    `exclude_dates` drops every counted match falling on one of the listed dates
-    from this rule: each window is evaluated as if nothing counted happened then,
-    for both `max_matches` and `max_playing_teams`. Unlike the `*_overrides` maps it
-    is not tied to a single-date window, so it is the way to exempt one date from a
-    multi-day rolling cap -- typically a date whose load is already pinned by
-    `fixed_fixtures` and bounded by its own `max_matches_overrides` entry. Mutually
-    exclusive with `date_ranges` (leave the date out of the ranges instead).
+
+class _Measure(enum.Enum):
+    """The quantity one of a MatchCountLimit's Caps bounds within a window.
+
+    MATCHES counts each counted candidate once. PLAYING_TEAMS counts how many of
+    the rule's `teams` that candidate puts on to play: one for an ordinary match,
+    two for an internal match between two of `teams` (e.g. a same-club derby) --
+    see _FixtureVars.teams_playing.
+    """
+
+    MATCHES = "matches"
+    PLAYING_TEAMS = "playing_teams"
+
+    def term(
+        self,
+        fixture_vars: _FixtureVars,
+        fixture: Fixture,
+        match_date: date,
+        team_set: Collection[Team],
+    ) -> cp_model.LinearExprT:
+        """This measure's contribution from one counted (fixture, match_date)
+        candidate, as a linear expression in that candidate's decision variable."""
+        if self is _Measure.MATCHES:
+            return fixture_vars.fixture_date_vars()[fixture, match_date]
+        return fixture_vars.teams_playing(fixture, match_date, team_set)
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class MatchCountLimit(abc.ABC):
+    """A cap on how many of `teams`' matches -- and/or how many teams'-worth of
+    their players -- may fall within a window of dates. This is the sole
+    match-count constraint mechanism: a per-team gap ("each team plays at most
+    once a week"), a venue's concurrent-match capacity ("at most two home matches
+    a night"), a keep-these-teams-apart rule and a school-holiday blackout are all
+    expressed as one of the two concrete subclasses below, which differ only in
+    how a window is defined:
+
+      - RollingLimit: every run of `window_days` consecutive calendar days
+        (window_days == 1, the default, is one window per date).
+      - RangeLimit: exactly the given explicit calendar ranges, each counted
+        independently -- for a limit tied to specific weeks (a school-holiday
+        week, a congress fortnight) that a rolling window can't express.
+
+    Everything else is shared here:
+
+      `teams` is the set whose matches are counted. `venue_scope` (see VenueScope)
+      narrows which of those matches count: HOME only their home matches, AWAY
+      only their away matches, ALL (the default) every match they play. An
+      internal match (both teams the same club) is never counted under AWAY
+      scope -- its "away" team plays at its own club's venue -- but still counts
+      under HOME and ALL.
+
+      `apply_per` (see ApplyPer) decides whether the caps below are one shared
+      budget for the whole `teams` set (ACROSS_TEAMS, the default) or enforced
+      separately for every team (EACH_TEAM -- `teams` is then typically a whole
+      club and the cap a per-team gap).
+
+      `match_cap` caps the number of counted matches in a window; `playing_teams_cap`
+      caps how many teams'-worth of players it asks for -- each counted match
+      contributes one, or two if it's an internal match between two of `teams`
+      (e.g. a same-club derby counted by that club's own venue-capacity rule): one
+      entry towards `match_cap`, but two teams from the set on to play. Either may
+      be None (that measure left uncapped); at least one must be set. A venue that
+      can physically host 3 simultaneous matches but only has 3 teams' worth of
+      players to field wants both `match_cap=Cap(3)` and `playing_teams_cap=Cap(3)`
+      -- a `match_cap` alone can't tell that 3 matches, one an internal derby,
+      need 4 teams' worth of players. Over a window spanning more than a single
+      date, the same pair meeting twice counts twice towards `playing_teams_cap`:
+      it is a running tally of teams'-worth of players asked to play, not a count
+      of distinct teams touched.
     """
 
     teams: Collection[Team]
-    max_matches: int | None
-    time_window_days: int = 1
+    match_cap: Cap | None = None
+    playing_teams_cap: Cap | None = None
     venue_scope: VenueScope = VenueScope.ALL
     apply_per: ApplyPer = ApplyPer.ACROSS_TEAMS
-    max_matches_overrides: Mapping[date, int | None] = dataclasses.field(
-        default_factory=dict
-    )
-    date_ranges: tuple[DateRange, ...] = ()
-    max_playing_teams: int | None = None
-    max_playing_teams_overrides: Mapping[date, int | None] = dataclasses.field(
-        default_factory=dict
-    )
-    exclude_dates: frozenset[date] = frozenset()
 
     def __post_init__(self) -> None:
-        if self.max_matches_overrides and self.time_window_days != 1:
+        if self.match_cap is None and self.playing_teams_cap is None:
             raise ValueError(
-                "MatchCountLimit.max_matches_overrides requires time_window_days == 1"
+                "MatchCountLimit needs a match_cap and/or a playing_teams_cap"
             )
-        if self.max_playing_teams_overrides and self.time_window_days != 1:
-            raise ValueError(
-                "MatchCountLimit.max_playing_teams_overrides requires "
-                "time_window_days == 1"
-            )
-        if self.date_ranges:
-            if self.time_window_days != 1:
-                raise ValueError(
-                    "MatchCountLimit.date_ranges can't be combined with a "
-                    "non-default time_window_days (it replaces the rolling window)"
-                )
-            if self.max_matches_overrides:
-                raise ValueError(
-                    "MatchCountLimit.date_ranges and max_matches_overrides are "
-                    "mutually exclusive"
-                )
-            if self.exclude_dates:
-                raise ValueError(
-                    "MatchCountLimit.date_ranges and exclude_dates are mutually "
-                    "exclusive (leave the date out of the ranges instead)"
-                )
-
-    def max_matches_for_window(self, window: Collection[date]) -> int | None:
-        """The effective matches cap for one window: a `max_matches_overrides` entry
-        when the window is a single overridden date, otherwise `max_matches`."""
-        if self.max_matches_overrides and len(window) == 1:
-            (d,) = tuple(window)
-            return self.max_matches_overrides.get(d, self.max_matches)
-        return self.max_matches
-
-    def max_playing_teams_for_window(self, window: Collection[date]) -> int | None:
-        """The effective playing-teams cap for one window: a
-        `max_playing_teams_overrides` entry when the window is a single overridden
-        date, otherwise `max_playing_teams`."""
-        if self.max_playing_teams_overrides and len(window) == 1:
-            (d,) = tuple(window)
-            return self.max_playing_teams_overrides.get(d, self.max_playing_teams)
-        return self.max_playing_teams
 
     def counts_fixture(self, fixture: Fixture) -> bool:
         """Whether this limit counts `fixture` at all: its home team (for a HOME or
@@ -384,18 +384,188 @@ class MatchCountLimit:
         effective cap of 0 over a window that covers `d`. _build_model skips
         creating a decision variable for such a candidate (it could only ever be
         0)."""
-        if not self.counts_fixture(fixture):
-            return False
-        if self.date_ranges:
-            return (self.max_matches == 0 or self.max_playing_teams == 0) and any(
-                d in rng for rng in self.date_ranges
+        return self.counts_fixture(fixture) and self._covers_zero(d)
+
+    def add_to_model(self, model: cp_model.CpModel, fixture_vars: _FixtureVars) -> None:
+        """Emit this limit's constraints into `model`: for each team group (one per
+        team under EACH_TEAM, else the whole set) and each of this rule's windows,
+        bound every cap it carries over the counted candidates falling in that
+        window."""
+        fixture_date_vars = fixture_vars.fixture_date_vars()
+        for team_set in self._team_groups():
+            # Every candidate this rule counts (per its venue_scope), grouped by
+            # date. A match between two teams both in `team_set` (e.g. a same-club
+            # derby counted by that club's own rule) appears once here, under one
+            # variable -- counted once towards match_cap below, but twice towards
+            # playing_teams_cap (see _Measure.PLAYING_TEAMS), since it puts two of
+            # `team_set` on to play.
+            counted_by_date = self._counted_by_date(
+                _counted_fixtures_by_date(fixture_date_vars, team_set, self.venue_scope)
             )
-        if self.max_matches == 0 or self.max_playing_teams == 0:
-            return True
-        return (
-            self.max_matches_overrides.get(d) == 0
-            or self.max_playing_teams_overrides.get(d) == 0
+            for window in self._windows(list(counted_by_date)):
+                window_fixture_dates = [
+                    (fixture, d) for d in window for fixture in counted_by_date[d]
+                ]
+                for measure, cap in self._active_caps():
+                    ceiling = cap.for_window(window)
+                    if ceiling is None:
+                        continue
+                    # A shared-budget matches cap that is >= the group size can
+                    # never bind on a single instant -- the teams can't play more
+                    # simultaneous matches than there are of them (this is how a
+                    # venue capacity stated above a club's team count stays a
+                    # no-op). Subclasses/measures that can't make that guarantee
+                    # (a per-team cap, a playing-teams cap, or a window spanning
+                    # more than one date) report no such shortcut (None).
+                    skip_size = self._trivial_skip_size(measure, team_set)
+                    if skip_size is not None and ceiling >= skip_size:
+                        continue
+                    terms = [
+                        measure.term(fixture_vars, fixture, d, team_set)
+                        for fixture, d in window_fixture_dates
+                    ]
+                    if not terms:
+                        continue
+                    if measure is _Measure.MATCHES and len(terms) <= ceiling:
+                        continue
+                    model.add(cp_model.LinearExpr.Sum(terms) <= ceiling)
+
+    def _team_groups(self) -> list[set[Team]]:
+        """The groups this rule's caps apply to: one singleton set per team under
+        EACH_TEAM, or the whole `teams` set as one shared-budget group."""
+        if self.apply_per is ApplyPer.EACH_TEAM:
+            return [{team} for team in self.teams]
+        return [set(self.teams)]
+
+    def _active_caps(self) -> Iterable[tuple[_Measure, Cap]]:
+        """This rule's set caps, paired with the measure each bounds."""
+        if self.match_cap is not None:
+            yield _Measure.MATCHES, self.match_cap
+        if self.playing_teams_cap is not None:
+            yield _Measure.PLAYING_TEAMS, self.playing_teams_cap
+
+    def _counted_by_date(
+        self, counted_by_date: Mapping[date, list[Fixture]]
+    ) -> Mapping[date, list[Fixture]]:
+        """Hook for a subclass to drop dates from the counted set before windows
+        are formed (RollingLimit applies `exclude_dates` here). The base keeps
+        every date as counted."""
+        return counted_by_date
+
+    def _trivial_skip_size(
+        self, measure: _Measure, team_set: Collection[Team]
+    ) -> int | None:
+        """The group size at or above which `measure`'s cap provably can't bind for
+        this rule, or None if no such shortcut is sound here. See add_to_model."""
+        return None
+
+    @abc.abstractmethod
+    def _windows(self, counted_dates: Collection[date]) -> Iterable[Collection[date]]:
+        """The windows this rule enforces its caps over, given the dates on which
+        it counts at least one candidate."""
+
+    @abc.abstractmethod
+    def _covers_zero(self, d: date) -> bool:
+        """Whether some cap of this rule is an effective 0 over a window covering
+        `d` -- so a counted candidate on `d` could only ever be 0. See forbids."""
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class RollingLimit(MatchCountLimit):
+    """A MatchCountLimit whose windows are every run of `window_days` consecutive
+    calendar days. `window_days` counts a run of days, not a gap between two
+    endpoints: `window_days=1` (the default) limits matches on a single date;
+    `window_days=7` limits matches in any seven-consecutive-day period, so two
+    matches exactly a week apart (day N and day N+7) never share a window and are
+    unrestricted relative to each other.
+
+    `exclude_dates` drops every counted match falling on one of the listed dates
+    from this rule: each window is evaluated as if nothing counted happened then,
+    for both `match_cap` and `playing_teams_cap`. Unlike a Cap override it is not
+    tied to a single-date window, so it is the way to exempt one date from a
+    multi-day rolling cap -- typically a date whose load is already pinned by
+    `fixed_fixtures` and bounded by its own Cap override.
+
+    A Cap with per-date `overrides` requires `window_days == 1` (see Cap).
+    """
+
+    window_days: int = 1
+    exclude_dates: frozenset[date] = frozenset()
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if self.window_days < 1:
+            raise ValueError(
+                f"RollingLimit.window_days must be >= 1, got {self.window_days}"
+            )
+        if self.window_days != 1 and any(
+            cap.overrides for _, cap in self._active_caps()
+        ):
+            raise ValueError(
+                "RollingLimit per-date Cap overrides require window_days == 1"
+            )
+
+    def _windows(self, counted_dates: Collection[date]) -> Iterable[Collection[date]]:
+        return date_windows(counted_dates, self.window_days - 1)
+
+    def _counted_by_date(
+        self, counted_by_date: Mapping[date, list[Fixture]]
+    ) -> Mapping[date, list[Fixture]]:
+        if not self.exclude_dates:
+            return counted_by_date
+        return {
+            d: fixtures
+            for d, fixtures in counted_by_date.items()
+            if d not in self.exclude_dates
+        }
+
+    def _trivial_skip_size(
+        self, measure: _Measure, team_set: Collection[Team]
+    ) -> int | None:
+        if measure is _Measure.MATCHES and self.apply_per is ApplyPer.ACROSS_TEAMS:
+            return len(team_set)
+        return None
+
+    def _covers_zero(self, d: date) -> bool:
+        return any(cap.zero_on(d) for _, cap in self._active_caps())
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class RangeLimit(MatchCountLimit):
+    """A MatchCountLimit whose windows are exactly the given inclusive calendar
+    `ranges`, each counted independently, instead of a rolling window. A
+    `match_cap` of `Cap(0)` bars every counted match across the ranges -- a
+    whole-club, all-teams RangeLimit with `match_cap=Cap(0)` is how a spec-wide
+    "nobody plays these dates" block is expressed.
+
+    Caps here carry no per-date overrides, and there is no `exclude_dates`: both
+    are meaningless once the windows are already explicit calendar ranges --
+    leave the date out of `ranges` instead.
+    """
+
+    ranges: tuple[DateRange, ...]
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if not self.ranges:
+            raise ValueError("RangeLimit needs at least one DateRange")
+        if any(cap.overrides for _, cap in self._active_caps()):
+            raise ValueError(
+                "RangeLimit caps can't carry per-date overrides (leave the date "
+                "out of the ranges instead)"
+            )
+
+    def _windows(self, counted_dates: Collection[date]) -> Iterable[Collection[date]]:
+        dates = list(counted_dates)
+        return [[d for d in dates if d in rng] for rng in self.ranges]
+
+    def _covers_zero(self, d: date) -> bool:
+        return any(cap.zero_on(d) for _, cap in self._active_caps()) and any(
+            d in rng for rng in self.ranges
         )
+
+
+type MatchLimit = RollingLimit | RangeLimit
 
 
 def _check_no_duplicate_teams(teams: Collection[Team]) -> None:
@@ -458,7 +628,7 @@ class Parameters:
     team_unavailable_away_dates: Mapping[Team, list[date]] = dataclasses.field(
         default_factory=dict
     )
-    match_count_limits: Collection[MatchCountLimit] = ()
+    match_count_limits: Collection[MatchLimit] = ()
     # Fixture generation scheme per division number (see FixtureScheme); a division
     # with no entry here uses FixtureScheme.DOUBLE_ROUND. This is the only
     # per-division input -- the `divisions` view below, including each SINGLE_ROUND
@@ -627,7 +797,7 @@ class _FixtureVars:
         candidate in a window gives exactly how many teams'-worth of players from
         `teams` the window asks for -- once per match a team plays in, not just once
         per team, so the same pair meeting twice in the window counts twice (see
-        MatchCountLimit.max_playing_teams)."""
+        MatchCountLimit's playing_teams_cap)."""
         count = (fixture.home_team in teams) + (fixture.away_team in teams)
         if count == 0:
             return 0
@@ -699,92 +869,17 @@ def _add_home_dates_used_constraints(
 
 def _add_match_count_limit_constraints(
     model: cp_model.CpModel,
-    limits: Collection[MatchCountLimit],
+    limits: Collection[MatchLimit],
     fixture_vars: _FixtureVars,
 ) -> None:
-    """Apply every MatchCountLimit: no window of `time_window_days` consecutive days
-    -- or, when the rule sets `date_ranges`, no listed calendar range -- may hold
-    more than the rule's effective cap (see max_matches_for_window) matches from the
-    counted set, nor (when `max_playing_teams` is set) more teams'-worth of players
-    from the set than that. `venue_scope` selects which of the teams' matches count
-    (home only, away only, or all); `apply_per` decides whether the caps are a
-    shared budget for the whole group or enforced separately per team.
+    """Apply every match-count limit (see MatchCountLimit.add_to_model): within
+    each of a rule's windows -- rolling runs of `window_days` consecutive days for
+    a RollingLimit, or the listed calendar ranges for a RangeLimit -- no more than
+    its `match_cap` matches from the counted set, nor more than its
+    `playing_teams_cap` teams'-worth of players, may be scheduled.
     """
-    fixture_date_vars = fixture_vars.fixture_date_vars()
     for rule in limits:
-        each_team = rule.apply_per is ApplyPer.EACH_TEAM
-        groups = [{team} for team in rule.teams] if each_team else [set(rule.teams)]
-        for team_set in groups:
-            # Every candidate this rule counts (per its venue_scope), grouped by
-            # date. A match between two teams both in `team_set` (e.g. a same-club
-            # derby counted by that club's own rule) appears once here, under one
-            # variable -- counted once towards max_matches below, but twice towards
-            # max_playing_teams (see _FixtureVars.teams_playing), since it puts two of
-            # `team_set` on to play.
-            fixtures_by_date = _counted_fixtures_by_date(
-                fixture_date_vars, team_set, rule.venue_scope
-            )
-            if rule.exclude_dates:
-                fixtures_by_date = {
-                    d: fx
-                    for d, fx in fixtures_by_date.items()
-                    if d not in rule.exclude_dates
-                }
-
-            # With explicit date_ranges the windows are exactly those inclusive
-            # ranges (each counted independently). Otherwise date_windows groups
-            # dates spanning up to its window arg in days, so pass
-            # time_window_days - 1: a window is then any run of time_window_days
-            # consecutive calendar days, and two dates exactly time_window_days
-            # apart (e.g. a week apart when time_window_days=7) fall in separate
-            # windows. time_window_days=1 gives one window per date.
-            windows: Iterable[Collection[date]]
-            if rule.date_ranges:
-                windows = [
-                    [d for d in fixtures_by_date if d in rng]
-                    for rng in rule.date_ranges
-                ]
-            else:
-                windows = date_windows(
-                    fixtures_by_date.keys(), rule.time_window_days - 1
-                )
-            for window in windows:
-                window_fixture_dates = [
-                    (fixture, d) for d in window for fixture in fixtures_by_date[d]
-                ]
-
-                cap = rule.max_matches_for_window(window)
-                # A shared-budget cap that is >= the group size can never bind: the
-                # teams can't play more simultaneous matches than there are of them
-                # (this is how a stated venue capacity above a club's team count
-                # stays a no-op). A date range spans many days, in which one team
-                # can play more than once, so the shortcut only holds for the
-                # single-instant rolling-window form.
-                if cap is not None and (
-                    each_team or rule.date_ranges or cap < len(team_set)
-                ):
-                    window_vars = [
-                        fixture_date_vars[fixture, d]
-                        for fixture, d in window_fixture_dates
-                    ]
-                    if len(window_vars) > cap:
-                        model.add(cp_model.LinearExpr.Sum(window_vars) <= cap)
-
-                # Unlike max_matches, a shared cap here can still bind even at or
-                # above the group size -- the same two teams meeting twice in the
-                # window already asks for twice their number of teams'-worth of
-                # players -- so there's no equivalent no-op shortcut to check first.
-                playing_cap = rule.max_playing_teams_for_window(window)
-                if playing_cap is not None:
-                    playing_contributions = [
-                        fixture_vars.teams_playing(fixture, d, team_set)
-                        for fixture, d in window_fixture_dates
-                    ]
-                    if playing_contributions:
-                        model.add(
-                            cp_model.LinearExpr.Sum(playing_contributions)
-                            <= playing_cap
-                        )
+        rule.add_to_model(model, fixture_vars)
 
 
 def _add_fixed_fixtures_constraints(

--- a/genfixtures.py
+++ b/genfixtures.py
@@ -161,18 +161,20 @@ for _team in _TEAMS:
 
 # One match per team per week, plus at most two home matches a night per club --
 # expressed as match_count_limits, the sole match-count constraint mechanism.
-_MATCH_COUNT_LIMITS = [
-    fmodel.MatchCountLimit(
+_MATCH_COUNT_LIMITS: list[fmodel.MatchLimit] = []
+_MATCH_COUNT_LIMITS += [
+    fmodel.RollingLimit(
         teams=club_teams,
-        max_matches=1,
-        time_window_days=_MIN_MATCH_GAP_DAYS,
+        match_cap=fmodel.Cap(1),
+        window_days=_MIN_MATCH_GAP_DAYS,
         apply_per=fmodel.ApplyPer.EACH_TEAM,
     )
     for club_teams in _TEAMS_BY_CLUB.values()
-] + [
-    fmodel.MatchCountLimit(
+]
+_MATCH_COUNT_LIMITS += [
+    fmodel.RollingLimit(
         teams=club_teams,
-        max_matches=2,
+        match_cap=fmodel.Cap(2),
         venue_scope=fmodel.VenueScope.HOME,
     )
     for club_teams in _TEAMS_BY_CLUB.values()

--- a/model_test.py
+++ b/model_test.py
@@ -40,7 +40,7 @@ def _params(
     max_concurrent_matches: (
         dict[str, tuple[fmodel.VenueScope, int | None]] | None
     ) = None,
-    match_count_limits: Collection[fmodel.MatchCountLimit] = (),
+    match_count_limits: Collection[fmodel.MatchLimit] = (),
     **kwargs: Any,
 ) -> fmodel.Parameters:
     """fmodel.Parameters with the old min_gap_days / max_concurrent_matches
@@ -56,21 +56,21 @@ def _params(
     for team in teams:
         teams_by_club[team.club].append(team)
 
-    limits = list(match_count_limits)
+    limits: list[fmodel.MatchLimit] = list(match_count_limits)
     if min_gap_days:
         for club_teams in teams_by_club.values():
             limits.append(
-                fmodel.MatchCountLimit(
+                fmodel.RollingLimit(
                     teams=club_teams,
-                    max_matches=1,
-                    time_window_days=min_gap_days,
+                    match_cap=fmodel.Cap(1),
+                    window_days=min_gap_days,
                     apply_per=fmodel.ApplyPer.EACH_TEAM,
                 )
             )
     for club, (scope, n) in (max_concurrent_matches or {}).items():
         limits.append(
-            fmodel.MatchCountLimit(
-                teams=teams_by_club[club], max_matches=n, venue_scope=scope
+            fmodel.RollingLimit(
+                teams=teams_by_club[club], match_cap=fmodel.Cap(n), venue_scope=scope
             )
         )
     return fmodel.Parameters(match_count_limits=limits, **kwargs)
@@ -412,8 +412,10 @@ class TestSharedLimitAtOrAboveGroupSize(unittest.TestCase):
             home_dates={"A": [date(2025, 1, 1), date(2025, 1, 8)]},
             unavailable_away_dates={"A": []},
             match_count_limits=[
-                fmodel.MatchCountLimit(
-                    teams=teams, max_matches=limit, venue_scope=fmodel.VenueScope.HOME
+                fmodel.RollingLimit(
+                    teams=teams,
+                    match_cap=fmodel.Cap(limit),
+                    venue_scope=fmodel.VenueScope.HOME,
                 )
             ],
         )
@@ -439,8 +441,10 @@ class TestSharedLimitAtOrAboveGroupSize(unittest.TestCase):
             home_dates={"A": [date(2025, 1, 1)]},
             unavailable_away_dates={"A": []},
             match_count_limits=[
-                fmodel.MatchCountLimit(
-                    teams=teams, max_matches=2, venue_scope=fmodel.VenueScope.HOME
+                fmodel.RollingLimit(
+                    teams=teams,
+                    match_cap=fmodel.Cap(2),
+                    venue_scope=fmodel.VenueScope.HOME,
                 )
             ],
         )
@@ -1290,23 +1294,23 @@ class TestTeamConstraints(unittest.TestCase):
 
 
 class TestMatchCountLimits(unittest.TestCase):
-    """Test cases for MatchCountLimit: no window of time_window_days consecutive
-    days may hold more than `limit` matches involving a given set of teams (two
-    dates exactly time_window_days apart fall in separate windows).
+    """Test cases for RollingLimit: no window of window_days consecutive days may
+    hold more than `limit` matches involving a given set of teams (two dates
+    exactly window_days apart fall in separate windows).
     """
 
-    def test_time_window_days_defaults_to_one(self) -> None:
+    def test_window_days_defaults_to_one(self) -> None:
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=2, club="A", index=2)
         self.assertEqual(
-            fmodel.MatchCountLimit(teams=[a1, a2], max_matches=1).time_window_days, 1
+            fmodel.RollingLimit(teams=[a1, a2], match_cap=fmodel.Cap(1)).window_days, 1
         )
 
     def test_venue_scope_defaults_to_all(self) -> None:
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=2, club="A", index=2)
         self.assertEqual(
-            fmodel.MatchCountLimit(teams=[a1, a2], max_matches=1).venue_scope,
+            fmodel.RollingLimit(teams=[a1, a2], match_cap=fmodel.Cap(1)).venue_scope,
             fmodel.VenueScope.ALL,
         )
 
@@ -1334,7 +1338,9 @@ class TestMatchCountLimits(unittest.TestCase):
                 "X": _home_limit(2),
             },
             min_gap_days=7,
-            match_count_limits=[fmodel.MatchCountLimit(teams=[a1, a2], max_matches=1)],
+            match_count_limits=[
+                fmodel.RollingLimit(teams=[a1, a2], match_cap=fmodel.Cap(1))
+            ],
         )
         fixtures = list(fmodel.solve(params).fixtures)
         a1_home_date = next(sf.date for sf in fixtures if sf.fixture.home_team == a1)
@@ -1361,7 +1367,9 @@ class TestMatchCountLimits(unittest.TestCase):
                 "X": _home_limit(2),
             },
             min_gap_days=7,
-            match_count_limits=[fmodel.MatchCountLimit(teams=[a1, a2], max_matches=1)],
+            match_count_limits=[
+                fmodel.RollingLimit(teams=[a1, a2], match_cap=fmodel.Cap(1))
+            ],
         )
         with self.assertRaises(ValueError):
             fmodel.solve(params)
@@ -1388,7 +1396,9 @@ class TestMatchCountLimits(unittest.TestCase):
                 "X": _home_limit(2),
             },
             min_gap_days=7,
-            match_count_limits=[fmodel.MatchCountLimit(teams=[a1, a2], max_matches=1)],
+            match_count_limits=[
+                fmodel.RollingLimit(teams=[a1, a2], match_cap=fmodel.Cap(1))
+            ],
         )
         with self.assertRaises(ValueError):
             fmodel.solve(params)
@@ -1417,8 +1427,8 @@ class TestMatchCountLimits(unittest.TestCase):
             },
             min_gap_days=7,
             match_count_limits=[
-                fmodel.MatchCountLimit(
-                    teams=[a1, a2], max_matches=1, time_window_days=3
+                fmodel.RollingLimit(
+                    teams=[a1, a2], match_cap=fmodel.Cap(1), window_days=3
                 )
             ],
         )
@@ -1451,8 +1461,8 @@ class TestMatchCountLimits(unittest.TestCase):
             },
             min_gap_days=7,
             match_count_limits=[
-                fmodel.MatchCountLimit(
-                    teams=[a1, a2], max_matches=1, time_window_days=7
+                fmodel.RollingLimit(
+                    teams=[a1, a2], match_cap=fmodel.Cap(1), window_days=7
                 )
             ],
         )
@@ -1478,7 +1488,9 @@ class TestMatchCountLimits(unittest.TestCase):
             max_concurrent_matches={"A": _home_limit(1)},
             min_gap_days=7,
             excluded_fixtures=[fmodel.Fixture(home_team=a2, away_team=a1)],
-            match_count_limits=[fmodel.MatchCountLimit(teams=[a1, a2], max_matches=1)],
+            match_count_limits=[
+                fmodel.RollingLimit(teams=[a1, a2], match_cap=fmodel.Cap(1))
+            ],
         )
         fixtures = list(fmodel.solve(params).fixtures)
         self.assertEqual(
@@ -1513,8 +1525,10 @@ class TestMatchCountLimits(unittest.TestCase):
             },
             min_gap_days=7,
             match_count_limits=[
-                fmodel.MatchCountLimit(
-                    teams=[a1, a2], max_matches=1, venue_scope=fmodel.VenueScope.AWAY
+                fmodel.RollingLimit(
+                    teams=[a1, a2],
+                    match_cap=fmodel.Cap(1),
+                    venue_scope=fmodel.VenueScope.AWAY,
                 )
             ],
         )
@@ -1543,8 +1557,10 @@ class TestMatchCountLimits(unittest.TestCase):
             },
             min_gap_days=7,
             match_count_limits=[
-                fmodel.MatchCountLimit(
-                    teams=[a1, a2], max_matches=1, venue_scope=fmodel.VenueScope.AWAY
+                fmodel.RollingLimit(
+                    teams=[a1, a2],
+                    match_cap=fmodel.Cap(1),
+                    venue_scope=fmodel.VenueScope.AWAY,
                 )
             ],
         )
@@ -1572,8 +1588,10 @@ class TestMatchCountLimits(unittest.TestCase):
             },
             min_gap_days=7,
             match_count_limits=[
-                fmodel.MatchCountLimit(
-                    teams=[a1, a2], max_matches=1, venue_scope=fmodel.VenueScope.HOME
+                fmodel.RollingLimit(
+                    teams=[a1, a2],
+                    match_cap=fmodel.Cap(1),
+                    venue_scope=fmodel.VenueScope.HOME,
                 )
             ],
         )
@@ -1602,8 +1620,10 @@ class TestMatchCountLimits(unittest.TestCase):
             },
             min_gap_days=7,
             match_count_limits=[
-                fmodel.MatchCountLimit(
-                    teams=[a1, a2], max_matches=1, venue_scope=fmodel.VenueScope.HOME
+                fmodel.RollingLimit(
+                    teams=[a1, a2],
+                    match_cap=fmodel.Cap(1),
+                    venue_scope=fmodel.VenueScope.HOME,
                 )
             ],
         )
@@ -1635,8 +1655,8 @@ class TestMatchCountLimits(unittest.TestCase):
                 fmodel.Fixture(home_team=x3, away_team=a3),
             ],
             match_count_limits=[
-                fmodel.MatchCountLimit(
-                    teams=[a1, a2, a3], max_matches=limit, time_window_days=30
+                fmodel.RollingLimit(
+                    teams=[a1, a2, a3], match_cap=fmodel.Cap(limit), window_days=30
                 )
             ],
         )
@@ -1656,20 +1676,20 @@ class TestMatchCountLimits(unittest.TestCase):
 
 
 class TestMaxPlayingTeams(unittest.TestCase):
-    """Test cases for MatchCountLimit.max_playing_teams: unlike max_matches, which
+    """Test cases for MatchCountLimit.playing_teams_cap: unlike match_cap, which
     counts matches, this counts the *distinct* teams from `teams` that play (home or
     away) within a window. A same-club derby is one match (one candidate variable)
     but puts two of the club's own teams on to play, so it counts as 1 towards
-    max_matches but 2 towards max_playing_teams -- guarding against exactly the case
-    a plain max_matches cap misses: N matches, one of them an internal derby,
-    needing N+1 teams' worth of players.
+    match_cap but 2 towards playing_teams_cap -- guarding against exactly the case a
+    plain match_cap misses: N matches, one of them an internal derby, needing N+1
+    teams' worth of players.
     """
 
     def test_internal_derby_alone_blocked_by_a_playing_teams_cap_of_one(self) -> None:
         """A single derby match between two of a club's own teams already needs two
-        of them playing -- so a max_playing_teams: 1 cap makes every candidate date
-        infeasible, even though it's only one match (well within max_matches). Unlike
-        a plain max_matches: 0 (which prunes the candidate variables entirely, see
+        of them playing -- so a playing_teams_cap of 1 makes every candidate date
+        infeasible, even though it's only one match (well within match_cap). Unlike
+        a plain match_cap of 0 (which prunes the candidate variables entirely, see
         MatchCountLimit.forbids), this isn't detectable per-candidate -- it only
         shows up as a genuine solver infeasibility."""
         h1 = fmodel.Team(division=1, club="H", index=1)
@@ -1679,10 +1699,10 @@ class TestMaxPlayingTeams(unittest.TestCase):
             home_dates={"H": [date(2025, 1, 1), date(2025, 1, 8)]},
             unavailable_away_dates={"H": []},
             match_count_limits=[
-                fmodel.MatchCountLimit(
+                fmodel.RollingLimit(
                     teams=[h1, h2],
-                    max_matches=2,
-                    max_playing_teams=1,
+                    match_cap=fmodel.Cap(2),
+                    playing_teams_cap=fmodel.Cap(1),
                     venue_scope=fmodel.VenueScope.HOME,
                 )
             ],
@@ -1716,10 +1736,10 @@ class TestMaxPlayingTeams(unittest.TestCase):
             unavailable_away_dates={"H": [], "X": [], "Y": []},
             team_home_dates={h3: [shared_date], h4: [shared_date]},
             match_count_limits=[
-                fmodel.MatchCountLimit(
+                fmodel.RollingLimit(
                     teams=[h1, h2, h3, h4],
-                    max_matches=3,
-                    max_playing_teams=3,
+                    match_cap=fmodel.Cap(3),
+                    playing_teams_cap=fmodel.Cap(3),
                     venue_scope=fmodel.VenueScope.HOME,
                 )
             ],
@@ -1743,10 +1763,10 @@ class TestMaxPlayingTeams(unittest.TestCase):
             home_dates={"H": [date(2025, 1, 1), date(2025, 1, 8)]},
             unavailable_away_dates={"H": []},
             match_count_limits=[
-                fmodel.MatchCountLimit(
+                fmodel.RollingLimit(
                     teams=[h1, h2],
-                    max_matches=2,
-                    max_playing_teams=2,
+                    match_cap=fmodel.Cap(2),
+                    playing_teams_cap=fmodel.Cap(2),
                     venue_scope=fmodel.VenueScope.HOME,
                 )
             ],
@@ -1755,15 +1775,15 @@ class TestMaxPlayingTeams(unittest.TestCase):
         self.assertEqual(len(fixtures), 2)
 
     def test_zero_forbids_the_candidate_up_front_like_max_matches_zero(self) -> None:
-        """Unlike a cap of 1 or more, max_playing_teams: 0 is an up-front bar: any
-        counted match puts at least one team from `teams` on to play, so it's
+        """Unlike a cap of 1 or more, a playing_teams_cap of 0 is an up-front bar:
+        any counted match puts at least one team from `teams` on to play, so it's
         detectable per-candidate (see MatchCountLimit.forbids) rather than only
         showing up as a solver infeasibility."""
         h1 = fmodel.Team(division=1, club="H", index=1)
         h2 = fmodel.Team(division=1, club="H", index=2)
         fix = fmodel.Fixture(home_team=h1, away_team=h2)
-        blocked = fmodel.MatchCountLimit(
-            teams=[h1, h2], max_matches=2, max_playing_teams=0
+        blocked = fmodel.RollingLimit(
+            teams=[h1, h2], match_cap=fmodel.Cap(2), playing_teams_cap=fmodel.Cap(0)
         )
         self.assertTrue(blocked.forbids(fix, date(2025, 1, 1)))
 
@@ -1785,14 +1805,13 @@ class TestMaxPlayingTeams(unittest.TestCase):
             home_dates={"H": [overridden_date_1, overridden_date_2, plain_date]},
             unavailable_away_dates={"H": []},
             match_count_limits=[
-                fmodel.MatchCountLimit(
+                fmodel.RollingLimit(
                     teams=[h1, h2],
-                    max_matches=2,
-                    max_playing_teams=1,
-                    max_playing_teams_overrides={
-                        overridden_date_1: 2,
-                        overridden_date_2: 2,
-                    },
+                    match_cap=fmodel.Cap(2),
+                    playing_teams_cap=fmodel.Cap(
+                        1,
+                        {overridden_date_1: 2, overridden_date_2: 2},
+                    ),
                     venue_scope=fmodel.VenueScope.HOME,
                 )
             ],
@@ -1805,18 +1824,18 @@ class TestMaxPlayingTeams(unittest.TestCase):
         }
         self.assertEqual(derby_dates, {overridden_date_1, overridden_date_2})
 
-    def test_overrides_reject_non_default_time_window_days(self) -> None:
-        """Unlike max_playing_teams itself (see the multi-day-window tests below,
-        which show it's meaningful over a wider window), max_playing_teams_overrides
-        is still tied to a single date: an override names one specific date, which
-        only lines up with one specific window when time_window_days is 1."""
+    def test_overrides_reject_non_default_window_days(self) -> None:
+        """Unlike playing_teams_cap itself (see the multi-day-window tests below,
+        which show it's meaningful over a wider window), a Cap's per-date overrides
+        are still tied to a single date: an override names one specific date, which
+        only lines up with one specific window when window_days is 1."""
         a1 = fmodel.Team(division=1, club="A", index=1)
         with self.assertRaises(ValueError):
-            fmodel.MatchCountLimit(
+            fmodel.RollingLimit(
                 teams=[a1],
-                max_matches=1,
-                time_window_days=7,
-                max_playing_teams_overrides={date(2025, 1, 1): 1},
+                match_cap=fmodel.Cap(1),
+                window_days=7,
+                playing_teams_cap=fmodel.Cap(overrides={date(2025, 1, 1): 1}),
             )
 
     def test_multi_day_window_counts_a_repeated_pair_twice(self) -> None:
@@ -1836,11 +1855,10 @@ class TestMaxPlayingTeams(unittest.TestCase):
             home_dates={"H": sorted(close_dates | {far_date})},
             unavailable_away_dates={"H": []},
             match_count_limits=[
-                fmodel.MatchCountLimit(
+                fmodel.RollingLimit(
                     teams=[h1, h2],
-                    max_matches=None,
-                    max_playing_teams=3,
-                    time_window_days=7,
+                    playing_teams_cap=fmodel.Cap(3),
+                    window_days=7,
                 )
             ],
         )
@@ -1861,11 +1879,10 @@ class TestMaxPlayingTeams(unittest.TestCase):
             home_dates={"H": sorted(in_range_dates | {out_of_range_date})},
             unavailable_away_dates={"H": []},
             match_count_limits=[
-                fmodel.MatchCountLimit(
+                fmodel.RangeLimit(
                     teams=[h1, h2],
-                    max_matches=None,
-                    max_playing_teams=3,
-                    date_ranges=(fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 7)),),
+                    playing_teams_cap=fmodel.Cap(3),
+                    ranges=(fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 7)),),
                 )
             ],
         )
@@ -1893,11 +1910,10 @@ class TestMaxPlayingTeams(unittest.TestCase):
                 home_dates={"H": [d1, d2]},
                 unavailable_away_dates={"H": []},
                 match_count_limits=[
-                    fmodel.MatchCountLimit(
+                    fmodel.RollingLimit(
                         teams=[h1, h2],
-                        max_matches=None,
-                        max_playing_teams=3,
-                        time_window_days=7,
+                        playing_teams_cap=fmodel.Cap(3),
+                        window_days=7,
                         exclude_dates=exclude_dates,
                     )
                 ],
@@ -1909,17 +1925,12 @@ class TestMaxPlayingTeams(unittest.TestCase):
         fixtures = list(fmodel.solve(params_with(frozenset({d1}))).fixtures)
         self.assertEqual(len(fixtures), 2)
 
-    def test_exclude_dates_rejects_date_ranges(self) -> None:
-        """`exclude_dates` and `date_ranges` are mutually exclusive -- with explicit
-        ranges you simply leave the date out of them."""
-        a1 = fmodel.Team(division=1, club="A", index=1)
-        with self.assertRaises(ValueError):
-            fmodel.MatchCountLimit(
-                teams=[a1],
-                max_matches=1,
-                date_ranges=(fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 7)),),
-                exclude_dates=frozenset({date(2025, 1, 3)}),
-            )
+    # `exclude_dates` and explicit ranges are now structurally exclusive --
+    # `exclude_dates` is a RollingLimit-only field, `ranges` a RangeLimit-only one
+    # -- rather than a runtime check, so there is no MatchCountLimit-level rejection
+    # test here any more. fixturespec_test.py still covers the YAML-level rejection
+    # (see test_match_count_limits_exclude_dates_reject_date_ranges), since a YAML
+    # mapping can still name both keys.
 
 
 class TestMatchCountLimitDateRanges(unittest.TestCase):
@@ -1957,8 +1968,8 @@ class TestMatchCountLimitDateRanges(unittest.TestCase):
                 fmodel.Fixture(home_team=x3, away_team=a3),
             ],
             match_count_limits=[
-                fmodel.MatchCountLimit(
-                    teams=[a1, a2, a3], max_matches=limit, date_ranges=date_ranges
+                fmodel.RangeLimit(
+                    teams=[a1, a2, a3], match_cap=fmodel.Cap(limit), ranges=date_ranges
                 )
             ],
         )
@@ -2032,12 +2043,10 @@ class TestMatchCountLimitDateRanges(unittest.TestCase):
             min_gap_days=7,
             excluded_fixtures=[fmodel.Fixture(home_team=x1, away_team=a1)],
             match_count_limits=[
-                fmodel.MatchCountLimit(
+                fmodel.RangeLimit(
                     teams=[a1],
-                    max_matches=0,
-                    date_ranges=(
-                        fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31)),
-                    ),
+                    match_cap=fmodel.Cap(0),
+                    ranges=(fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31)),),
                 )
             ],
         )
@@ -2064,36 +2073,33 @@ class TestMatchCountLimitDateRanges(unittest.TestCase):
                 fmodel.Fixture(home_team=y1, away_team=x1),
             ],
             match_count_limits=[
-                fmodel.MatchCountLimit(
+                fmodel.RangeLimit(
                     teams=[a1],
-                    max_matches=1,
-                    date_ranges=(
-                        fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31)),
-                    ),
+                    match_cap=fmodel.Cap(1),
+                    ranges=(fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31)),),
                 )
             ],
         )
         with self.assertRaises(ValueError):
             fmodel.solve(params)
 
-    def test_rejects_non_default_time_window_days(self) -> None:
-        a1 = fmodel.Team(division=1, club="A", index=1)
-        with self.assertRaises(ValueError):
-            fmodel.MatchCountLimit(
-                teams=[a1],
-                max_matches=1,
-                time_window_days=7,
-                date_ranges=(fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31)),),
-            )
+    # There is no longer a "RangeLimit rejects a non-default window_days" test:
+    # RangeLimit has no window_days field at all (windows come from `ranges`), so
+    # the combination is now a structural impossibility rather than a runtime
+    # check. fixturespec_test.py still covers the YAML-level rejection (see
+    # test_match_count_limits_date_ranges_reject_time_window_days), since a YAML
+    # mapping can still name both keys.
 
-    def test_rejects_max_matches_overrides(self) -> None:
+    def test_rejects_cap_overrides(self) -> None:
+        """A RangeLimit's caps carry no per-date overrides (an override only lines
+        up with a single-date rolling window) -- leave the date out of `ranges`
+        instead."""
         a1 = fmodel.Team(division=1, club="A", index=1)
         with self.assertRaises(ValueError):
-            fmodel.MatchCountLimit(
+            fmodel.RangeLimit(
                 teams=[a1],
-                max_matches=1,
-                max_matches_overrides={date(2025, 1, 1): 1},
-                date_ranges=(fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31)),),
+                match_cap=fmodel.Cap(1, {date(2025, 1, 1): 1}),
+                ranges=(fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31)),),
             )
 
     def test_date_range_rejects_start_after_end(self) -> None:
@@ -2129,12 +2135,10 @@ class TestMatchCountLimitDateRanges(unittest.TestCase):
                 )
             ],
             match_count_limits=[
-                fmodel.MatchCountLimit(
+                fmodel.RangeLimit(
                     teams=[a1, x1],
-                    max_matches=0,
-                    date_ranges=(
-                        fmodel.DateRange(date(2025, 12, 22), date(2026, 1, 4)),
-                    ),
+                    match_cap=fmodel.Cap(0),
+                    ranges=(fmodel.DateRange(date(2025, 12, 22), date(2026, 1, 4)),),
                 )
             ],
         )
@@ -2147,25 +2151,25 @@ class TestMatchCountLimitDateRanges(unittest.TestCase):
         home_fix = fmodel.Fixture(home_team=a1, away_team=x1)
         away_fix = fmodel.Fixture(home_team=x1, away_team=a1)
         rng = fmodel.DateRange(date(2025, 12, 22), date(2026, 1, 4))
-        away_only = fmodel.MatchCountLimit(
+        away_only = fmodel.RangeLimit(
             teams=[a1],
-            max_matches=0,
+            match_cap=fmodel.Cap(0),
             venue_scope=fmodel.VenueScope.AWAY,
-            date_ranges=(rng,),
+            ranges=(rng,),
         )
         # AWAY scope: bars a1's away fixture in the range, not its home one.
         self.assertTrue(away_only.forbids(away_fix, date(2025, 12, 29)))
         self.assertFalse(away_only.forbids(home_fix, date(2025, 12, 29)))
         # Outside the range: not forbidden.
         self.assertFalse(away_only.forbids(away_fix, date(2026, 1, 5)))
-        # max_matches > 0: never an up-front bar.
-        keep = fmodel.MatchCountLimit(teams=[a1], max_matches=1, date_ranges=(rng,))
+        # A non-zero cap is never an up-front bar.
+        keep = fmodel.RangeLimit(teams=[a1], match_cap=fmodel.Cap(1), ranges=(rng,))
         self.assertFalse(keep.forbids(away_fix, date(2025, 12, 29)))
 
 
 class TestPerClubGap(unittest.TestCase):
     """A per-team gap expressed per club: each club gets its own apply_per=EACH_TEAM
-    MatchCountLimit, so one club can be given a closer gap than another."""
+    RollingLimit, so one club can be given a closer gap than another."""
 
     def _params(self, gaps: dict[str, int]) -> fmodel.Parameters:
         """Two teams per club, each club's pair sharing a division so they play a
@@ -2185,10 +2189,10 @@ class TestPerClubGap(unittest.TestCase):
             },
             unavailable_away_dates={"A": [], "B": []},
             match_count_limits=[
-                fmodel.MatchCountLimit(
+                fmodel.RollingLimit(
                     teams=teams_by_club[club],
-                    max_matches=1,
-                    time_window_days=gap,
+                    match_cap=fmodel.Cap(1),
+                    window_days=gap,
                     apply_per=fmodel.ApplyPer.EACH_TEAM,
                 )
                 for club, gap in gaps.items()
@@ -2287,11 +2291,10 @@ class TestSharedHomeLimitNullAndOverrides(unittest.TestCase):
             unavailable_away_dates={"A": [], "X": []},
             max_concurrent_matches={"X": _home_limit(2)},
             match_count_limits=(
-                fmodel.MatchCountLimit(
+                fmodel.RollingLimit(
                     teams=[a1, a2],
-                    max_matches=1,
+                    match_cap=fmodel.Cap(1, {date(2025, 1, 1): None}),
                     venue_scope=fmodel.VenueScope.HOME,
-                    max_matches_overrides={date(2025, 1, 1): None},
                 ),
             ),
             min_gap_days=7,
@@ -2304,7 +2307,7 @@ class TestSharedHomeLimitNullAndOverrides(unittest.TestCase):
 
 
 class TestSharedLimitAwayAndAllScopes(unittest.TestCase):
-    """A shared-budget MatchCountLimit with venue_scope AWAY or ALL (HOME is covered
+    """A shared-budget RollingLimit with venue_scope AWAY or ALL (HOME is covered
     by the classes above). Scenario: club A's two teams (different divisions, so no
     direct fixture) play their away legs at club X, whose single home date forces
     both onto the same night unless something says otherwise.
@@ -2312,7 +2315,7 @@ class TestSharedLimitAwayAndAllScopes(unittest.TestCase):
 
     def _params(
         self,
-        a_limit: fmodel.MatchCountLimit,
+        a_limit: fmodel.RollingLimit,
         *,
         x_home_dates: list[date],
     ) -> fmodel.Parameters:
@@ -2329,14 +2332,14 @@ class TestSharedLimitAwayAndAllScopes(unittest.TestCase):
             min_gap_days=7,
         )
 
-    def _any(self, limit: int | None) -> fmodel.MatchCountLimit:
-        return fmodel.MatchCountLimit(
-            teams=[], max_matches=limit, venue_scope=fmodel.VenueScope.ALL
+    def _any(self, limit: int | None) -> fmodel.RollingLimit:
+        return fmodel.RollingLimit(
+            teams=[], match_cap=fmodel.Cap(limit), venue_scope=fmodel.VenueScope.ALL
         )
 
-    def _away(self, limit: int | None) -> fmodel.MatchCountLimit:
-        return fmodel.MatchCountLimit(
-            teams=[], max_matches=limit, venue_scope=fmodel.VenueScope.AWAY
+    def _away(self, limit: int | None) -> fmodel.RollingLimit:
+        return fmodel.RollingLimit(
+            teams=[], match_cap=fmodel.Cap(limit), venue_scope=fmodel.VenueScope.AWAY
         )
 
     def test_any_scope_limit_blocks_two_matches_on_one_date(self) -> None:
@@ -2384,9 +2387,9 @@ class TestInternalMatchAwayScope(unittest.TestCase):
     away_at_x = fmodel.Fixture(home_team=x1, away_team=h1)
 
     def test_counts_fixture_skips_internal_derby_under_away_scope(self) -> None:
-        away = fmodel.MatchCountLimit(
+        away = fmodel.RollingLimit(
             teams=[self.h1, self.h2],
-            max_matches=1,
+            match_cap=fmodel.Cap(1),
             venue_scope=fmodel.VenueScope.AWAY,
         )
         self.assertFalse(away.counts_fixture(self.derby))
@@ -2395,18 +2398,18 @@ class TestInternalMatchAwayScope(unittest.TestCase):
 
     def test_counts_fixture_keeps_internal_derby_under_home_and_all_scope(self) -> None:
         for scope in (fmodel.VenueScope.HOME, fmodel.VenueScope.ALL):
-            rule = fmodel.MatchCountLimit(
-                teams=[self.h1, self.h2], max_matches=1, venue_scope=scope
+            rule = fmodel.RollingLimit(
+                teams=[self.h1, self.h2], match_cap=fmodel.Cap(1), venue_scope=scope
             )
             self.assertTrue(rule.counts_fixture(self.derby), scope)
 
     def test_forbids_ignores_internal_derby_under_away_scope(self) -> None:
         rng = fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31))
-        away_blackout = fmodel.MatchCountLimit(
+        away_blackout = fmodel.RangeLimit(
             teams=[self.h1, self.h2],
-            max_matches=0,
+            match_cap=fmodel.Cap(0),
             venue_scope=fmodel.VenueScope.AWAY,
-            date_ranges=(rng,),
+            ranges=(rng,),
         )
         self.assertFalse(away_blackout.forbids(self.derby, date(2025, 1, 15)))
         self.assertTrue(away_blackout.forbids(self.away_at_x, date(2025, 1, 15)))
@@ -2436,10 +2439,9 @@ class TestInternalMatchAwayScope(unittest.TestCase):
                 ),
             ],
             match_count_limits=[
-                fmodel.MatchCountLimit(
+                fmodel.RollingLimit(
                     teams=[self.h1, self.h2, h3, h4],
-                    max_matches=None,
-                    max_playing_teams=2,
+                    playing_teams_cap=fmodel.Cap(2),
                     venue_scope=fmodel.VenueScope.AWAY,
                 )
             ],
@@ -2463,10 +2465,9 @@ class TestInternalMatchAwayScope(unittest.TestCase):
             home_dates={"A": [date(2025, 3, 1)], "X": [date(2025, 1, 6)]},
             unavailable_away_dates={"A": [], "X": []},
             match_count_limits=[
-                fmodel.MatchCountLimit(
+                fmodel.RollingLimit(
                     teams=[a1, a2],
-                    max_matches=None,
-                    max_playing_teams=1,
+                    playing_teams_cap=fmodel.Cap(1),
                     venue_scope=fmodel.VenueScope.AWAY,
                 )
             ],

--- a/validate_test.py
+++ b/validate_test.py
@@ -138,8 +138,8 @@ class TestCheckSchedule(unittest.TestCase):
             },
             unavailable_away_dates={},
             match_count_limits=[
-                fmodel.MatchCountLimit(
-                    teams=[_A1, _B1], max_matches=1, time_window_days=7
+                fmodel.RollingLimit(
+                    teams=[_A1, _B1], match_cap=fmodel.Cap(1), window_days=7
                 )
             ],
         )


### PR DESCRIPTION
fmodel.MatchCountLimit had accreted a validation matrix of mutually exclusive fields (date_ranges vs time_window_days/*_overrides/ exclude_dates) plus parallel max_matches/max_playing_teams logic throughout _add_match_count_limit_constraints. Re-designed per the analysis in #93:

- Cap: a value object (base + per-date overrides) shared by both the matches measure and the playing-teams measure, replacing the four parallel max_matches*/max_playing_teams* fields and their two near-duplicate *_for_window methods.
- _Measure: a small enum dispatching the one place matches vs playing-teams differ (the linear-expression term for one candidate), collapsing the two parallel constraint-emission blocks into one loop.
- MatchCountLimit is now an ABC holding everything shared (teams, the two Caps, venue_scope, apply_per, counts_fixture, forbids, add_to_model), with _windows() and _covers_zero() as the two dispatched methods.
- RollingLimit and RangeLimit are the two concrete subclasses, one per windowing strategy. The old date_ranges-vs-everything-else "can't combine" checks are now either structurally impossible (RangeLimit has no window_days/exclude_dates fields at all) or reduced to one check per subclass.

The YAML schema is unchanged; fixturespec.py's parser picks RangeLimit vs RollingLimit based on whether date_ranges was given. Also relaxed one parser rule so date_ranges + max_playing_teams alone (no max_matches) is accepted, reconciling it with what the model layer already permitted.

Migrated all direct MatchCountLimit construction and field access in model_test.py and fixturespec_test.py to the new shape. Two model-layer tests (date_ranges/exclude_dates and date_ranges/ time_window_days rejection) became structurally impossible to even construct, so they're replaced with comments pointing at the equivalent YAML-level tests in fixturespec_test.py.


Claude-Session: https://claude.ai/code/session_01RjPAzUnHkT1fw1N2Zi9me9