### PR TITLE
Allow open-ended date_ranges on match_count_limits (towards #50)

### DIFF
--- a/fixturespec.py
+++ b/fixturespec.py
@@ -667,7 +667,9 @@ def _parse_match_count_date_ranges(
 ) -> tuple[fmodel.DateRange, ...]:
     """Parse a match_count_limits entry's optional 'date_ranges': a non-empty list
     of {start_date, end_date} mappings, each an inclusive fmodel.DateRange (which
-    enforces start on or before end)."""
+    enforces start on or before end). Either 'start_date' or 'end_date' may be
+    omitted for a range that's open-ended on that side (no earliest, or no latest,
+    date) -- but not both."""
     if not isinstance(value, list) or not value:
         raise SpecError(f"{context} must be a non-empty list")
     ranges: list[fmodel.DateRange] = []
@@ -681,10 +683,18 @@ def _parse_match_count_date_ranges(
                 f"{item_context}.{sorted(unsupported)} not supported (only "
                 "['end_date', 'start_date'] are)"
             )
-        if "start_date" not in item or "end_date" not in item:
-            raise SpecError(f"{item_context} needs both 'start_date' and 'end_date'")
-        start = _parse_date(item["start_date"], f"{item_context}.start_date")
-        end = _parse_date(item["end_date"], f"{item_context}.end_date")
+        if "start_date" not in item and "end_date" not in item:
+            raise SpecError(f"{item_context} needs 'start_date' and/or 'end_date'")
+        start = (
+            _parse_date(item["start_date"], f"{item_context}.start_date")
+            if "start_date" in item
+            else None
+        )
+        end = (
+            _parse_date(item["end_date"], f"{item_context}.end_date")
+            if "end_date" in item
+            else None
+        )
         try:
             ranges.append(fmodel.DateRange(start=start, end=end))
         except ValueError as e:
@@ -746,7 +756,9 @@ def _parse_match_count_limits(
       - 'max_matches_overrides' (optional): per-date replacements of 'max_matches'.
         Only allowed when 'time_window_days' is 1.
       - 'date_ranges' (optional): a non-empty list of {start_date, end_date}
-        inclusive ranges. When given, the rule applies to exactly those ranges
+        inclusive ranges. Either 'start_date' or 'end_date' may be omitted for a
+        range that's open-ended on that side (no earliest, or no latest, date),
+        but not both. When given, the rule applies to exactly those ranges
         instead of every rolling 'time_window_days' window. Allowed on both club
         and 'defaults' entries; not combinable with 'time_window_days' or
         'max_matches_overrides', nor (on a club entry) with 'override_key'. 'max_matches'

--- a/fixturespec_test.py
+++ b/fixturespec_test.py
@@ -907,7 +907,21 @@ class TestLoadSpec(unittest.TestCase):
         with self.assertRaisesRegex(fixturespec.SpecError, "is after end"):
             fixturespec.load_spec(path)
 
-    def test_match_count_limits_date_ranges_reject_missing_end_date(self) -> None:
+    def test_match_count_limits_date_ranges_reject_missing_both_dates(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - max_matches: 1\n"
+            "        date_ranges:\n"
+            "          - {}\n"
+        )
+        with self.assertRaisesRegex(
+            fixturespec.SpecError, "start_date.*and/or.*end_date"
+        ):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_date_ranges_open_ended_start(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
@@ -916,8 +930,34 @@ class TestLoadSpec(unittest.TestCase):
             "        date_ranges:\n"
             "          - start_date: 2025-10-27\n"
         )
-        with self.assertRaisesRegex(fixturespec.SpecError, "end_date"):
-            fixturespec.load_spec(path)
+        spec = fixturespec.load_spec(path)
+        limit = _find_limit(
+            spec.parameters.match_count_limits,
+            club="albany",
+            venue_scope=fmodel.VenueScope.ALL,
+            apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
+        )
+        assert isinstance(limit, fmodel.RangeLimit)
+        self.assertEqual(limit.ranges, (fmodel.DateRange(start=date(2025, 10, 27)),))
+
+    def test_match_count_limits_date_ranges_open_ended_end(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - max_matches: 1\n"
+            "        date_ranges:\n"
+            "          - end_date: 2025-11-02\n"
+        )
+        spec = fixturespec.load_spec(path)
+        limit = _find_limit(
+            spec.parameters.match_count_limits,
+            club="albany",
+            venue_scope=fmodel.VenueScope.ALL,
+            apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
+        )
+        assert isinstance(limit, fmodel.RangeLimit)
+        self.assertEqual(limit.ranges, (fmodel.DateRange(end=date(2025, 11, 2)),))
 
     def test_match_count_limits_date_ranges_reject_unknown_key(self) -> None:
         path = self._write(

--- a/fmodel.py
+++ b/fmodel.py
@@ -183,25 +183,35 @@ class Division:
 
 @dataclasses.dataclass(frozen=True)
 class DateRange:
-    """An inclusive span of calendar dates, `start` on or before `end`.
+    """An inclusive span of calendar dates, `start` on or before `end`. Either may
+    be None for an open-ended bound (no earliest, or no latest, date) -- but not
+    both, since an unbounded-on-both-sides range is never what's meant.
 
     Used by RangeLimit.ranges to pin a cap to specific calendar periods (a
     school-holiday week, say) rather than a rolling window. `d in date_range`
     tests membership.
     """
 
-    start: date
-    end: date
+    start: date | None = None
+    end: date | None = None
 
     def __post_init__(self) -> None:
-        if self.start > self.end:
+        if self.start is None and self.end is None:
+            raise ValueError("DateRange needs a start and/or an end")
+        if self.start is not None and self.end is not None and self.start > self.end:
             raise ValueError(
                 f"DateRange start {self.start.isoformat()} is after end "
                 f"{self.end.isoformat()}"
             )
 
     def __contains__(self, d: object) -> bool:
-        return isinstance(d, date) and self.start <= d <= self.end
+        if not isinstance(d, date):
+            return False
+        if self.start is not None and d < self.start:
+            return False
+        if self.end is not None and d > self.end:
+            return False
+        return True
 
 
 class VenueScope(enum.Enum):

--- a/model_test.py
+++ b/model_test.py
@@ -2112,6 +2112,22 @@ class TestMatchCountLimitDateRanges(unittest.TestCase):
         self.assertIn(date(2025, 1, 31), rng)
         self.assertNotIn(date(2025, 2, 1), rng)
 
+    def test_date_range_rejects_neither_start_nor_end(self) -> None:
+        with self.assertRaises(ValueError):
+            fmodel.DateRange()
+
+    def test_date_range_open_ended_start_contains_everything_up_to_end(self) -> None:
+        rng = fmodel.DateRange(end=date(2025, 1, 31))
+        self.assertIn(date(2020, 1, 1), rng)
+        self.assertIn(date(2025, 1, 31), rng)
+        self.assertNotIn(date(2025, 2, 1), rng)
+
+    def test_date_range_open_ended_end_contains_everything_from_start(self) -> None:
+        rng = fmodel.DateRange(start=date(2025, 1, 1))
+        self.assertIn(date(2025, 1, 1), rng)
+        self.assertIn(date(2099, 1, 1), rng)
+        self.assertNotIn(date(2024, 12, 31), rng)
+
     def test_max_zero_prunes_candidate_var(self) -> None:
         """A max_matches: 0 limit makes its candidates a certain zero, so _build_model
         never creates a decision variable for them -- observable because a

--- a/spec-schema.json
+++ b/spec-schema.json
@@ -296,15 +296,15 @@
         "items": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["start_date", "end_date"],
+          "anyOf": [{ "required": ["start_date"] }, { "required": ["end_date"] }],
           "properties": {
             "start_date": {
               "$ref": "#/$defs/date",
-              "description": "First day of the range (inclusive)."
+              "description": "First day of the range (inclusive). Omit for a range open-ended at the start (no earliest date) -- 'end_date' must then be given instead."
             },
             "end_date": {
               "$ref": "#/$defs/date",
-              "description": "Last day of the range (inclusive); must be on or after 'start_date'."
+              "description": "Last day of the range (inclusive); must be on or after 'start_date'. Omit for a range open-ended at the end (no latest date) -- 'start_date' must then be given instead."
             }
           }
         }


### PR DESCRIPTION
DateRange.start/end may now each be None (but not both), so a match_count_limits date_ranges entry can give just start_date or just end_date for a range with no upper or lower bound, instead of needing an artificial far-future/far-past date.


Claude-Session: https://claude.ai/code/session_013b52P7W2AXMKHWDVJswhXA