### PR TITLE
Add min support to match_count_limits, nested under matches/playing_teams (#50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,10 +155,12 @@ club_constraints:
       - override_key: weekly-gap     # each team plays at most once a week
         apply_per: each_team
         time_window_days: 7
-        max: 1
+        matches:
+          max: 1
       - override_key: venue-capacity # at most two home matches a night
         venue_scope: home
-        max: 2
+        matches:
+          max: 2
   albany:
     home_dates: [2025-09-01, 2025-09-15, 2025-09-29]
   hackney:
@@ -167,19 +169,24 @@ club_constraints:
       - override_key: weekly-gap     # a fortnight between this club's matches
         apply_per: each_team          # (replaces the like-keyed spec-wide default)
         time_window_days: 14
-        max: 1
+        matches:
+          max: 1
 ```
 
-`match_count_limits` is the one match-count constraint: each entry caps how many
+`match_count_limits` is the one match-count constraint: each entry bounds how many
 matches involving a set of teams may fall in any window of `time_window_days`
-consecutive days. It expresses a per-team gap (`apply_per: each_team`), a venue's
-concurrent-match capacity (`venue_scope: home`, with per-date
-`date_max_overrides`), and a keep-these-teams-apart rule (`teams: [...]`) alike.
-An entry can instead set `date_ranges` (a list of `{start_date, end_date}`
-inclusive ranges) to cap matches within specific calendar periods -- a
-school-holiday week, say -- rather than a rolling window, with `max: 0` to bar
-them outright; a whole-club `max: 0` `date_ranges` entry under `defaults` is how
-a spec-wide "nobody plays these dates" block (e.g. Christmas) is expressed. Every
+consecutive days, via a `matches` mapping (`max`/`max_overrides` from above,
+`min`/`min_overrides` from below) and/or a `playing_teams` one of the same shape,
+which counts teams'-worth of players instead of matches. It expresses a per-team
+gap (`apply_per: each_team`), a venue's concurrent-match capacity (`venue_scope:
+home`, with per-date `matches.max_overrides`), a keep-these-teams-apart rule
+(`teams: [...]`), and a floor on activity (`matches: {min: 1}`, e.g. at least one
+match in a congress fortnight) alike. An entry can instead set `date_ranges` (a
+list of `{start_date, end_date}` inclusive ranges, either end open-ended) to
+bound matches within specific calendar periods -- a school-holiday week, say --
+rather than a rolling window, with `matches: {max: 0}` to bar them outright; a
+whole-club `matches: {max: 0}` `date_ranges` entry under `defaults` is how a
+spec-wide "nobody plays these dates" block (e.g. Christmas) is expressed. Every
 spec-wide default entry carries a unique `override_key`; a club entry repeating
 one replaces that default for the club, and a club entry
 with no `override_key` is additive.

--- a/build_site_test.py
+++ b/build_site_test.py
@@ -59,7 +59,8 @@ club_constraints:
     match_count_limits:
       - override_key: venue-capacity
         venue_scope: home
-        max_matches: 1
+        matches:
+          max: 1
   albany:
     home_dates: [2025-09-01, 2025-09-29]
   hackney:

--- a/fixturespec.py
+++ b/fixturespec.py
@@ -359,17 +359,17 @@ _TEAM_CONSTRAINT_FIELD_KEYS = {"unavailable_home_dates", "unavailable_away_dates
 
 _MATCH_COUNT_LIMIT_FIELD_KEYS = {
     "teams",
-    "max_matches",
-    "max_playing_teams",
+    "matches",
+    "playing_teams",
     "time_window_days",
     "venue_scope",
     "apply_per",
-    "max_matches_overrides",
-    "max_playing_teams_overrides",
     "date_ranges",
     "exclude_dates",
     "override_key",
 }
+
+_MATCH_COUNT_MEASURE_FIELD_KEYS = {"max", "max_overrides", "min", "min_overrides"}
 
 _HOME_DATES_USED_FIELD_KEYS = {"min", "max"}
 
@@ -394,31 +394,42 @@ _TOP_LEVEL_KEYS = {
 }
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class _ParsedMatchCountLimit:
     """One match_count_limits entry, parsed but not yet resolved to concrete Teams.
 
     `team_ids` is None when the entry omitted 'teams' (meaning "every team of the
     club it applies to"). `override_key`, on a club entry, names the
     club_constraints.defaults entry this one replaces for that club; None means the
-    entry is purely additive. Every defaults entry has an `override_key`. `max_matches`
-    is None only for an entry that carries `max_playing_teams` and/or
-    `max_matches_overrides` instead, or to cancel an inherited default (a club entry
-    with an override_key and nothing else). `date_ranges`, when non-empty, restricts
-    the rule to those explicit inclusive calendar ranges instead of every rolling
-    `time_window_days` window.
+    entry is purely additive. Every defaults entry has an `override_key`.
+    `match_max`/`match_min`/`playing_teams_max`/`playing_teams_min` (from the
+    entry's 'matches'/'playing_teams' mappings) are None wherever that bound
+    wasn't given -- all four may be None at once, for an entry that only cancels
+    an inherited default (a club entry with an override_key and nothing else).
+    `date_ranges`, when non-empty, restricts the rule to those explicit inclusive
+    calendar ranges instead of every rolling `time_window_days` window.
     """
 
     team_ids: tuple[str, ...] | None
-    max_matches: int | None
     time_window_days: int
     venue_scope: fmodel.VenueScope
     apply_per: fmodel.ApplyPer
-    max_matches_overrides: Mapping[date, int | None]
     date_ranges: tuple[fmodel.DateRange, ...]
     override_key: str | None
-    max_playing_teams: int | None = None
-    max_playing_teams_overrides: Mapping[date, int | None] = dataclasses.field(
+    match_max: int | None = None
+    match_max_overrides: Mapping[date, int | None] = dataclasses.field(
+        default_factory=dict
+    )
+    match_min: int | None = None
+    match_min_overrides: Mapping[date, int | None] = dataclasses.field(
+        default_factory=dict
+    )
+    playing_teams_max: int | None = None
+    playing_teams_max_overrides: Mapping[date, int | None] = dataclasses.field(
+        default_factory=dict
+    )
+    playing_teams_min: int | None = None
+    playing_teams_min_overrides: Mapping[date, int | None] = dataclasses.field(
         default_factory=dict
     )
     exclude_dates: frozenset[date] = frozenset()
@@ -647,9 +658,9 @@ def _club_team_ids(club_id: str, teams: Mapping[str, fmodel.Team]) -> list[str]:
 def _parse_match_count_overrides(
     value: Any, context: str, min_value: int = 1
 ) -> dict[date, int | None]:
-    """Parse a match_count_limits entry's optional 'max_matches_overrides' or
-    'max_playing_teams_overrides': a date-keyed mapping of per-date limits (an
-    integer >= min_value, or null to lift the limit that day)."""
+    """Parse one of a 'matches'/'playing_teams' mapping's 'max_overrides' or
+    'min_overrides': a date-keyed mapping of per-date limits (an integer >=
+    min_value, or null to lift the limit that day)."""
     if not isinstance(value, dict):
         raise SpecError(f"{context} must be a mapping keyed by date")
     overrides: dict[date, int | None] = {}
@@ -702,6 +713,102 @@ def _parse_match_count_date_ranges(
     return tuple(ranges)
 
 
+def _has_measure_bound(
+    max_: int | None,
+    max_overrides: Mapping[date, int | None],
+    min_: int | None,
+    min_overrides: Mapping[date, int | None],
+) -> bool:
+    """Whether a parsed 'matches'/'playing_teams' measure carries an actual bound
+    -- as opposed to a 'matches: {max: null}'-shaped entry that names the key but
+    supplies nothing (meaningless on its own, e.g. as a bare cancel-a-default
+    marker without 'override_key', or as a pointless 'date_ranges' entry)."""
+    return (
+        max_ is not None
+        or bool(max_overrides)
+        or min_ is not None
+        or bool(min_overrides)
+    )
+
+
+def _parse_match_count_measure(
+    value: Any,
+    context: str,
+    *,
+    time_window_days: int,
+    has_date_ranges: bool,
+    max_zero_allowed: bool,
+) -> tuple[int | None, dict[date, int | None], int | None, dict[date, int | None]]:
+    """Parse a match_count_limits entry's 'matches' or 'playing_teams' mapping:
+    'max'/'max_overrides' cap the measure from above, 'min'/'min_overrides' floor
+    it from below. Returns (max_, max_overrides, min_, min_overrides).
+
+    'max_overrides'/'min_overrides' are only allowed when 'time_window_days' is 1
+    (each window is then a single date) and are never combinable with
+    'date_ranges' (whose windows are already explicit). 'max_overrides' and
+    'min_overrides' values may always be >= 0 and >= 1 respectively -- an
+    override ties to one specific date, and "no counted match/team at all that
+    day" (0) is meaningful for either measure, the single-day equivalent of a
+    RangeLimit 'max: 0' blackout; a floor override, unlike a ceiling one, can
+    never usefully be 0 (it can never bind), so 'min_overrides' stays >= 1. Only
+    the un-overridden 'max' base keeps the matches/playing_teams asymmetry (see
+    'max_zero_allowed'): a plain matches cap of 0 only makes sense together with
+    'date_ranges', a full blackout; a playing_teams cap of 0 -- "nobody from
+    this set plays" -- is meaningful either way.
+    """
+    if not isinstance(value, dict) or not value:
+        raise SpecError(f"{context} must be a non-empty mapping")
+    unsupported = value.keys() - _MATCH_COUNT_MEASURE_FIELD_KEYS
+    if unsupported:
+        raise SpecError(
+            f"{context}.{sorted(unsupported)} not supported (only "
+            f"{sorted(_MATCH_COUNT_MEASURE_FIELD_KEYS)} are)"
+        )
+
+    max_ = None
+    if "max" in value:
+        max_ = _require_int_or_none(value["max"], f"{context}.max")
+        min_max = 0 if max_zero_allowed else 1
+        if max_ is not None and max_ < min_max:
+            raise SpecError(f"{context}.max must be >= {min_max} or null")
+
+    min_ = None
+    if "min" in value:
+        min_ = _require_int_or_none(value["min"], f"{context}.min")
+        if min_ is not None and min_ < 1:
+            raise SpecError(f"{context}.min must be >= 1 or null")
+
+    max_overrides: dict[date, int | None] = {}
+    if "max_overrides" in value:
+        if time_window_days != 1:
+            raise SpecError(
+                f"{context}.max_overrides is only allowed when time_window_days is 1"
+            )
+        if has_date_ranges:
+            raise SpecError(
+                f"{context}.max_overrides and 'date_ranges' can't be combined"
+            )
+        max_overrides = _parse_match_count_overrides(
+            value["max_overrides"], f"{context}.max_overrides", min_value=0
+        )
+
+    min_overrides: dict[date, int | None] = {}
+    if "min_overrides" in value:
+        if time_window_days != 1:
+            raise SpecError(
+                f"{context}.min_overrides is only allowed when time_window_days is 1"
+            )
+        if has_date_ranges:
+            raise SpecError(
+                f"{context}.min_overrides and 'date_ranges' can't be combined"
+            )
+        min_overrides = _parse_match_count_overrides(
+            value["min_overrides"], f"{context}.min_overrides", min_value=1
+        )
+
+    return max_, max_overrides, min_, min_overrides
+
+
 def _parse_match_count_limits(
     entries_spec: Any,
     club_id: str | None,
@@ -711,41 +818,52 @@ def _parse_match_count_limits(
     """Parse a 'match_count_limits' list -- a club's own entry, or (when club_id is
     None) the club_constraints.defaults list applied to every club.
 
-    Each entry needs at least one of 'max_matches' or 'max_playing_teams' -- either
-    alone is fine (a rule can cap just matches, just distinct playing teams, or
-    both) -- unless it carries 'max_matches_overrides', 'date_ranges', or (for a
-    club entry) an 'override_key' cancelling a default, any of which can supply the
-    actual cap on its own.
-      - 'max_matches' (optional): an integer >= 1 (or >= 0 when 'date_ranges' is
-        set), or null (meaningless on its own -- see above).
-      - 'max_playing_teams' (optional): a non-negative integer cap on how many
-        teams'-worth of players from 'teams' each window asks for, as opposed to
-        'max_matches', which counts matches. Each counted match adds one of 'teams'
-        playing, or two if it's an internal match between two of 'teams' (e.g. a
-        same-club derby counted by that club's own venue-capacity rule): one match
-        towards 'max_matches', but two teams from the set on to play. (Under 'away'
-        venue_scope an internal match is not counted at all, so it adds nothing
-        here either.) A venue that
-        can physically host 3 simultaneous matches but only has 3 teams' worth of
-        players to field wants both 'max_matches: 3' and 'max_playing_teams: 3' --
-        otherwise 3 matches, one an internal derby, would need 4 teams' worth of
-        players. Given 'max_playing_teams' alone (no 'max_matches'), the number of
-        matches is left uncapped directly, though it's usually bounded in practice
-        by the same team limit. Over a wider window (a multi-day
-        'time_window_days', or 'date_ranges'), the same pair meeting twice counts
-        twice -- this is a running tally of teams asked to play, not a count of
-        distinct teams touched.
-      - 'max_playing_teams_overrides' (optional): per-date replacements of
-        'max_playing_teams' (an integer >= 0, or null to lift the cap that day),
-        mirroring 'max_matches_overrides'. Only allowed when 'time_window_days' is 1;
-        not combinable with 'date_ranges'.
+    Each entry needs a 'matches' and/or 'playing_teams' mapping carrying an actual
+    bound -- either alone is fine (a rule can bound just matches, just distinct
+    playing teams, or both) -- unless (for a club entry) an 'override_key'
+    cancelling a default supplies the point of the entry instead.
+      - 'matches' (optional): bounds on how many matches (of the kind selected by
+        'venue_scope') fall within a window, via up to four sub-keys:
+          - 'max': an integer >= 1 (or >= 0 when 'date_ranges' is set), or null
+            (meaningless on its own).
+          - 'max_overrides': per-date replacements of 'max' (an integer >= 0, or
+            null to lift the cap that day -- 0 bars every counted match that one
+            date, the single-day equivalent of a 'date_ranges' blackout). Only
+            allowed when 'time_window_days' is 1; not combinable with
+            'date_ranges'.
+          - 'min': the fewest matches required within a window -- an integer >= 1,
+            or null. A floor of 0 is never meaningful (it can never bind), so
+            there's no 'date_ranges'-shaped exception the way 'max' has one.
+          - 'min_overrides': per-date replacements of 'min' (an integer >= 1, or
+            null to lift the floor that day), mirroring 'max_overrides'.
+      - 'playing_teams' (optional): the same four sub-keys ('max', 'max_overrides',
+        'min', 'min_overrides'), but bounding how many teams'-worth of players
+        from 'teams' a window asks for, as opposed to 'matches' (a count of
+        matches). Each counted match adds one of 'teams' playing, or two if it's
+        an internal match between two of 'teams' (e.g. a same-club derby counted
+        by that club's own venue-capacity rule): one match towards 'matches.max',
+        but two teams from the set on to play. (Under 'away' venue_scope an
+        internal match is not counted at all, so it adds nothing here either.) A
+        venue that can physically host 3 simultaneous matches but only has 3
+        teams' worth of players to field wants both 'matches: {max: 3}' and
+        'playing_teams: {max: 3}' -- otherwise 3 matches, one an internal derby,
+        would need 4 teams' worth of players. Given 'playing_teams' alone (no
+        'matches'), the number of matches is left uncapped directly, though it's
+        usually bounded in practice by the same team limit. Over a wider window
+        (a multi-day 'time_window_days', or 'date_ranges'), the same pair meeting
+        twice counts twice here -- a running tally of teams asked to play, not a
+        count of distinct teams touched. Unlike 'matches.max', 'playing_teams.max'
+        may be 0 regardless of 'date_ranges' -- "nobody from this set plays" is
+        meaningful either way (both measures' 'max_overrides' already allow 0,
+        since an override ties to one specific date regardless).
+        When both a 'max' and a 'min' are given for the same measure, 'min' may
+        not exceed 'max'.
       - 'teams' (optional): IDs of this club's teams whose matches are counted.
         Omitted => every team of the club. Not allowed under 'defaults', nor
         alongside 'override_key' (an override replaces a spec-wide, all-teams
         default).
       - 'apply_per' (optional, default 'across_teams'): 'across_teams' => the listed
-        teams share one budget of 'max_matches'/'max_playing_teams' per window;
-        'each_team' => enforced per team.
+        teams share one budget per window; 'each_team' => enforced per team.
       - 'time_window_days' (optional, default 1): window length in consecutive
         calendar days. 7 limits matches in any 7-consecutive-day period -- two
         matches exactly a week apart fall in separate windows.
@@ -753,18 +871,16 @@ def _parse_match_count_limits(
         internal match (both teams the same club) is never counted under 'away'
         scope -- its 'away' team plays at its own club's venue -- but still
         counts under 'home' and 'all'.
-      - 'max_matches_overrides' (optional): per-date replacements of 'max_matches'.
-        Only allowed when 'time_window_days' is 1.
       - 'date_ranges' (optional): a non-empty list of {start_date, end_date}
         inclusive ranges. Either 'start_date' or 'end_date' may be omitted for a
         range that's open-ended on that side (no earliest, or no latest, date),
         but not both. When given, the rule applies to exactly those ranges
         instead of every rolling 'time_window_days' window. Allowed on both club
-        and 'defaults' entries; not combinable with 'time_window_days' or
-        'max_matches_overrides', nor (on a club entry) with 'override_key'. 'max_matches'
+        and 'defaults' entries; not combinable with 'time_window_days' or any
+        '*_overrides', nor (on a club entry) with 'override_key'. 'matches.max'
         must then be a non-negative integer (0 bars every counted match in the
-        range -- a whole-club, all-teams 'defaults' entry with max_matches 0 is how a
-        spec-wide "nobody plays these dates" block is expressed).
+        range -- a whole-club, all-teams 'defaults' entry with 'matches: {max: 0}'
+        is how a spec-wide "nobody plays these dates" block is expressed).
       - 'exclude_dates' (optional): a non-empty list of dates whose counted
         matches this rule ignores entirely -- every window is evaluated as if
         nothing counted falls on them. Unlike the '*_overrides' maps it is not tied
@@ -795,25 +911,9 @@ def _parse_match_count_limits(
                 f"{sorted(_MATCH_COUNT_LIMIT_FIELD_KEYS)} are)"
             )
 
-        max_ = None
-        if "max_matches" in entry:
-            max_ = _require_int_or_none(
-                entry["max_matches"], f"{entry_context}.max_matches"
-            )
-        # 'date_ranges' permits max_matches: 0 (a full blackout of the listed
-        # periods); every other form needs max_matches >= 1 or null.
+        # 'date_ranges' permits matches.max: 0 (a full blackout of the listed
+        # periods); every other form needs matches.max >= 1 or null.
         has_date_ranges = "date_ranges" in entry
-        min_max = 0 if has_date_ranges else 1
-        if max_ is not None and max_ < min_max:
-            raise SpecError(f"{entry_context}.max_matches must be >= {min_max} or null")
-
-        max_playing_teams: int | None = None
-        if "max_playing_teams" in entry:
-            max_playing_teams = _require_int_or_none(
-                entry["max_playing_teams"], f"{entry_context}.max_playing_teams"
-            )
-            if max_playing_teams is not None and max_playing_teams < 0:
-                raise SpecError(f"{entry_context}.max_playing_teams must be >= 0")
 
         override_key: str | None = None
         if "override_key" in entry:
@@ -904,29 +1004,56 @@ def _parse_match_count_limits(
                     f"{entry['venue_scope']!r}"
                 ) from None
 
-        max_matches_overrides: dict[date, int | None] = {}
-        if "max_matches_overrides" in entry:
-            if time_window_days != 1:
-                raise SpecError(
-                    f"{entry_context}.max_matches_overrides is only allowed when "
-                    "time_window_days is 1"
+        match_max: int | None = None
+        match_max_overrides: dict[date, int | None] = {}
+        match_min: int | None = None
+        match_min_overrides: dict[date, int | None] = {}
+        if "matches" in entry:
+            match_max, match_max_overrides, match_min, match_min_overrides = (
+                _parse_match_count_measure(
+                    entry["matches"],
+                    f"{entry_context}.matches",
+                    time_window_days=time_window_days,
+                    has_date_ranges=has_date_ranges,
+                    max_zero_allowed=has_date_ranges,
                 )
-            max_matches_overrides = _parse_match_count_overrides(
-                entry["max_matches_overrides"], f"{entry_context}.max_matches_overrides"
             )
+            if (
+                match_min is not None
+                and match_max is not None
+                and match_min > match_max
+            ):
+                raise SpecError(
+                    f"{entry_context}.matches.min {match_min} exceeds "
+                    f"{entry_context}.matches.max {match_max}"
+                )
 
-        max_playing_teams_overrides: dict[date, int | None] = {}
-        if "max_playing_teams_overrides" in entry:
-            if time_window_days != 1:
-                raise SpecError(
-                    f"{entry_context}.max_playing_teams_overrides is only allowed "
-                    "when time_window_days is 1"
-                )
-            max_playing_teams_overrides = _parse_match_count_overrides(
-                entry["max_playing_teams_overrides"],
-                f"{entry_context}.max_playing_teams_overrides",
-                min_value=0,
+        playing_teams_max: int | None = None
+        playing_teams_max_overrides: dict[date, int | None] = {}
+        playing_teams_min: int | None = None
+        playing_teams_min_overrides: dict[date, int | None] = {}
+        if "playing_teams" in entry:
+            (
+                playing_teams_max,
+                playing_teams_max_overrides,
+                playing_teams_min,
+                playing_teams_min_overrides,
+            ) = _parse_match_count_measure(
+                entry["playing_teams"],
+                f"{entry_context}.playing_teams",
+                time_window_days=time_window_days,
+                has_date_ranges=has_date_ranges,
+                max_zero_allowed=True,
             )
+            if (
+                playing_teams_min is not None
+                and playing_teams_max is not None
+                and playing_teams_min > playing_teams_max
+            ):
+                raise SpecError(
+                    f"{entry_context}.playing_teams.min {playing_teams_min} "
+                    f"exceeds {entry_context}.playing_teams.max {playing_teams_max}"
+                )
 
         date_ranges: tuple[fmodel.DateRange, ...] = ()
         if has_date_ranges:
@@ -942,20 +1069,17 @@ def _parse_match_count_limits(
                     f"{entry_context}: 'date_ranges' and 'time_window_days' can't "
                     "be combined ('date_ranges' replaces the rolling window)"
                 )
-            if max_matches_overrides:
+            if not _has_measure_bound(
+                match_max, match_max_overrides, match_min, match_min_overrides
+            ) and not _has_measure_bound(
+                playing_teams_max,
+                playing_teams_max_overrides,
+                playing_teams_min,
+                playing_teams_min_overrides,
+            ):
                 raise SpecError(
-                    f"{entry_context}: 'date_ranges' and 'max_matches_overrides' "
-                    "can't be combined"
-                )
-            if max_playing_teams_overrides:
-                raise SpecError(
-                    f"{entry_context}: 'date_ranges' and "
-                    "'max_playing_teams_overrides' can't be combined"
-                )
-            if max_ is None and max_playing_teams is None:
-                raise SpecError(
-                    f"{entry_context}.date_ranges needs an integer 'max_matches' "
-                    "(>= 0) and/or a 'max_playing_teams'"
+                    f"{entry_context}.date_ranges needs a 'matches' and/or "
+                    "'playing_teams' cap"
                 )
             date_ranges = _parse_match_count_date_ranges(
                 entry["date_ranges"], f"{entry_context}.date_ranges"
@@ -975,30 +1099,39 @@ def _parse_match_count_limits(
             )
 
         if (
-            max_ is None
-            and not max_matches_overrides
-            and not date_ranges
+            not _has_measure_bound(
+                match_max, match_max_overrides, match_min, match_min_overrides
+            )
+            and not _has_measure_bound(
+                playing_teams_max,
+                playing_teams_max_overrides,
+                playing_teams_min,
+                playing_teams_min_overrides,
+            )
             and override_key is None
-            and max_playing_teams is None
         ):
             raise SpecError(
-                f"{entry_context} needs 'max_matches' and/or 'max_playing_teams' to "
-                "carry an actual cap (or 'max_matches_overrides', or an "
-                "'override_key' to cancel a default)"
+                f"{entry_context} needs a 'matches' and/or 'playing_teams' mapping "
+                "to carry an actual bound (or an 'override_key' to cancel a "
+                "default)"
             )
 
         limits.append(
             _ParsedMatchCountLimit(
                 team_ids=team_ids,
-                max_matches=max_,
-                max_playing_teams=max_playing_teams,
+                match_max=match_max,
+                match_max_overrides=match_max_overrides,
+                match_min=match_min,
+                match_min_overrides=match_min_overrides,
+                playing_teams_max=playing_teams_max,
+                playing_teams_max_overrides=playing_teams_max_overrides,
+                playing_teams_min=playing_teams_min,
+                playing_teams_min_overrides=playing_teams_min_overrides,
                 time_window_days=time_window_days,
                 venue_scope=venue_scope,
                 apply_per=apply_per,
-                max_matches_overrides=max_matches_overrides,
                 date_ranges=date_ranges,
                 override_key=override_key,
-                max_playing_teams_overrides=max_playing_teams_overrides,
                 exclude_dates=exclude_dates,
             )
         )
@@ -1009,10 +1142,10 @@ def _parse_match_count_limits(
 def _resolved_cap(
     base: int | None, overrides: Mapping[date, int | None]
 ) -> fmodel.Cap | None:
-    """A fmodel.Cap for a parsed (base, overrides) pair -- 'max_matches'/
-    'max_matches_overrides' or 'max_playing_teams'/'max_playing_teams_overrides'
-    -- or None when neither carries an actual cap, so that measure is left
-    unconstrained on the resolved MatchLimit."""
+    """A fmodel.Cap for a parsed (base, overrides) pair -- one of 'matches' or
+    'playing_teams' 'max'/'max_overrides' or 'min'/'min_overrides' -- or None
+    when neither carries an actual bound, so that bound is left unconstrained on
+    the resolved MatchLimit."""
     if base is None and not overrides:
         return None
     return fmodel.Cap(base=base, overrides=dict(overrides))
@@ -1031,10 +1164,9 @@ def _resolve_match_count_limits(
 
     A club entry whose 'override_key' names a default entry replaces that default
     for the club (an unknown key, or two club entries sharing one, is an error);
-    every other club entry is additive. Entries that carry none of 'max_matches',
-    'max_matches_overrides', 'max_playing_teams' or 'max_playing_teams_overrides'
-    (a pure cancel-the-default marker) and entries that resolve to no teams are
-    dropped.
+    every other club entry is additive. Entries that carry none of 'matches'/
+    'playing_teams' max or min bound (a pure cancel-the-default marker) and
+    entries that resolve to no teams are dropped.
     """
     default_keys = {pl.override_key for pl in default_limits}
     resolved: list[fmodel.MatchLimit] = []
@@ -1063,11 +1195,20 @@ def _resolve_match_count_limits(
 
         club_team_objs = [teams[tid] for tid in _club_team_ids(club_id, teams)]
         for pl in effective:
-            match_cap = _resolved_cap(pl.max_matches, pl.max_matches_overrides)
-            playing_teams_cap = _resolved_cap(
-                pl.max_playing_teams, pl.max_playing_teams_overrides
+            match_max = _resolved_cap(pl.match_max, pl.match_max_overrides)
+            match_min = _resolved_cap(pl.match_min, pl.match_min_overrides)
+            playing_teams_max = _resolved_cap(
+                pl.playing_teams_max, pl.playing_teams_max_overrides
             )
-            if match_cap is None and playing_teams_cap is None:
+            playing_teams_min = _resolved_cap(
+                pl.playing_teams_min, pl.playing_teams_min_overrides
+            )
+            if (
+                match_max is None
+                and match_min is None
+                and playing_teams_max is None
+                and playing_teams_min is None
+            ):
                 continue
             team_objs = (
                 club_team_objs
@@ -1080,8 +1221,10 @@ def _resolve_match_count_limits(
                 resolved.append(
                     fmodel.RangeLimit(
                         teams=team_objs,
-                        match_cap=match_cap,
-                        playing_teams_cap=playing_teams_cap,
+                        match_max=match_max,
+                        match_min=match_min,
+                        playing_teams_max=playing_teams_max,
+                        playing_teams_min=playing_teams_min,
                         venue_scope=pl.venue_scope,
                         apply_per=pl.apply_per,
                         ranges=pl.date_ranges,
@@ -1091,8 +1234,10 @@ def _resolve_match_count_limits(
                 resolved.append(
                     fmodel.RollingLimit(
                         teams=team_objs,
-                        match_cap=match_cap,
-                        playing_teams_cap=playing_teams_cap,
+                        match_max=match_max,
+                        match_min=match_min,
+                        playing_teams_max=playing_teams_max,
+                        playing_teams_min=playing_teams_min,
                         venue_scope=pl.venue_scope,
                         apply_per=pl.apply_per,
                         window_days=pl.time_window_days,

--- a/fixturespec_test.py
+++ b/fixturespec_test.py
@@ -47,8 +47,9 @@ def _find_limit(
 
 def _cap_base(cap: fmodel.Cap | None) -> int | None:
     """`cap.base`, or None if there's no cap at all -- lets a test assert on the
-    effective plain value ('max_matches'/'max_playing_teams' in the old flat
-    shape) without caring whether the whole Cap is absent or just its base."""
+    effective plain value ('matches.max'/'playing_teams.max', or their 'min'
+    counterparts) without caring whether the whole Cap is absent or just its
+    base."""
     return cap.base if cap is not None else None
 
 
@@ -116,7 +117,7 @@ club_constraints:
 
 _MINIMAL_SPEC = (
     _MINIMAL_SPEC_NO_CONCURRENCY
-    + "  defaults:\n    match_count_limits:\n      - override_key: venue-capacity\n        venue_scope: home\n        max_matches: 1\n"
+    + "  defaults:\n    match_count_limits:\n      - override_key: venue-capacity\n        venue_scope: home\n        matches:\n          max: 1\n"
 )
 
 # A three-team spec (two Albany teams plus Hackney) for exclude_fixtures tests, which
@@ -217,7 +218,7 @@ class TestLoadSpec(unittest.TestCase):
                 venue_scope=fmodel.VenueScope.HOME,
                 apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
             )
-            self.assertEqual(_cap_base(limit.match_cap), 1)
+            self.assertEqual(_cap_base(limit.match_max), 1)
         self.assertEqual(spec.name, "")
         self.assertFalse(spec.draft)
 
@@ -353,21 +354,22 @@ class TestLoadSpec(unittest.TestCase):
             fixturespec.load_spec(path)
 
     def test_avoid_dates_key_no_longer_recognised(self) -> None:
-        # avoid_dates was removed in favour of a defaults max_matches: 0 date_ranges
-        # entry; the old top-level key is now an unknown field.
+        # avoid_dates was removed in favour of a defaults matches: {max: 0}
+        # date_ranges entry; the old top-level key is now an unknown field.
         path = self._write(_MINIMAL_SPEC + "avoid_dates: [2025-12-25]\n")
         with self.assertRaisesRegex(fixturespec.SpecError, "avoid_dates"):
             fixturespec.load_spec(path)
 
     def test_no_play_dates_default_resolves_per_club(self) -> None:
-        # A whole-club max_matches: 0 date_ranges defaults entry (the avoid_dates
-        # replacement): every club gets a resolved limit over all its teams.
+        # A whole-club matches: {max: 0} date_ranges defaults entry (the
+        # avoid_dates replacement): every club gets a resolved limit over all
+        # its teams.
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    match_count_limits:\n"
             "      - override_key: no-play-dates\n"
-            "        max_matches: 0\n"
+            "        matches:\n          max: 0\n"
             "        date_ranges:\n"
             "          - start_date: 2025-12-22\n"
             "            end_date: 2026-01-04\n"
@@ -379,7 +381,7 @@ class TestLoadSpec(unittest.TestCase):
         spec = fixturespec.load_spec(path)
         by_club: dict[str, fmodel.RangeLimit] = {}
         for limit in spec.parameters.match_count_limits:
-            if isinstance(limit, fmodel.RangeLimit) and _cap_base(limit.match_cap) == 0:
+            if isinstance(limit, fmodel.RangeLimit) and _cap_base(limit.match_max) == 0:
                 (club,) = {t.club for t in limit.teams}
                 by_club[club] = limit
         self.assertEqual(set(by_club), {"albany", "hackney"})
@@ -390,13 +392,13 @@ class TestLoadSpec(unittest.TestCase):
 
     def test_no_play_dates_default_can_be_overridden_by_a_club(self) -> None:
         # A club naming the override_key replaces the block wholesale -- here
-        # cancelling it, so that club has no max_matches: 0 limit.
+        # cancelling it, so that club has no matches: {max: 0} limit.
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    match_count_limits:\n"
             "      - override_key: no-play-dates\n"
-            "        max_matches: 0\n"
+            "        matches:\n          max: 0\n"
             "        date_ranges:\n"
             "          - start_date: 2025-12-22\n"
             "            end_date: 2026-01-04\n"
@@ -404,7 +406,7 @@ class TestLoadSpec(unittest.TestCase):
             "    home_dates: [2025-12-15]\n"
             "    match_count_limits:\n"
             "      - override_key: no-play-dates\n"
-            "        max_matches: null\n"
+            "        matches:\n          max: null\n"
             "  hackney:\n"
             "    home_dates: [2025-12-08]\n"
         )
@@ -412,7 +414,7 @@ class TestLoadSpec(unittest.TestCase):
         zero_clubs = {
             t.club
             for limit in spec.parameters.match_count_limits
-            if isinstance(limit, fmodel.RangeLimit) and _cap_base(limit.match_cap) == 0
+            if isinstance(limit, fmodel.RangeLimit) and _cap_base(limit.match_max) == 0
             for t in limit.teams
         }
         self.assertEqual(zero_clubs, {"hackney"})
@@ -427,7 +429,7 @@ class TestLoadSpec(unittest.TestCase):
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    match_count_limits:\n"
-            "      - override_key: venue-capacity\n        venue_scope: home\n        max_matches: 1\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        matches:\n          max: 1\n"
             "  albany:\n"
             "    home_dates: [2025-09-01]\n"
             "  albany:\n"
@@ -449,12 +451,12 @@ class TestLoadSpec(unittest.TestCase):
             "    match_count_limits:\n"
             "      - override_key: venue-capacity\n"
             "        venue_scope: home\n"
-            "        max_matches: 1\n"
+            "        matches:\n          max: 1\n"
             "  albany:\n"
             "    match_count_limits:\n"
             "      - override_key: venue-capacity\n"
             "        venue_scope: home\n"
-            "        max_matches: 3\n"
+            "        matches:\n          max: 3\n"
         )
         spec = fixturespec.load_spec(path)
         albany = _find_limit(
@@ -463,7 +465,7 @@ class TestLoadSpec(unittest.TestCase):
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertEqual(_cap_base(albany.match_cap), 3)
+        self.assertEqual(_cap_base(albany.match_max), 3)
         # hackney has no entry of its own, so it keeps the default home cap 1.
         hackney = _find_limit(
             spec.parameters.match_count_limits,
@@ -471,17 +473,18 @@ class TestLoadSpec(unittest.TestCase):
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertEqual(_cap_base(hackney.match_cap), 1)
+        self.assertEqual(_cap_base(hackney.match_max), 1)
 
-    def test_match_count_limits_max_matches_overrides_parsed(self) -> None:
+    def test_match_count_limits_matches_max_overrides_parsed(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max_matches: 2\n"
-            "        max_matches_overrides:\n"
-            "          2025-09-01: 3\n"
+            "        matches:\n"
+            "          max: 2\n"
+            "          max_overrides:\n"
+            "            2025-09-01: 3\n"
         )
         spec = fixturespec.load_spec(path)
         albany = _find_limit(
@@ -490,8 +493,45 @@ class TestLoadSpec(unittest.TestCase):
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertEqual(_cap_base(albany.match_cap), 2)
-        self.assertEqual(_cap_overrides(albany.match_cap), {date(2025, 9, 1): 3})
+        self.assertEqual(_cap_base(albany.match_max), 2)
+        self.assertEqual(_cap_overrides(albany.match_max), {date(2025, 9, 1): 3})
+
+    def test_match_count_limits_matches_max_overrides_allow_zero(self) -> None:
+        """A 'matches.max_overrides' entry of 0 is meaningful on its own terms --
+        the single-day equivalent of a 'date_ranges' blackout -- unlike a plain
+        'matches.max' of 0, which needs 'date_ranges' to mean anything."""
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        matches:\n"
+            "          max: 2\n"
+            "          max_overrides:\n"
+            "            2025-09-01: 0\n"
+        )
+        spec = fixturespec.load_spec(path)
+        albany = _find_limit(
+            spec.parameters.match_count_limits,
+            club="albany",
+            venue_scope=fmodel.VenueScope.HOME,
+            apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
+        )
+        self.assertEqual(_cap_overrides(albany.match_max), {date(2025, 9, 1): 0})
+
+    def test_match_count_limits_matches_max_overrides_reject_negative(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        matches:\n"
+            "          max: 2\n"
+            "          max_overrides:\n"
+            "            2025-09-01: -1\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "max_overrides"):
+            fixturespec.load_spec(path)
 
     def test_match_count_limits_override_null_lifts_the_cap_that_day(self) -> None:
         path = self._write(
@@ -499,9 +539,10 @@ class TestLoadSpec(unittest.TestCase):
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max_matches: null\n"
-            "        max_matches_overrides:\n"
-            "          2025-09-01: 3\n"
+            "        matches:\n"
+            "          max: null\n"
+            "          max_overrides:\n"
+            "            2025-09-01: 3\n"
         )
         spec = fixturespec.load_spec(path)
         albany = _find_limit(
@@ -510,8 +551,8 @@ class TestLoadSpec(unittest.TestCase):
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertIsNone(_cap_base(albany.match_cap))
-        self.assertEqual(_cap_overrides(albany.match_cap), {date(2025, 9, 1): 3})
+        self.assertIsNone(_cap_base(albany.match_max))
+        self.assertEqual(_cap_overrides(albany.match_max), {date(2025, 9, 1): 3})
 
     def test_match_count_limits_null_max_cancels_default_via_override_key(self) -> None:
         path = self._write(
@@ -520,12 +561,12 @@ class TestLoadSpec(unittest.TestCase):
             "    match_count_limits:\n"
             "      - override_key: venue-capacity\n"
             "        venue_scope: home\n"
-            "        max_matches: 1\n"
+            "        matches:\n          max: 1\n"
             "  albany:\n"
             "    match_count_limits:\n"
             "      - override_key: venue-capacity\n"
             "        venue_scope: home\n"
-            "        max_matches: null\n"
+            "        matches:\n          max: null\n"
         )
         spec = fixturespec.load_spec(path)
         albany_home = [
@@ -542,7 +583,7 @@ class TestLoadSpec(unittest.TestCase):
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertEqual(_cap_base(hackney.match_cap), 1)
+        self.assertEqual(_cap_base(hackney.match_max), 1)
 
     def test_match_count_limits_unknown_override_key_rejected(self) -> None:
         path = self._write(
@@ -551,12 +592,12 @@ class TestLoadSpec(unittest.TestCase):
             "    match_count_limits:\n"
             "      - override_key: venue-capacity\n"
             "        venue_scope: home\n"
-            "        max_matches: 1\n"
+            "        matches:\n          max: 1\n"
             "  albany:\n"
             "    match_count_limits:\n"
             "      - override_key: typo\n"
             "        venue_scope: home\n"
-            "        max_matches: 2\n"
+            "        matches:\n          max: 2\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "override_key"):
             fixturespec.load_spec(path)
@@ -567,7 +608,7 @@ class TestLoadSpec(unittest.TestCase):
             "  defaults:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max_matches: 1\n"
+            "        matches:\n          max: 1\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "override_key"):
             fixturespec.load_spec(path)
@@ -579,10 +620,10 @@ class TestLoadSpec(unittest.TestCase):
             "    match_count_limits:\n"
             "      - override_key: cap\n"
             "        venue_scope: home\n"
-            "        max_matches: 1\n"
+            "        matches:\n          max: 1\n"
             "      - override_key: cap\n"
             "        venue_scope: away\n"
-            "        max_matches: 1\n"
+            "        matches:\n          max: 1\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "override_key"):
             fixturespec.load_spec(path)
@@ -594,17 +635,17 @@ class TestLoadSpec(unittest.TestCase):
             "    match_count_limits:\n"
             "      - override_key: cap\n"
             "        venue_scope: home\n"
-            "        max_matches: 1\n"
+            "        matches:\n          max: 1\n"
             "  albany:\n"
             "    match_count_limits:\n"
             "      - override_key: cap\n"
             "        teams: [albany-1]\n"
-            "        max_matches: 1\n"
+            "        matches:\n          max: 1\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "override_key"):
             fixturespec.load_spec(path)
 
-    def test_match_count_limits_max_matches_overrides_require_one_day_window(
+    def test_match_count_limits_matches_max_overrides_require_one_day_window(
         self,
     ) -> None:
         path = self._write(
@@ -612,12 +653,13 @@ class TestLoadSpec(unittest.TestCase):
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max_matches: 2\n"
+            "        matches:\n"
+            "          max: 2\n"
+            "          max_overrides:\n"
+            "            2025-09-01: 3\n"
             "        time_window_days: 7\n"
-            "        max_matches_overrides:\n"
-            "          2025-09-01: 3\n"
         )
-        with self.assertRaisesRegex(fixturespec.SpecError, "max_matches_overrides"):
+        with self.assertRaisesRegex(fixturespec.SpecError, "max_overrides"):
             fixturespec.load_spec(path)
 
     def test_match_count_limits_missing_max_field_rejected(self) -> None:
@@ -627,7 +669,7 @@ class TestLoadSpec(unittest.TestCase):
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
         )
-        with self.assertRaisesRegex(fixturespec.SpecError, "max"):
+        with self.assertRaisesRegex(fixturespec.SpecError, "matches.*playing_teams"):
             fixturespec.load_spec(path)
 
     def test_match_count_limits_defaults_additive_when_no_override_key(self) -> None:
@@ -639,11 +681,11 @@ class TestLoadSpec(unittest.TestCase):
             "    match_count_limits:\n"
             "      - override_key: venue-capacity\n"
             "        venue_scope: home\n"
-            "        max_matches: 2\n"
+            "        matches:\n          max: 2\n"
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: all\n"
-            "        max_matches: 1\n"
+            "        matches:\n          max: 1\n"
         )
         spec = fixturespec.load_spec(path)
         self.assertEqual(
@@ -653,7 +695,7 @@ class TestLoadSpec(unittest.TestCase):
                     club="albany",
                     venue_scope=fmodel.VenueScope.HOME,
                     apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
-                ).match_cap
+                ).match_max
             ),
             2,
         )
@@ -664,7 +706,7 @@ class TestLoadSpec(unittest.TestCase):
                     club="albany",
                     venue_scope=fmodel.VenueScope.ALL,
                     apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
-                ).match_cap
+                ).match_max
             ),
             1,
         )
@@ -676,7 +718,7 @@ class TestLoadSpec(unittest.TestCase):
             "    match_count_limits:\n"
             "      - override_key: k\n"
             "        teams: [albany-1]\n"
-            "        max_matches: 1\n"
+            "        matches:\n          max: 1\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "teams is not allowed"):
             fixturespec.load_spec(path)
@@ -688,7 +730,7 @@ class TestLoadSpec(unittest.TestCase):
             "    match_count_limits:\n"
             "      - apply_per: each_team\n"
             "        time_window_days: 7\n"
-            "        max_matches: 1\n"
+            "        matches:\n          max: 1\n"
         )
         spec = fixturespec.load_spec(path)
         limit = _find_limit(
@@ -698,7 +740,7 @@ class TestLoadSpec(unittest.TestCase):
             apply_per=fmodel.ApplyPer.EACH_TEAM,
         )
         assert isinstance(limit, fmodel.RollingLimit)
-        self.assertEqual((limit.window_days, _cap_base(limit.match_cap)), (7, 1))
+        self.assertEqual((limit.window_days, _cap_base(limit.match_max)), (7, 1))
 
     def test_match_count_limits_unknown_venue_scope_rejected(self) -> None:
         path = self._write(
@@ -706,7 +748,7 @@ class TestLoadSpec(unittest.TestCase):
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: sideways\n"
-            "        max_matches: 1\n"
+            "        matches:\n          max: 1\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "venue_scope"):
             fixturespec.load_spec(path)
@@ -717,7 +759,7 @@ class TestLoadSpec(unittest.TestCase):
             "  albany:\n"
             "    match_count_limits:\n"
             "      - apply_per: sometimes\n"
-            "        max_matches: 1\n"
+            "        matches:\n          max: 1\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "apply_per"):
             fixturespec.load_spec(path)
@@ -740,7 +782,7 @@ class TestLoadSpec(unittest.TestCase):
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max_matches: 1\n"
+            "        matches:\n          max: 1\n"
         )
         spec = fixturespec.load_spec(path)
         clubs = {
@@ -753,7 +795,7 @@ class TestLoadSpec(unittest.TestCase):
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
-            "      - max_matches: 1\n"
+            "      - matches:\n          max: 1\n"
             "        date_ranges:\n"
             "          - start_date: 2025-10-27\n"
             "            end_date: 2025-11-02\n"
@@ -775,14 +817,14 @@ class TestLoadSpec(unittest.TestCase):
                 fmodel.DateRange(date(2026, 2, 16), date(2026, 2, 22)),
             ),
         )
-        self.assertEqual(_cap_base(limit.match_cap), 1)
+        self.assertEqual(_cap_base(limit.match_max), 1)
 
     def test_match_count_limits_date_ranges_allow_max_zero(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
-            "      - max_matches: 0\n"
+            "      - matches:\n          max: 0\n"
             "        date_ranges:\n"
             "          - start_date: 2025-10-27\n"
             "            end_date: 2025-11-02\n"
@@ -794,7 +836,7 @@ class TestLoadSpec(unittest.TestCase):
             venue_scope=fmodel.VenueScope.ALL,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertEqual(_cap_base(limit.match_cap), 0)
+        self.assertEqual(_cap_base(limit.match_max), 0)
 
     def test_match_count_limits_max_zero_rejected_without_date_ranges(self) -> None:
         path = self._write(
@@ -802,7 +844,7 @@ class TestLoadSpec(unittest.TestCase):
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max_matches: 0\n"
+            "        matches:\n          max: 0\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "must be >= 1"):
             fixturespec.load_spec(path)
@@ -812,7 +854,7 @@ class TestLoadSpec(unittest.TestCase):
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
-            "      - max_matches: 1\n"
+            "      - matches:\n          max: 1\n"
             "        time_window_days: 7\n"
             "        date_ranges:\n"
             "          - start_date: 2025-10-27\n"
@@ -821,19 +863,20 @@ class TestLoadSpec(unittest.TestCase):
         with self.assertRaisesRegex(fixturespec.SpecError, "time_window_days"):
             fixturespec.load_spec(path)
 
-    def test_match_count_limits_date_ranges_reject_max_matches_overrides(self) -> None:
+    def test_match_count_limits_date_ranges_reject_max_overrides(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
-            "      - max_matches: 1\n"
-            "        max_matches_overrides:\n"
-            "          2025-10-27: 1\n"
+            "      - matches:\n"
+            "          max: 1\n"
+            "          max_overrides:\n"
+            "            2025-10-27: 1\n"
             "        date_ranges:\n"
             "          - start_date: 2025-10-27\n"
             "            end_date: 2025-11-02\n"
         )
-        with self.assertRaisesRegex(fixturespec.SpecError, "max_matches_overrides"):
+        with self.assertRaisesRegex(fixturespec.SpecError, "max_overrides"):
             fixturespec.load_spec(path)
 
     def test_match_count_limits_date_ranges_reject_override_key(self) -> None:
@@ -843,11 +886,11 @@ class TestLoadSpec(unittest.TestCase):
             "    match_count_limits:\n"
             "      - override_key: venue-capacity\n"
             "        venue_scope: home\n"
-            "        max_matches: 1\n"
+            "        matches:\n          max: 1\n"
             "  albany:\n"
             "    match_count_limits:\n"
             "      - override_key: venue-capacity\n"
-            "        max_matches: 1\n"
+            "        matches:\n          max: 1\n"
             "        date_ranges:\n"
             "          - start_date: 2025-10-27\n"
             "            end_date: 2025-11-02\n"
@@ -863,7 +906,7 @@ class TestLoadSpec(unittest.TestCase):
             "  defaults:\n"
             "    match_count_limits:\n"
             "      - override_key: k\n"
-            "        max_matches: 1\n"
+            "        matches:\n          max: 1\n"
             "        date_ranges:\n"
             "          - start_date: 2025-10-27\n"
             "            end_date: 2025-11-02\n"
@@ -886,12 +929,12 @@ class TestLoadSpec(unittest.TestCase):
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
-            "      - max_matches: null\n"
+            "      - matches:\n          max: null\n"
             "        date_ranges:\n"
             "          - start_date: 2025-10-27\n"
             "            end_date: 2025-11-02\n"
         )
-        with self.assertRaisesRegex(fixturespec.SpecError, "integer 'max_matches'"):
+        with self.assertRaisesRegex(fixturespec.SpecError, "date_ranges needs"):
             fixturespec.load_spec(path)
 
     def test_match_count_limits_date_ranges_reject_start_after_end(self) -> None:
@@ -899,7 +942,7 @@ class TestLoadSpec(unittest.TestCase):
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
-            "      - max_matches: 1\n"
+            "      - matches:\n          max: 1\n"
             "        date_ranges:\n"
             "          - start_date: 2025-11-02\n"
             "            end_date: 2025-10-27\n"
@@ -912,7 +955,7 @@ class TestLoadSpec(unittest.TestCase):
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
-            "      - max_matches: 1\n"
+            "      - matches:\n          max: 1\n"
             "        date_ranges:\n"
             "          - {}\n"
         )
@@ -926,7 +969,7 @@ class TestLoadSpec(unittest.TestCase):
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
-            "      - max_matches: 1\n"
+            "      - matches:\n          max: 1\n"
             "        date_ranges:\n"
             "          - start_date: 2025-10-27\n"
         )
@@ -945,7 +988,7 @@ class TestLoadSpec(unittest.TestCase):
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
-            "      - max_matches: 1\n"
+            "      - matches:\n          max: 1\n"
             "        date_ranges:\n"
             "          - end_date: 2025-11-02\n"
         )
@@ -964,7 +1007,7 @@ class TestLoadSpec(unittest.TestCase):
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
-            "      - max_matches: 1\n"
+            "      - matches:\n          max: 1\n"
             "        date_ranges:\n"
             "          - start_date: 2025-10-27\n"
             "            end_date: 2025-11-02\n"
@@ -978,7 +1021,7 @@ class TestLoadSpec(unittest.TestCase):
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
-            "      - max_matches: 1\n"
+            "      - matches:\n          max: 1\n"
             "        date_ranges: []\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "non-empty list"):
@@ -1185,7 +1228,7 @@ divisions:
     # to load successfully (the failure-path tests don't get this far).
     _SCHEME_SPEC_TAIL = (
         "club_constraints:\n"
-        "  defaults:\n    match_count_limits:\n      - override_key: venue-capacity\n        venue_scope: home\n        max_matches: 1\n"
+        "  defaults:\n    match_count_limits:\n      - override_key: venue-capacity\n        venue_scope: home\n        matches:\n          max: 1\n"
         "  albany:\n    home_dates: [2025-09-01, 2025-09-08, 2025-09-15]\n"
     )
 
@@ -1274,7 +1317,8 @@ club_constraints:
     match_count_limits:
       - override_key: venue-capacity
         venue_scope: home
-        max_matches: 1
+        matches:
+          max: 1
   albany:
     home_dates: [2025-09-01, 2025-09-08, 2025-09-15]
 """)
@@ -1391,7 +1435,7 @@ club_constraints:
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    match_count_limits:\n"
-            "      - override_key: venue-capacity\n        venue_scope: home\n        max_matches: 1\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        matches:\n          max: 1\n"
             "  albany:\n"
             "    home_dates_used:\n"
             "      max: 1\n"
@@ -1415,7 +1459,7 @@ club_constraints:
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    match_count_limits:\n"
-            "      - override_key: venue-capacity\n        venue_scope: home\n        max_matches: 1\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        matches:\n          max: 1\n"
             "  albany:\n"
             "    home_dates_used:\n"
             "      min: 3\n"
@@ -1436,7 +1480,7 @@ club_constraints:
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    match_count_limits:\n"
-            "      - override_key: venue-capacity\n        venue_scope: home\n        max_matches: 1\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        matches:\n          max: 1\n"
             "  unknown-club:\n"
             "    home_dates_used:\n"
             "      max: 1\n"
@@ -1449,7 +1493,7 @@ club_constraints:
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    match_count_limits:\n"
-            "      - override_key: venue-capacity\n        venue_scope: home\n        max_matches: 1\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        matches:\n          max: 1\n"
             "  albany:\n"
             "    home_dates_used:\n"
             "      max: not-an-int\n"
@@ -1462,7 +1506,7 @@ club_constraints:
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    match_count_limits:\n"
-            "      - override_key: venue-capacity\n        venue_scope: home\n        max_matches: 1\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        matches:\n          max: 1\n"
             "  albany:\n"
             "    home_dates_used: 1\n"
         )
@@ -1474,7 +1518,7 @@ club_constraints:
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    match_count_limits:\n"
-            "      - override_key: venue-capacity\n        venue_scope: home\n        max_matches: 1\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        matches:\n          max: 1\n"
             "  albany:\n"
             "    home_dates_used: {}\n"
         )
@@ -1486,7 +1530,7 @@ club_constraints:
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    match_count_limits:\n"
-            "      - override_key: venue-capacity\n        venue_scope: home\n        max_matches: 1\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        matches:\n          max: 1\n"
             "  albany:\n"
             "    home_dates_used:\n"
             "      minimum: 2\n"
@@ -1499,7 +1543,7 @@ club_constraints:
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    match_count_limits:\n"
-            "      - override_key: venue-capacity\n        venue_scope: home\n        max_matches: 1\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        matches:\n          max: 1\n"
             "  albany:\n"
             "    home_dates_used:\n"
             "      min: 0\n"
@@ -1512,7 +1556,7 @@ club_constraints:
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    match_count_limits:\n"
-            "      - override_key: venue-capacity\n        venue_scope: home\n        max_matches: 1\n"
+            "      - override_key: venue-capacity\n        venue_scope: home\n        matches:\n          max: 1\n"
             "  albany:\n"
             "    home_dates_used:\n"
             "      min: 5\n"
@@ -1532,14 +1576,14 @@ club_constraints:
             "      - override_key: weekly-gap\n"
             "        apply_per: each_team\n"
             "        time_window_days: 7\n"
-            "        max_matches: 1\n"
+            "        matches:\n          max: 1\n"
             "  albany:\n"
             "    home_dates: [2025-09-01]\n"
             "    match_count_limits:\n"
             "      - override_key: weekly-gap\n"
             "        apply_per: each_team\n"
             "        time_window_days: 14\n"
-            "        max_matches: 1\n"
+            "        matches:\n          max: 1\n"
             "  hackney:\n"
             "    home_dates: [2025-09-15]\n"
         )
@@ -1567,12 +1611,12 @@ club_constraints:
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max_matches: -1\n"
+            "        matches:\n          max: -1\n"
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "max"):
             fixturespec.load_spec(path)
 
-    def test_match_count_limits_null_max_without_max_matches_overrides_rejected(
+    def test_match_count_limits_null_max_without_max_overrides_rejected(
         self,
     ) -> None:
         path = self._write(
@@ -1580,19 +1624,19 @@ club_constraints:
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max_matches: null\n"
+            "        matches:\n          max: null\n"
         )
-        with self.assertRaisesRegex(fixturespec.SpecError, "max"):
+        with self.assertRaisesRegex(fixturespec.SpecError, "matches.*playing_teams"):
             fixturespec.load_spec(path)
 
-    def test_match_count_limits_max_playing_teams_parsed(self) -> None:
+    def test_match_count_limits_playing_teams_max_parsed(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max_matches: 3\n"
-            "        max_playing_teams: 3\n"
+            "        matches:\n          max: 3\n"
+            "        playing_teams:\n          max: 3\n"
         )
         spec = fixturespec.load_spec(path)
         limit = _find_limit(
@@ -1601,10 +1645,10 @@ club_constraints:
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertEqual(_cap_base(limit.match_cap), 3)
-        self.assertEqual(_cap_base(limit.playing_teams_cap), 3)
+        self.assertEqual(_cap_base(limit.match_max), 3)
+        self.assertEqual(_cap_base(limit.playing_teams_max), 3)
 
-    def test_match_count_limits_max_playing_teams_defaults_to_none(self) -> None:
+    def test_match_count_limits_playing_teams_max_defaults_to_none(self) -> None:
         path = self._write(_MINIMAL_SPEC)
         spec = fixturespec.load_spec(path)
         limit = _find_limit(
@@ -1613,33 +1657,33 @@ club_constraints:
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertIsNone(_cap_base(limit.playing_teams_cap))
+        self.assertIsNone(_cap_base(limit.playing_teams_max))
 
-    def test_match_count_limits_max_playing_teams_negative_rejected(self) -> None:
+    def test_match_count_limits_playing_teams_max_negative_rejected(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max_matches: 1\n"
-            "        max_playing_teams: -1\n"
+            "        matches:\n          max: 1\n"
+            "        playing_teams:\n          max: -1\n"
         )
-        with self.assertRaisesRegex(fixturespec.SpecError, "max_playing_teams"):
+        with self.assertRaisesRegex(fixturespec.SpecError, "playing_teams.max"):
             fixturespec.load_spec(path)
 
-    def test_match_count_limits_max_playing_teams_allows_multi_day_window(
+    def test_match_count_limits_playing_teams_max_allows_multi_day_window(
         self,
     ) -> None:
-        """Unlike max_playing_teams_overrides (still tied to a single date), a
-        plain max_playing_teams cap is meaningful over a rolling multi-day window
+        """Unlike playing_teams.max_overrides (still tied to a single date), a
+        plain playing_teams.max cap is meaningful over a rolling multi-day window
         too -- see fmodel.MatchCountLimit for what it counts there."""
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max_matches: 3\n"
-            "        max_playing_teams: 1\n"
+            "        matches:\n          max: 3\n"
+            "        playing_teams:\n          max: 1\n"
             "        time_window_days: 7\n"
         )
         spec = fixturespec.load_spec(path)
@@ -1650,17 +1694,17 @@ club_constraints:
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
         assert isinstance(limit, fmodel.RollingLimit)
-        self.assertEqual(_cap_base(limit.playing_teams_cap), 1)
+        self.assertEqual(_cap_base(limit.playing_teams_max), 1)
         self.assertEqual(limit.window_days, 7)
 
-    def test_match_count_limits_max_playing_teams_allows_date_ranges(self) -> None:
+    def test_match_count_limits_playing_teams_max_allows_date_ranges(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max_matches: 0\n"
-            "        max_playing_teams: 0\n"
+            "        matches:\n          max: 0\n"
+            "        playing_teams:\n          max: 0\n"
             "        date_ranges:\n"
             "          - start_date: 2025-09-01\n"
             "            end_date: 2025-09-07\n"
@@ -1673,21 +1717,21 @@ club_constraints:
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
         assert isinstance(limit, fmodel.RangeLimit)
-        self.assertEqual(_cap_base(limit.playing_teams_cap), 0)
+        self.assertEqual(_cap_base(limit.playing_teams_max), 0)
         self.assertEqual(
             limit.ranges,
             (fmodel.DateRange(date(2025, 9, 1), date(2025, 9, 7)),),
         )
 
-    def test_match_count_limits_max_playing_teams_alone_is_allowed(self) -> None:
-        """max_playing_teams can carry a rule on its own, with 'max_matches' omitted
+    def test_match_count_limits_playing_teams_max_alone_is_allowed(self) -> None:
+        """'playing_teams' can carry a rule on its own, with 'matches' omitted
         entirely (no plain match-count cap, just a distinct-teams-playing one)."""
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max_playing_teams: 2\n"
+            "        playing_teams:\n          max: 2\n"
         )
         spec = fixturespec.load_spec(path)
         limit = _find_limit(
@@ -1696,21 +1740,21 @@ club_constraints:
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertIsNone(_cap_base(limit.match_cap))
-        self.assertEqual(_cap_base(limit.playing_teams_cap), 2)
+        self.assertIsNone(_cap_base(limit.match_max))
+        self.assertEqual(_cap_base(limit.playing_teams_max), 2)
 
-    def test_match_count_limits_max_playing_teams_alone_with_explicit_null(
+    def test_match_count_limits_playing_teams_max_alone_with_explicit_null(
         self,
     ) -> None:
-        """An explicit 'max_matches: null' alongside 'max_playing_teams' works the
-        same as omitting the key entirely."""
+        """An explicit 'matches: {max: null}' alongside 'playing_teams' works the
+        same as omitting 'matches' entirely."""
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max_matches: null\n"
-            "        max_playing_teams: 2\n"
+            "        matches:\n          max: null\n"
+            "        playing_teams:\n          max: 2\n"
         )
         spec = fixturespec.load_spec(path)
         limit = _find_limit(
@@ -1719,18 +1763,18 @@ club_constraints:
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertIsNone(_cap_base(limit.match_cap))
-        self.assertEqual(_cap_base(limit.playing_teams_cap), 2)
+        self.assertIsNone(_cap_base(limit.match_max))
+        self.assertEqual(_cap_base(limit.playing_teams_max), 2)
 
-    def test_match_count_limits_max_matches_alone_is_allowed(self) -> None:
-        """max_matches can carry a rule on its own, with 'max_playing_teams'
-        omitted entirely -- the pre-existing, still-supported shape."""
+    def test_match_count_limits_matches_alone_is_allowed(self) -> None:
+        """'matches' can carry a rule on its own, with 'playing_teams'
+        omitted entirely."""
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max_matches: 3\n"
+            "        matches:\n          max: 3\n"
         )
         spec = fixturespec.load_spec(path)
         limit = _find_limit(
@@ -1739,34 +1783,34 @@ club_constraints:
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertEqual(_cap_base(limit.match_cap), 3)
-        self.assertIsNone(_cap_base(limit.playing_teams_cap))
+        self.assertEqual(_cap_base(limit.match_max), 3)
+        self.assertIsNone(_cap_base(limit.playing_teams_max))
 
     def test_match_count_limits_neither_max_field_rejected(self) -> None:
-        """Neither 'max_matches' nor 'max_playing_teams', and no other way to carry
-        a cap (no override_key, max_matches_overrides or date_ranges): rejected."""
+        """Neither 'matches' nor 'playing_teams', and no other way to carry a
+        bound (no override_key): rejected."""
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
         )
-        with self.assertRaisesRegex(
-            fixturespec.SpecError, "max_matches.*max_playing_teams"
-        ):
+        with self.assertRaisesRegex(fixturespec.SpecError, "matches.*playing_teams"):
             fixturespec.load_spec(path)
 
-    def test_match_count_limits_max_playing_teams_overrides_parsed(self) -> None:
+    def test_match_count_limits_playing_teams_max_overrides_parsed(self) -> None:
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max_matches: 3\n"
-            "        max_playing_teams: 1\n"
-            "        max_playing_teams_overrides:\n"
-            "          2025-09-01: 2\n"
-            "          2025-09-08: null\n"
+            "        matches:\n"
+            "          max: 3\n"
+            "        playing_teams:\n"
+            "          max: 1\n"
+            "          max_overrides:\n"
+            "            2025-09-01: 2\n"
+            "            2025-09-08: null\n"
         )
         spec = fixturespec.load_spec(path)
         limit = _find_limit(
@@ -1775,37 +1819,36 @@ club_constraints:
             venue_scope=fmodel.VenueScope.HOME,
             apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
         )
-        self.assertEqual(_cap_base(limit.playing_teams_cap), 1)
+        self.assertEqual(_cap_base(limit.playing_teams_max), 1)
         self.assertEqual(
-            _cap_overrides(limit.playing_teams_cap),
+            _cap_overrides(limit.playing_teams_max),
             {date(2025, 9, 1): 2, date(2025, 9, 8): None},
         )
 
-    def test_match_count_limits_max_playing_teams_overrides_require_one_day_window(
+    def test_match_count_limits_playing_teams_max_overrides_require_one_day_window(
         self,
     ) -> None:
-        # max_playing_teams itself is omitted here (it would trigger its own,
+        # playing_teams.max itself is omitted here (it would trigger its own,
         # broader time_window_days==1 requirement first -- see
-        # test_match_count_limits_max_playing_teams_requires_one_day_window):
-        # max_playing_teams_overrides needs the same restriction independently,
-        # since it's usable on its own (a rule with only override dates, no
-        # everyday cap).
+        # test_match_count_limits_playing_teams_max_requires_one_day_window):
+        # max_overrides needs the same restriction independently, since it's
+        # usable on its own (a rule with only override dates, no everyday cap).
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max_matches: 3\n"
+            "        matches:\n"
+            "          max: 3\n"
             "        time_window_days: 7\n"
-            "        max_playing_teams_overrides:\n"
-            "          2025-09-01: 2\n"
+            "        playing_teams:\n"
+            "          max_overrides:\n"
+            "            2025-09-01: 2\n"
         )
-        with self.assertRaisesRegex(
-            fixturespec.SpecError, "max_playing_teams_overrides"
-        ):
+        with self.assertRaisesRegex(fixturespec.SpecError, "max_overrides"):
             fixturespec.load_spec(path)
 
-    def test_match_count_limits_max_playing_teams_overrides_reject_negative(
+    def test_match_count_limits_playing_teams_max_overrides_reject_negative(
         self,
     ) -> None:
         path = self._write(
@@ -1813,35 +1856,252 @@ club_constraints:
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max_matches: 3\n"
-            "        max_playing_teams: 1\n"
-            "        max_playing_teams_overrides:\n"
-            "          2025-09-01: -1\n"
+            "        matches:\n"
+            "          max: 3\n"
+            "        playing_teams:\n"
+            "          max: 1\n"
+            "          max_overrides:\n"
+            "            2025-09-01: -1\n"
         )
-        with self.assertRaisesRegex(fixturespec.SpecError, "max_playing_teams"):
+        with self.assertRaisesRegex(fixturespec.SpecError, "max_overrides"):
             fixturespec.load_spec(path)
 
-    def test_match_count_limits_max_playing_teams_overrides_reject_date_ranges(
+    def test_match_count_limits_playing_teams_max_overrides_reject_date_ranges(
         self,
     ) -> None:
-        # max_playing_teams itself is omitted -- see the comment on
-        # test_match_count_limits_max_playing_teams_overrides_require_one_day_window
+        # playing_teams.max itself is omitted -- see the comment on
+        # test_match_count_limits_playing_teams_max_overrides_require_one_day_window
         # above.
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max_matches: 0\n"
-            "        max_playing_teams_overrides:\n"
-            "          2025-09-01: 1\n"
+            "        matches:\n"
+            "          max: 0\n"
+            "        playing_teams:\n"
+            "          max_overrides:\n"
+            "            2025-09-01: 1\n"
             "        date_ranges:\n"
             "          - start_date: 2025-09-01\n"
             "            end_date: 2025-09-07\n"
         )
+        with self.assertRaisesRegex(fixturespec.SpecError, "max_overrides"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_matches_min_parsed(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        matches:\n"
+            "          max: 3\n"
+            "          min: 1\n"
+            "          min_overrides:\n"
+            "            2025-09-01: 2\n"
+            "            2025-09-08: null\n"
+        )
+        spec = fixturespec.load_spec(path)
+        limit = _find_limit(
+            spec.parameters.match_count_limits,
+            club="albany",
+            venue_scope=fmodel.VenueScope.HOME,
+            apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
+        )
+        self.assertEqual(_cap_base(limit.match_min), 1)
+        self.assertEqual(
+            _cap_overrides(limit.match_min),
+            {date(2025, 9, 1): 2, date(2025, 9, 8): None},
+        )
+
+    def test_match_count_limits_playing_teams_min_parsed(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        playing_teams:\n"
+            "          max: 3\n"
+            "          min: 1\n"
+            "          min_overrides:\n"
+            "            2025-09-01: 2\n"
+        )
+        spec = fixturespec.load_spec(path)
+        limit = _find_limit(
+            spec.parameters.match_count_limits,
+            club="albany",
+            venue_scope=fmodel.VenueScope.HOME,
+            apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
+        )
+        self.assertEqual(_cap_base(limit.playing_teams_min), 1)
+        self.assertEqual(_cap_overrides(limit.playing_teams_min), {date(2025, 9, 1): 2})
+
+    def test_match_count_limits_min_alone_is_allowed(self) -> None:
+        """A rule can be a pure floor, with no 'max' at all."""
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        matches:\n"
+            "          min: 1\n"
+        )
+        spec = fixturespec.load_spec(path)
+        limit = _find_limit(
+            spec.parameters.match_count_limits,
+            club="albany",
+            venue_scope=fmodel.VenueScope.HOME,
+            apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
+        )
+        self.assertIsNone(_cap_base(limit.match_max))
+        self.assertEqual(_cap_base(limit.match_min), 1)
+
+    def test_match_count_limits_min_zero_rejected(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        matches:\n"
+            "          min: 0\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "matches.min"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_playing_teams_min_zero_rejected(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        playing_teams:\n"
+            "          min: 0\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "playing_teams.min"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_min_overrides_zero_rejected(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        matches:\n"
+            "          max: 3\n"
+            "          min_overrides:\n"
+            "            2025-09-01: 0\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "min_overrides"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_min_overrides_require_one_day_window(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        time_window_days: 7\n"
+            "        matches:\n"
+            "          max: 3\n"
+            "          min_overrides:\n"
+            "            2025-09-01: 1\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "min_overrides"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_min_allowed_with_date_ranges(self) -> None:
+        """Unlike 'min_overrides', a plain 'min' base value is fine alongside
+        'date_ranges' -- there's no 0-with-date_ranges special case the way
+        'max' has one, since a floor of 0 is never meaningful either way."""
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        matches:\n"
+            "          min: 1\n"
+            "        date_ranges:\n"
+            "          - start_date: 2025-10-27\n"
+            "            end_date: 2025-11-02\n"
+        )
+        spec = fixturespec.load_spec(path)
+        limit = _find_limit(
+            spec.parameters.match_count_limits,
+            club="albany",
+            venue_scope=fmodel.VenueScope.HOME,
+            apply_per=fmodel.ApplyPer.ACROSS_TEAMS,
+        )
+        assert isinstance(limit, fmodel.RangeLimit)
+        self.assertEqual(_cap_base(limit.match_min), 1)
+
+    def test_match_count_limits_min_overrides_reject_date_ranges(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        matches:\n"
+            "          min: 1\n"
+            "          min_overrides:\n"
+            "            2025-10-27: 2\n"
+            "        date_ranges:\n"
+            "          - start_date: 2025-10-27\n"
+            "            end_date: 2025-11-02\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "min_overrides"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_min_exceeds_max_rejected(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        matches:\n"
+            "          max: 2\n"
+            "          min: 3\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "matches.min.*exceeds"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_playing_teams_min_exceeds_max_rejected(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        playing_teams:\n"
+            "          max: 2\n"
+            "          min: 3\n"
+        )
         with self.assertRaisesRegex(
-            fixturespec.SpecError, "max_playing_teams_overrides"
+            fixturespec.SpecError, "playing_teams.min.*exceeds"
         ):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_measure_unsupported_key_rejected(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        matches:\n"
+            "          max: 1\n"
+            "          nonsense: true\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "not supported"):
+            fixturespec.load_spec(path)
+
+    def test_match_count_limits_measure_empty_mapping_rejected(self) -> None:
+        path = self._write(
+            _BOILERPLATE + "club_constraints:\n"
+            "  albany:\n"
+            "    match_count_limits:\n"
+            "      - venue_scope: home\n"
+            "        matches: {}\n"
+        )
+        with self.assertRaisesRegex(fixturespec.SpecError, "non-empty mapping"):
             fixturespec.load_spec(path)
 
     def test_match_count_limits_exclude_dates_parsed(self) -> None:
@@ -1853,7 +2113,7 @@ club_constraints:
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max_playing_teams: 3\n"
+            "        playing_teams:\n          max: 3\n"
             "        time_window_days: 7\n"
             "        exclude_dates:\n"
             "          - 2025-09-01\n"
@@ -1891,7 +2151,7 @@ club_constraints:
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max_matches: 3\n"
+            "        matches:\n          max: 3\n"
             "        exclude_dates:\n"
             "          - not-a-date\n"
         )
@@ -1904,7 +2164,7 @@ club_constraints:
             "  albany:\n"
             "    match_count_limits:\n"
             "      - venue_scope: home\n"
-            "        max_matches: 0\n"
+            "        matches:\n          max: 0\n"
             "        exclude_dates:\n"
             "          - 2025-09-01\n"
             "        date_ranges:\n"
@@ -2215,7 +2475,7 @@ club_constraints:
             self._with_albany_match_count_limits(
                 "    match_count_limits:\n"
                 "      - teams: [albany-1, albany-2]\n"
-                "        max_matches: 1\n"
+                "        matches:\n          max: 1\n"
             )
         )
         spec = fixturespec.load_spec(path)
@@ -2230,7 +2490,7 @@ club_constraints:
             [
                 fmodel.RollingLimit(
                     teams=[albany_1, albany_2],
-                    match_cap=fmodel.Cap(1),
+                    match_max=fmodel.Cap(1),
                     window_days=1,
                 )
             ],
@@ -2239,7 +2499,7 @@ club_constraints:
     def test_match_count_limits_teams_defaults_to_all_of_club(self) -> None:
         path = self._write(
             self._with_albany_match_count_limits(
-                "    match_count_limits:\n      - max_matches: 3\n        time_window_days: 7\n"
+                "    match_count_limits:\n      - matches:\n          max: 3\n        time_window_days: 7\n"
             )
         )
         spec = fixturespec.load_spec(path)
@@ -2252,7 +2512,7 @@ club_constraints:
         constraints = list(spec.parameters.match_count_limits)
         self.assertEqual(list(constraints[0].teams), [albany_1, albany_2])
         assert isinstance(constraints[0], fmodel.RollingLimit)
-        self.assertEqual(_cap_base(constraints[0].match_cap), 3)
+        self.assertEqual(_cap_base(constraints[0].match_max), 3)
         self.assertEqual(constraints[0].window_days, 7)
 
     def test_match_count_limits_time_window_days_parsed(self) -> None:
@@ -2260,7 +2520,7 @@ club_constraints:
             self._with_albany_match_count_limits(
                 "    match_count_limits:\n"
                 "      - teams: [albany-1, albany-2]\n"
-                "        max_matches: 1\n"
+                "        matches:\n          max: 1\n"
                 "        time_window_days: 3\n"
             )
         )
@@ -2274,7 +2534,7 @@ club_constraints:
             self._with_albany_match_count_limits(
                 "    match_count_limits:\n"
                 "      - teams: [albany-1, albany-2]\n"
-                "        max_matches: 1\n"
+                "        matches:\n          max: 1\n"
             )
         )
         spec = fixturespec.load_spec(path)
@@ -2287,7 +2547,7 @@ club_constraints:
             self._with_albany_match_count_limits(
                 "    match_count_limits:\n"
                 "      - teams: [albany-1, albany-2]\n"
-                "        max_matches: 1\n"
+                "        matches:\n          max: 1\n"
             )
         )
         spec = fixturespec.load_spec(path)
@@ -2299,7 +2559,7 @@ club_constraints:
             self._with_albany_match_count_limits(
                 "    match_count_limits:\n"
                 "      - teams: [albany-1, albany-2]\n"
-                "        max_matches: 1\n"
+                "        matches:\n          max: 1\n"
                 "        venue_scope: away\n"
             )
         )
@@ -2312,7 +2572,7 @@ club_constraints:
             self._with_albany_match_count_limits(
                 "    match_count_limits:\n"
                 "      - teams: [albany-1, albany-2]\n"
-                "        max_matches: 1\n"
+                "        matches:\n          max: 1\n"
                 "        venue_scope: sometimes\n"
             )
         )
@@ -2325,7 +2585,7 @@ club_constraints:
                 "    match_count_limits:\n      - teams: [albany-1, albany-2]\n"
             )
         )
-        with self.assertRaisesRegex(fixturespec.SpecError, "max"):
+        with self.assertRaisesRegex(fixturespec.SpecError, "matches.*playing_teams"):
             fixturespec.load_spec(path)
 
     def test_match_count_limits_max_below_one_rejected(self) -> None:
@@ -2333,7 +2593,7 @@ club_constraints:
             self._with_albany_match_count_limits(
                 "    match_count_limits:\n"
                 "      - teams: [albany-1, albany-2]\n"
-                "        max_matches: 0\n"
+                "        matches:\n          max: 0\n"
             )
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "max"):
@@ -2344,7 +2604,7 @@ club_constraints:
             self._with_albany_match_count_limits(
                 "    match_count_limits:\n"
                 "      - teams: [albany-1, albany-2]\n"
-                "        max_matches: 1\n"
+                "        matches:\n          max: 1\n"
                 "        time_window_days: 0\n"
             )
         )
@@ -2370,7 +2630,7 @@ club_constraints:
     def test_match_count_limits_empty_teams_list(self) -> None:
         path = self._write(
             self._with_albany_match_count_limits(
-                "    match_count_limits:\n      - teams: []\n        max_matches: 1\n"
+                "    match_count_limits:\n      - teams: []\n        matches:\n          max: 1\n"
             )
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "non-empty"):
@@ -2381,7 +2641,7 @@ club_constraints:
             self._with_albany_match_count_limits(
                 "    match_count_limits:\n"
                 "      - teams: [albany-1, albany-1]\n"
-                "        max_matches: 1\n"
+                "        matches:\n          max: 1\n"
             )
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "duplicate"):
@@ -2392,7 +2652,7 @@ club_constraints:
             self._with_albany_match_count_limits(
                 "    match_count_limits:\n"
                 "      - teams: [albany-1, nonexistent]\n"
-                "        max_matches: 1\n"
+                "        matches:\n          max: 1\n"
             )
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "nonexistent"):
@@ -2403,7 +2663,7 @@ club_constraints:
             self._with_albany_match_count_limits(
                 "    match_count_limits:\n"
                 "      - teams: [albany-1, hackney-1]\n"
-                "        max_matches: 1\n"
+                "        matches:\n          max: 1\n"
             )
         )
         with self.assertRaisesRegex(fixturespec.SpecError, "hackney-1"):
@@ -2414,7 +2674,7 @@ club_constraints:
             self._with_albany_match_count_limits(
                 "    match_count_limits:\n"
                 "      - teams: [albany-1, albany-2]\n"
-                "        max_matches: 1\n"
+                "        matches:\n          max: 1\n"
                 "        venue: elsewhere\n"
             )
         )

--- a/fmodel.py
+++ b/fmodel.py
@@ -224,11 +224,11 @@ class VenueScope(enum.Enum):
 
 
 class ApplyPer(enum.Enum):
-    """How a MatchCountLimit's caps (`match_cap`/`playing_teams_cap`) apply to its
-    `teams`. ACROSS_TEAMS: one shared budget for the whole set (a venue capacity, or
-    a keep-these-teams-apart rule). EACH_TEAM: the cap is enforced separately for
-    every team in the set (a per-team gap -- `teams` is then typically every team of
-    a club and `match_cap` is `Cap(1)`).
+    """How a MatchCountLimit's caps (`match_max`/`match_min`/`playing_teams_max`/
+    `playing_teams_min`) apply to its `teams`. ACROSS_TEAMS: one shared budget for
+    the whole set (a venue capacity, or a keep-these-teams-apart rule). EACH_TEAM:
+    the cap is enforced separately for every team in the set (a per-team gap --
+    `teams` is then typically every team of a club and `match_max` is `Cap(1)`).
     """
 
     EACH_TEAM = "each_team"
@@ -257,11 +257,13 @@ def _fixture_counts_for_scope(
 
 @dataclasses.dataclass(frozen=True)
 class Cap:
-    """A per-window integer ceiling: `base` (None = unbounded) together with
-    optional per-date `overrides`.
+    """A per-window integer bound: `base` (None = unbounded) together with
+    optional per-date `overrides`. Used as either a ceiling (MatchCountLimit's
+    `match_max`/`playing_teams_max`) or a floor (`match_min`/`playing_teams_min`)
+    -- the direction lives in which field it's assigned to, not in Cap itself.
 
     An override applies only where a window is a single date (see for_window) --
-    it names that date's replacement ceiling (an int, or None to lift the cap for
+    it names that date's replacement bound (an int, or None to lift the bound for
     that date). Overrides are therefore only meaningful, and only accepted, on a
     RollingLimit with window_days == 1: an override names one date, which lines up
     with exactly one window only then.
@@ -285,7 +287,7 @@ class Cap:
                 )
 
     def for_window(self, window: Collection[date]) -> int | None:
-        """This cap's effective ceiling for `window`: an `overrides` entry when the
+        """This cap's effective bound for `window`: an `overrides` entry when the
         window is a single overridden date, otherwise `base`."""
         if self.overrides and len(window) == 1:
             (d,) = tuple(window)
@@ -295,7 +297,8 @@ class Cap:
     def zero_on(self, d: date) -> bool:
         """Whether this cap is an effective 0 on `d`: a `base` of 0 (every day), or
         an `overrides` entry of 0 for `d` specifically. Feeds the up-front
-        candidate pruning in MatchCountLimit.forbids."""
+        candidate pruning in MatchCountLimit.forbids (a ceiling-only concept -- see
+        MatchCountLimit._active_max_caps)."""
         return self.base == 0 or self.overrides.get(d) == 0
 
 
@@ -355,32 +358,63 @@ class MatchCountLimit(abc.ABC):
       separately for every team (EACH_TEAM -- `teams` is then typically a whole
       club and the cap a per-team gap).
 
-      `match_cap` caps the number of counted matches in a window; `playing_teams_cap`
-      caps how many teams'-worth of players it asks for -- each counted match
+      `match_max` caps the number of counted matches in a window from above;
+      `match_min` floors it from below (e.g. "each team must play at least once
+      every 14 days"). `playing_teams_max`/`playing_teams_min` do the same for how
+      many teams'-worth of players a window asks for -- each counted match
       contributes one, or two if it's an internal match between two of `teams`
       (e.g. a same-club derby counted by that club's own venue-capacity rule): one
-      entry towards `match_cap`, but two teams from the set on to play. Either may
-      be None (that measure left uncapped); at least one must be set. A venue that
-      can physically host 3 simultaneous matches but only has 3 teams' worth of
-      players to field wants both `match_cap=Cap(3)` and `playing_teams_cap=Cap(3)`
-      -- a `match_cap` alone can't tell that 3 matches, one an internal derby,
-      need 4 teams' worth of players. Over a window spanning more than a single
-      date, the same pair meeting twice counts twice towards `playing_teams_cap`:
-      it is a running tally of teams'-worth of players asked to play, not a count
-      of distinct teams touched.
+      entry towards the matches measure, but two teams from the set on to play.
+      Any of the four may be None (that bound left unset); at least one must be
+      set. A venue that can physically host 3 simultaneous matches but only has 3
+      teams' worth of players to field wants both `match_max=Cap(3)` and
+      `playing_teams_max=Cap(3)` -- a matches cap alone can't tell that 3 matches,
+      one an internal derby, need 4 teams' worth of players. Over a window
+      spanning more than a single date, the same pair meeting twice counts twice
+      towards a playing-teams bound: it is a running tally of teams'-worth of
+      players asked to play, not a count of distinct teams touched.
+
+      A floor of 0 is never meaningful (it can never bind), so `match_min`/
+      `playing_teams_min` are expected to always carry a `base`/override `>= 1`;
+      unlike the max side, callers are responsible for that -- Cap itself only
+      rejects negative values. When both a max and a min are set for the same
+      measure and both have a `base`, the min's `base` may not exceed the max's.
     """
 
     teams: Collection[Team]
-    match_cap: Cap | None = None
-    playing_teams_cap: Cap | None = None
+    match_max: Cap | None = None
+    match_min: Cap | None = None
+    playing_teams_max: Cap | None = None
+    playing_teams_min: Cap | None = None
     venue_scope: VenueScope = VenueScope.ALL
     apply_per: ApplyPer = ApplyPer.ACROSS_TEAMS
 
     def __post_init__(self) -> None:
-        if self.match_cap is None and self.playing_teams_cap is None:
+        if (
+            self.match_max is None
+            and self.match_min is None
+            and self.playing_teams_max is None
+            and self.playing_teams_min is None
+        ):
             raise ValueError(
-                "MatchCountLimit needs a match_cap and/or a playing_teams_cap"
+                "MatchCountLimit needs at least one of match_max, match_min, "
+                "playing_teams_max or playing_teams_min"
             )
+        for label, max_cap, min_cap in (
+            ("match", self.match_max, self.match_min),
+            ("playing_teams", self.playing_teams_max, self.playing_teams_min),
+        ):
+            if (
+                max_cap is not None
+                and min_cap is not None
+                and max_cap.base is not None
+                and min_cap.base is not None
+                and min_cap.base > max_cap.base
+            ):
+                raise ValueError(
+                    f"{label}_min base {min_cap.base} exceeds {label}_max base "
+                    f"{max_cap.base}"
+                )
 
     def counts_fixture(self, fixture: Fixture) -> bool:
         """Whether this limit counts `fixture` at all: its home team (for a HOME or
@@ -406,9 +440,9 @@ class MatchCountLimit(abc.ABC):
             # Every candidate this rule counts (per its venue_scope), grouped by
             # date. A match between two teams both in `team_set` (e.g. a same-club
             # derby counted by that club's own rule) appears once here, under one
-            # variable -- counted once towards match_cap below, but twice towards
-            # playing_teams_cap (see _Measure.PLAYING_TEAMS), since it puts two of
-            # `team_set` on to play.
+            # variable -- counted once towards the matches measure below, but
+            # twice towards the playing-teams measure (see
+            # _Measure.PLAYING_TEAMS), since it puts two of `team_set` on to play.
             counted_by_date = self._counted_by_date(
                 _counted_fixtures_by_date(fixture_date_vars, team_set, self.venue_scope)
             )
@@ -416,7 +450,7 @@ class MatchCountLimit(abc.ABC):
                 window_fixture_dates = [
                     (fixture, d) for d in window for fixture in counted_by_date[d]
                 ]
-                for measure, cap in self._active_caps():
+                for measure, cap in self._active_max_caps():
                     ceiling = cap.for_window(window)
                     if ceiling is None:
                         continue
@@ -439,6 +473,19 @@ class MatchCountLimit(abc.ABC):
                     if measure is _Measure.MATCHES and len(terms) <= ceiling:
                         continue
                     model.add(cp_model.LinearExpr.Sum(terms) <= ceiling)
+                for measure, cap in self._active_min_caps():
+                    floor = cap.for_window(window)
+                    if floor is None:
+                        continue
+                    terms = [
+                        measure.term(fixture_vars, fixture, d, team_set)
+                        for fixture, d in window_fixture_dates
+                    ]
+                    # Unlike the max side, an empty `terms` here is not a no-op --
+                    # a floor with nothing at all to count towards it is genuinely
+                    # infeasible, and the constraint must still be added so the
+                    # solver reports that rather than silently ignoring it.
+                    model.add(cp_model.LinearExpr.Sum(terms) >= floor)
 
     def _team_groups(self) -> list[set[Team]]:
         """The groups this rule's caps apply to: one singleton set per team under
@@ -447,12 +494,22 @@ class MatchCountLimit(abc.ABC):
             return [{team} for team in self.teams]
         return [set(self.teams)]
 
-    def _active_caps(self) -> Iterable[tuple[_Measure, Cap]]:
-        """This rule's set caps, paired with the measure each bounds."""
-        if self.match_cap is not None:
-            yield _Measure.MATCHES, self.match_cap
-        if self.playing_teams_cap is not None:
-            yield _Measure.PLAYING_TEAMS, self.playing_teams_cap
+    def _active_max_caps(self) -> Iterable[tuple[_Measure, Cap]]:
+        """This rule's set ceilings, paired with the measure each bounds. Used by
+        add_to_model and by forbids/_covers_zero -- a floor can never make a
+        single candidate impossible outright the way a ceiling of 0 does, so
+        those stay ceiling-only."""
+        if self.match_max is not None:
+            yield _Measure.MATCHES, self.match_max
+        if self.playing_teams_max is not None:
+            yield _Measure.PLAYING_TEAMS, self.playing_teams_max
+
+    def _active_min_caps(self) -> Iterable[tuple[_Measure, Cap]]:
+        """This rule's set floors, paired with the measure each bounds."""
+        if self.match_min is not None:
+            yield _Measure.MATCHES, self.match_min
+        if self.playing_teams_min is not None:
+            yield _Measure.PLAYING_TEAMS, self.playing_teams_min
 
     def _counted_by_date(
         self, counted_by_date: Mapping[date, list[Fixture]]
@@ -491,10 +548,10 @@ class RollingLimit(MatchCountLimit):
 
     `exclude_dates` drops every counted match falling on one of the listed dates
     from this rule: each window is evaluated as if nothing counted happened then,
-    for both `match_cap` and `playing_teams_cap`. Unlike a Cap override it is not
-    tied to a single-date window, so it is the way to exempt one date from a
-    multi-day rolling cap -- typically a date whose load is already pinned by
-    `fixed_fixtures` and bounded by its own Cap override.
+    for every one of `match_max`/`match_min`/`playing_teams_max`/`playing_teams_min`.
+    Unlike a Cap override it is not tied to a single-date window, so it is the way
+    to exempt one date from a multi-day rolling cap -- typically a date whose load
+    is already pinned by `fixed_fixtures` and bounded by its own Cap override.
 
     A Cap with per-date `overrides` requires `window_days == 1` (see Cap).
     """
@@ -509,7 +566,10 @@ class RollingLimit(MatchCountLimit):
                 f"RollingLimit.window_days must be >= 1, got {self.window_days}"
             )
         if self.window_days != 1 and any(
-            cap.overrides for _, cap in self._active_caps()
+            cap.overrides
+            for _, cap in itertools.chain(
+                self._active_max_caps(), self._active_min_caps()
+            )
         ):
             raise ValueError(
                 "RollingLimit per-date Cap overrides require window_days == 1"
@@ -537,16 +597,17 @@ class RollingLimit(MatchCountLimit):
         return None
 
     def _covers_zero(self, d: date) -> bool:
-        return any(cap.zero_on(d) for _, cap in self._active_caps())
+        return any(cap.zero_on(d) for _, cap in self._active_max_caps())
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class RangeLimit(MatchCountLimit):
     """A MatchCountLimit whose windows are exactly the given inclusive calendar
     `ranges`, each counted independently, instead of a rolling window. A
-    `match_cap` of `Cap(0)` bars every counted match across the ranges -- a
-    whole-club, all-teams RangeLimit with `match_cap=Cap(0)` is how a spec-wide
-    "nobody plays these dates" block is expressed.
+    `match_max` of `Cap(0)` bars every counted match across the ranges -- a
+    whole-club, all-teams RangeLimit with `match_max=Cap(0)` is how a spec-wide
+    "nobody plays these dates" block is expressed. A `match_min`/`playing_teams_min`
+    instead requires at least that many within each range.
 
     Caps here carry no per-date overrides, and there is no `exclude_dates`: both
     are meaningless once the windows are already explicit calendar ranges --
@@ -559,7 +620,12 @@ class RangeLimit(MatchCountLimit):
         super().__post_init__()
         if not self.ranges:
             raise ValueError("RangeLimit needs at least one DateRange")
-        if any(cap.overrides for _, cap in self._active_caps()):
+        if any(
+            cap.overrides
+            for _, cap in itertools.chain(
+                self._active_max_caps(), self._active_min_caps()
+            )
+        ):
             raise ValueError(
                 "RangeLimit caps can't carry per-date overrides (leave the date "
                 "out of the ranges instead)"
@@ -570,7 +636,7 @@ class RangeLimit(MatchCountLimit):
         return [[d for d in dates if d in rng] for rng in self.ranges]
 
     def _covers_zero(self, d: date) -> bool:
-        return any(cap.zero_on(d) for _, cap in self._active_caps()) and any(
+        return any(cap.zero_on(d) for _, cap in self._active_max_caps()) and any(
             d in rng for rng in self.ranges
         )
 
@@ -807,7 +873,7 @@ class _FixtureVars:
         candidate in a window gives exactly how many teams'-worth of players from
         `teams` the window asks for -- once per match a team plays in, not just once
         per team, so the same pair meeting twice in the window counts twice (see
-        MatchCountLimit's playing_teams_cap)."""
+        MatchCountLimit's playing_teams_max/playing_teams_min)."""
         count = (fixture.home_team in teams) + (fixture.away_team in teams)
         if count == 0:
             return 0
@@ -884,9 +950,9 @@ def _add_match_count_limit_constraints(
 ) -> None:
     """Apply every match-count limit (see MatchCountLimit.add_to_model): within
     each of a rule's windows -- rolling runs of `window_days` consecutive days for
-    a RollingLimit, or the listed calendar ranges for a RangeLimit -- no more than
-    its `match_cap` matches from the counted set, nor more than its
-    `playing_teams_cap` teams'-worth of players, may be scheduled.
+    a RollingLimit, or the listed calendar ranges for a RangeLimit -- the counted
+    set is bounded above by `match_max`/`playing_teams_max` and/or below by
+    `match_min`/`playing_teams_min`, as configured.
     """
     for rule in limits:
         rule.add_to_model(model, fixture_vars)

--- a/genfixtures.py
+++ b/genfixtures.py
@@ -165,7 +165,7 @@ _MATCH_COUNT_LIMITS: list[fmodel.MatchLimit] = []
 _MATCH_COUNT_LIMITS += [
     fmodel.RollingLimit(
         teams=club_teams,
-        match_cap=fmodel.Cap(1),
+        match_max=fmodel.Cap(1),
         window_days=_MIN_MATCH_GAP_DAYS,
         apply_per=fmodel.ApplyPer.EACH_TEAM,
     )
@@ -174,7 +174,7 @@ _MATCH_COUNT_LIMITS += [
 _MATCH_COUNT_LIMITS += [
     fmodel.RollingLimit(
         teams=club_teams,
-        match_cap=fmodel.Cap(2),
+        match_max=fmodel.Cap(2),
         venue_scope=fmodel.VenueScope.HOME,
     )
     for club_teams in _TEAMS_BY_CLUB.values()

--- a/model_test.py
+++ b/model_test.py
@@ -62,7 +62,7 @@ def _params(
             limits.append(
                 fmodel.RollingLimit(
                     teams=club_teams,
-                    match_cap=fmodel.Cap(1),
+                    match_max=fmodel.Cap(1),
                     window_days=min_gap_days,
                     apply_per=fmodel.ApplyPer.EACH_TEAM,
                 )
@@ -70,7 +70,7 @@ def _params(
     for club, (scope, n) in (max_concurrent_matches or {}).items():
         limits.append(
             fmodel.RollingLimit(
-                teams=teams_by_club[club], match_cap=fmodel.Cap(n), venue_scope=scope
+                teams=teams_by_club[club], match_max=fmodel.Cap(n), venue_scope=scope
             )
         )
     return fmodel.Parameters(match_count_limits=limits, **kwargs)
@@ -393,7 +393,7 @@ class TestOneMatchPerTeamPerDate(unittest.TestCase):
 
 
 class TestSharedLimitAtOrAboveGroupSize(unittest.TestCase):
-    """A shared-budget MatchCountLimit (apply_per=ACROSS_TEAMS) with max_matches >= the number
+    """A shared-budget MatchCountLimit (apply_per=ACROSS_TEAMS) with match_max >= the number
     of teams it covers can never bind -- the teams can't play more simultaneous
     matches than there are of them -- so the solver skips it (this is how a
     venue capacity stated above a club's team count stays a no-op). See issue #22.
@@ -414,7 +414,7 @@ class TestSharedLimitAtOrAboveGroupSize(unittest.TestCase):
             match_count_limits=[
                 fmodel.RollingLimit(
                     teams=teams,
-                    match_cap=fmodel.Cap(limit),
+                    match_max=fmodel.Cap(limit),
                     venue_scope=fmodel.VenueScope.HOME,
                 )
             ],
@@ -443,7 +443,7 @@ class TestSharedLimitAtOrAboveGroupSize(unittest.TestCase):
             match_count_limits=[
                 fmodel.RollingLimit(
                     teams=teams,
-                    match_cap=fmodel.Cap(2),
+                    match_max=fmodel.Cap(2),
                     venue_scope=fmodel.VenueScope.HOME,
                 )
             ],
@@ -1303,14 +1303,14 @@ class TestMatchCountLimits(unittest.TestCase):
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=2, club="A", index=2)
         self.assertEqual(
-            fmodel.RollingLimit(teams=[a1, a2], match_cap=fmodel.Cap(1)).window_days, 1
+            fmodel.RollingLimit(teams=[a1, a2], match_max=fmodel.Cap(1)).window_days, 1
         )
 
     def test_venue_scope_defaults_to_all(self) -> None:
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=2, club="A", index=2)
         self.assertEqual(
-            fmodel.RollingLimit(teams=[a1, a2], match_cap=fmodel.Cap(1)).venue_scope,
+            fmodel.RollingLimit(teams=[a1, a2], match_max=fmodel.Cap(1)).venue_scope,
             fmodel.VenueScope.ALL,
         )
 
@@ -1339,7 +1339,7 @@ class TestMatchCountLimits(unittest.TestCase):
             },
             min_gap_days=7,
             match_count_limits=[
-                fmodel.RollingLimit(teams=[a1, a2], match_cap=fmodel.Cap(1))
+                fmodel.RollingLimit(teams=[a1, a2], match_max=fmodel.Cap(1))
             ],
         )
         fixtures = list(fmodel.solve(params).fixtures)
@@ -1368,7 +1368,7 @@ class TestMatchCountLimits(unittest.TestCase):
             },
             min_gap_days=7,
             match_count_limits=[
-                fmodel.RollingLimit(teams=[a1, a2], match_cap=fmodel.Cap(1))
+                fmodel.RollingLimit(teams=[a1, a2], match_max=fmodel.Cap(1))
             ],
         )
         with self.assertRaises(ValueError):
@@ -1397,14 +1397,14 @@ class TestMatchCountLimits(unittest.TestCase):
             },
             min_gap_days=7,
             match_count_limits=[
-                fmodel.RollingLimit(teams=[a1, a2], match_cap=fmodel.Cap(1))
+                fmodel.RollingLimit(teams=[a1, a2], match_max=fmodel.Cap(1))
             ],
         )
         with self.assertRaises(ValueError):
             fmodel.solve(params)
 
     def test_time_window_days_forbids_shorter_gaps(self) -> None:
-        """With time_window_days=3 and max_matches=1, A1 and A2's home matches can't share
+        """With time_window_days=3 and match_max=1, A1 and A2's home matches can't share
         any 3-consecutive-day window -- of A's three candidate dates (Jan 1, 3, 10),
         the only forbidden pairing is Jan 1 / Jan 3 (2 days apart), so the solver
         must pick a pairing that involves Jan 10. (X's two home dates, for A1/A2's
@@ -1428,7 +1428,7 @@ class TestMatchCountLimits(unittest.TestCase):
             min_gap_days=7,
             match_count_limits=[
                 fmodel.RollingLimit(
-                    teams=[a1, a2], match_cap=fmodel.Cap(1), window_days=3
+                    teams=[a1, a2], match_max=fmodel.Cap(1), window_days=3
                 )
             ],
         )
@@ -1440,7 +1440,7 @@ class TestMatchCountLimits(unittest.TestCase):
     def test_time_window_days_allows_exact_gap(self) -> None:
         """time_window_days=N counts a run of N consecutive days, not a gap between
         endpoints: two dates exactly N days apart fall in separate windows. With
-        time_window_days=7, max_matches=1 and A's only two home dates exactly a week apart
+        time_window_days=7, match_max=1 and A's only two home dates exactly a week apart
         (Jan 1 and Jan 8), A1 and A2 must take one each -- the schedule stays
         feasible. An off-by-one that put a 7-day span in one window would make this
         infeasible."""
@@ -1462,7 +1462,7 @@ class TestMatchCountLimits(unittest.TestCase):
             min_gap_days=7,
             match_count_limits=[
                 fmodel.RollingLimit(
-                    teams=[a1, a2], match_cap=fmodel.Cap(1), window_days=7
+                    teams=[a1, a2], match_max=fmodel.Cap(1), window_days=7
                 )
             ],
         )
@@ -1489,7 +1489,7 @@ class TestMatchCountLimits(unittest.TestCase):
             min_gap_days=7,
             excluded_fixtures=[fmodel.Fixture(home_team=a2, away_team=a1)],
             match_count_limits=[
-                fmodel.RollingLimit(teams=[a1, a2], match_cap=fmodel.Cap(1))
+                fmodel.RollingLimit(teams=[a1, a2], match_max=fmodel.Cap(1))
             ],
         )
         fixtures = list(fmodel.solve(params).fixtures)
@@ -1527,7 +1527,7 @@ class TestMatchCountLimits(unittest.TestCase):
             match_count_limits=[
                 fmodel.RollingLimit(
                     teams=[a1, a2],
-                    match_cap=fmodel.Cap(1),
+                    match_max=fmodel.Cap(1),
                     venue_scope=fmodel.VenueScope.AWAY,
                 )
             ],
@@ -1559,7 +1559,7 @@ class TestMatchCountLimits(unittest.TestCase):
             match_count_limits=[
                 fmodel.RollingLimit(
                     teams=[a1, a2],
-                    match_cap=fmodel.Cap(1),
+                    match_max=fmodel.Cap(1),
                     venue_scope=fmodel.VenueScope.AWAY,
                 )
             ],
@@ -1590,7 +1590,7 @@ class TestMatchCountLimits(unittest.TestCase):
             match_count_limits=[
                 fmodel.RollingLimit(
                     teams=[a1, a2],
-                    match_cap=fmodel.Cap(1),
+                    match_max=fmodel.Cap(1),
                     venue_scope=fmodel.VenueScope.HOME,
                 )
             ],
@@ -1622,7 +1622,7 @@ class TestMatchCountLimits(unittest.TestCase):
             match_count_limits=[
                 fmodel.RollingLimit(
                     teams=[a1, a2],
-                    match_cap=fmodel.Cap(1),
+                    match_max=fmodel.Cap(1),
                     venue_scope=fmodel.VenueScope.HOME,
                 )
             ],
@@ -1656,7 +1656,7 @@ class TestMatchCountLimits(unittest.TestCase):
             ],
             match_count_limits=[
                 fmodel.RollingLimit(
-                    teams=[a1, a2, a3], match_cap=fmodel.Cap(limit), window_days=30
+                    teams=[a1, a2, a3], match_max=fmodel.Cap(limit), window_days=30
                 )
             ],
         )
@@ -1676,20 +1676,20 @@ class TestMatchCountLimits(unittest.TestCase):
 
 
 class TestMaxPlayingTeams(unittest.TestCase):
-    """Test cases for MatchCountLimit.playing_teams_cap: unlike match_cap, which
+    """Test cases for MatchCountLimit.playing_teams_max: unlike match_max, which
     counts matches, this counts the *distinct* teams from `teams` that play (home or
     away) within a window. A same-club derby is one match (one candidate variable)
     but puts two of the club's own teams on to play, so it counts as 1 towards
-    match_cap but 2 towards playing_teams_cap -- guarding against exactly the case a
-    plain match_cap misses: N matches, one of them an internal derby, needing N+1
+    match_max but 2 towards playing_teams_max -- guarding against exactly the case a
+    plain match_max misses: N matches, one of them an internal derby, needing N+1
     teams' worth of players.
     """
 
-    def test_internal_derby_alone_blocked_by_a_playing_teams_cap_of_one(self) -> None:
+    def test_internal_derby_alone_blocked_by_a_playing_teams_max_of_one(self) -> None:
         """A single derby match between two of a club's own teams already needs two
-        of them playing -- so a playing_teams_cap of 1 makes every candidate date
-        infeasible, even though it's only one match (well within match_cap). Unlike
-        a plain match_cap of 0 (which prunes the candidate variables entirely, see
+        of them playing -- so a playing_teams_max of 1 makes every candidate date
+        infeasible, even though it's only one match (well within match_max). Unlike
+        a plain match_max of 0 (which prunes the candidate variables entirely, see
         MatchCountLimit.forbids), this isn't detectable per-candidate -- it only
         shows up as a genuine solver infeasibility."""
         h1 = fmodel.Team(division=1, club="H", index=1)
@@ -1701,8 +1701,8 @@ class TestMaxPlayingTeams(unittest.TestCase):
             match_count_limits=[
                 fmodel.RollingLimit(
                     teams=[h1, h2],
-                    match_cap=fmodel.Cap(2),
-                    playing_teams_cap=fmodel.Cap(1),
+                    match_max=fmodel.Cap(2),
+                    playing_teams_max=fmodel.Cap(1),
                     venue_scope=fmodel.VenueScope.HOME,
                 )
             ],
@@ -1712,13 +1712,14 @@ class TestMaxPlayingTeams(unittest.TestCase):
 
     def test_venue_capacity_spreads_an_internal_derby_off_a_full_night(self) -> None:
         """Mirrors the motivating case: a club hosts up to 3 matches a night
-        (max_matches: 3) but only has 3 teams' worth of players to field
-        (max_playing_teams: 3). Two of its teams (H3, H4) are only free to host on
-        one shared date; adding either leg of the H1-v-H2 derby there too would need
-        a 4th team's worth of players, so the solver must push both legs onto H1/H2's
-        other two shared dates instead (one leg per date, since -- regardless of this
-        cap -- a team may only play once per date), even though max_matches alone
-        (2 + 1 = 3) would have allowed combining a leg with H3/H4."""
+        (match_max=Cap(3)) but only has 3 teams' worth of players to field
+        (playing_teams_max=Cap(3)). Two of its teams (H3, H4) are only free to
+        host on one shared date; adding either leg of the H1-v-H2 derby there too
+        would need a 4th team's worth of players, so the solver must push both
+        legs onto H1/H2's other two shared dates instead (one leg per date,
+        since -- regardless of this cap -- a team may only play once per date),
+        even though match_max alone (2 + 1 = 3) would have allowed combining a
+        leg with H3/H4."""
         h1 = fmodel.Team(division=1, club="H", index=1)
         h2 = fmodel.Team(division=1, club="H", index=2)
         h3 = fmodel.Team(division=2, club="H", index=3)
@@ -1738,8 +1739,8 @@ class TestMaxPlayingTeams(unittest.TestCase):
             match_count_limits=[
                 fmodel.RollingLimit(
                     teams=[h1, h2, h3, h4],
-                    match_cap=fmodel.Cap(3),
-                    playing_teams_cap=fmodel.Cap(3),
+                    match_max=fmodel.Cap(3),
+                    playing_teams_max=fmodel.Cap(3),
                     venue_scope=fmodel.VenueScope.HOME,
                 )
             ],
@@ -1753,9 +1754,9 @@ class TestMaxPlayingTeams(unittest.TestCase):
         self.assertNotIn(shared_date, derby_dates)
 
     def test_cap_at_or_above_group_size_is_a_no_op(self) -> None:
-        """A max_playing_teams cap that can never bind (>= the group size) leaves the
-        derby free to land on either date -- unlike the test above, shared_date is
-        not excluded."""
+        """A playing_teams_max cap that can never bind (>= the group size) leaves
+        the derby free to land on either date -- unlike the test above,
+        shared_date is not excluded."""
         h1 = fmodel.Team(division=1, club="H", index=1)
         h2 = fmodel.Team(division=1, club="H", index=2)
         params = _params(
@@ -1765,8 +1766,8 @@ class TestMaxPlayingTeams(unittest.TestCase):
             match_count_limits=[
                 fmodel.RollingLimit(
                     teams=[h1, h2],
-                    match_cap=fmodel.Cap(2),
-                    playing_teams_cap=fmodel.Cap(2),
+                    match_max=fmodel.Cap(2),
+                    playing_teams_max=fmodel.Cap(2),
                     venue_scope=fmodel.VenueScope.HOME,
                 )
             ],
@@ -1774,8 +1775,8 @@ class TestMaxPlayingTeams(unittest.TestCase):
         fixtures = list(fmodel.solve(params).fixtures)
         self.assertEqual(len(fixtures), 2)
 
-    def test_zero_forbids_the_candidate_up_front_like_max_matches_zero(self) -> None:
-        """Unlike a cap of 1 or more, a playing_teams_cap of 0 is an up-front bar:
+    def test_zero_forbids_the_candidate_up_front_like_match_max_zero(self) -> None:
+        """Unlike a cap of 1 or more, a playing_teams_max of 0 is an up-front bar:
         any counted match puts at least one team from `teams` on to play, so it's
         detectable per-candidate (see MatchCountLimit.forbids) rather than only
         showing up as a solver infeasibility."""
@@ -1783,13 +1784,13 @@ class TestMaxPlayingTeams(unittest.TestCase):
         h2 = fmodel.Team(division=1, club="H", index=2)
         fix = fmodel.Fixture(home_team=h1, away_team=h2)
         blocked = fmodel.RollingLimit(
-            teams=[h1, h2], match_cap=fmodel.Cap(2), playing_teams_cap=fmodel.Cap(0)
+            teams=[h1, h2], match_max=fmodel.Cap(2), playing_teams_max=fmodel.Cap(0)
         )
         self.assertTrue(blocked.forbids(fix, date(2025, 1, 1)))
 
     def test_override_lifts_the_cap_on_a_specific_date(self) -> None:
-        """max_playing_teams_overrides replaces the base cap on that one date only
-        -- mirroring max_matches_overrides. A base cap of 1 blocks either derby leg
+        """playing_teams_max's overrides replace the base cap on that one date
+        only -- mirroring match_max's. A base cap of 1 blocks either derby leg
         everywhere on its own (each alone already needs 2 teams playing), but two
         overridden dates raise it to 2 -- enough for one leg apiece (a team may only
         play once per date, so the two legs can't share even an overridden date) --
@@ -1807,8 +1808,8 @@ class TestMaxPlayingTeams(unittest.TestCase):
             match_count_limits=[
                 fmodel.RollingLimit(
                     teams=[h1, h2],
-                    match_cap=fmodel.Cap(2),
-                    playing_teams_cap=fmodel.Cap(
+                    match_max=fmodel.Cap(2),
+                    playing_teams_max=fmodel.Cap(
                         1,
                         {overridden_date_1: 2, overridden_date_2: 2},
                     ),
@@ -1825,7 +1826,7 @@ class TestMaxPlayingTeams(unittest.TestCase):
         self.assertEqual(derby_dates, {overridden_date_1, overridden_date_2})
 
     def test_overrides_reject_non_default_window_days(self) -> None:
-        """Unlike playing_teams_cap itself (see the multi-day-window tests below,
+        """Unlike playing_teams_max itself (see the multi-day-window tests below,
         which show it's meaningful over a wider window), a Cap's per-date overrides
         are still tied to a single date: an override names one specific date, which
         only lines up with one specific window when window_days is 1."""
@@ -1833,14 +1834,14 @@ class TestMaxPlayingTeams(unittest.TestCase):
         with self.assertRaises(ValueError):
             fmodel.RollingLimit(
                 teams=[a1],
-                match_cap=fmodel.Cap(1),
+                match_max=fmodel.Cap(1),
                 window_days=7,
-                playing_teams_cap=fmodel.Cap(overrides={date(2025, 1, 1): 1}),
+                playing_teams_max=fmodel.Cap(overrides={date(2025, 1, 1): 1}),
             )
 
     def test_multi_day_window_counts_a_repeated_pair_twice(self) -> None:
         """Over a multi-day window, the same pair meeting twice counts towards
-        max_playing_teams once per match, not once per team: two internal H1-v-H2
+        playing_teams_max once per match, not once per team: two internal H1-v-H2
         matches within 7 days of each other would need 4 teams'-worth of players in
         that week (2 matches x 2 teams each), exceeding a cap of 3, even though only
         2 distinct teams are ever involved. H1 and H2 have two close-together dates
@@ -1857,7 +1858,7 @@ class TestMaxPlayingTeams(unittest.TestCase):
             match_count_limits=[
                 fmodel.RollingLimit(
                     teams=[h1, h2],
-                    playing_teams_cap=fmodel.Cap(3),
+                    playing_teams_max=fmodel.Cap(3),
                     window_days=7,
                 )
             ],
@@ -1881,7 +1882,7 @@ class TestMaxPlayingTeams(unittest.TestCase):
             match_count_limits=[
                 fmodel.RangeLimit(
                     teams=[h1, h2],
-                    playing_teams_cap=fmodel.Cap(3),
+                    playing_teams_max=fmodel.Cap(3),
                     ranges=(fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 7)),),
                 )
             ],
@@ -1896,7 +1897,7 @@ class TestMaxPlayingTeams(unittest.TestCase):
         on the listed dates -- unlike the *_overrides fields, it works over a
         multi-day rolling window. H1 and H2 (double_round, so two derby legs) have
         only two home dates two days apart: both legs land inside one 7-day window,
-        needing 4 teams'-worth of players, over a max_playing_teams cap of 3. That
+        needing 4 teams'-worth of players, over a playing_teams_max cap of 3. That
         is infeasible as-is; excluding one of the two dates drops its leg from the
         tally, leaving every window at 2 and letting both legs be scheduled."""
         h1 = fmodel.Team(division=1, club="H", index=1)
@@ -1912,7 +1913,7 @@ class TestMaxPlayingTeams(unittest.TestCase):
                 match_count_limits=[
                     fmodel.RollingLimit(
                         teams=[h1, h2],
-                        playing_teams_cap=fmodel.Cap(3),
+                        playing_teams_max=fmodel.Cap(3),
                         window_days=7,
                         exclude_dates=exclude_dates,
                     )
@@ -1969,13 +1970,13 @@ class TestMatchCountLimitDateRanges(unittest.TestCase):
             ],
             match_count_limits=[
                 fmodel.RangeLimit(
-                    teams=[a1, a2, a3], match_cap=fmodel.Cap(limit), ranges=date_ranges
+                    teams=[a1, a2, a3], match_max=fmodel.Cap(limit), ranges=date_ranges
                 )
             ],
         )
 
     def test_cap_binds_inside_the_range_only(self) -> None:
-        """The range covers January; A also has two February home dates. max_matches=1
+        """The range covers January; A also has two February home dates. match_max=1
         inside the range forces at least two of the three home legs into
         February, leaving at most one in January."""
         params = self._three_a_teams(
@@ -1995,7 +1996,7 @@ class TestMatchCountLimitDateRanges(unittest.TestCase):
 
     def test_infeasible_when_range_cap_leaves_nowhere(self) -> None:
         """Three in-range home dates plus one outside; with a one-a-night venue
-        and max_matches=1 inside the range, only two of the three required home legs can
+        and match_max=1 inside the range, only two of the three required home legs can
         be placed -> infeasible."""
         params = self._three_a_teams(
             a_home_dates=[
@@ -2031,7 +2032,7 @@ class TestMatchCountLimitDateRanges(unittest.TestCase):
             fmodel.solve(params)
 
     def test_max_zero_forces_matches_out_of_the_range(self) -> None:
-        """max_matches=0 bars every counted match inside the range: A1's one home leg,
+        """match_max=0 bars every counted match inside the range: A1's one home leg,
         with an in-range and an out-of-range home date available, is forced onto
         the out-of-range one."""
         a1 = fmodel.Team(division=1, club="A", index=1)
@@ -2045,7 +2046,7 @@ class TestMatchCountLimitDateRanges(unittest.TestCase):
             match_count_limits=[
                 fmodel.RangeLimit(
                     teams=[a1],
-                    match_cap=fmodel.Cap(0),
+                    match_max=fmodel.Cap(0),
                     ranges=(fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31)),),
                 )
             ],
@@ -2075,7 +2076,7 @@ class TestMatchCountLimitDateRanges(unittest.TestCase):
             match_count_limits=[
                 fmodel.RangeLimit(
                     teams=[a1],
-                    match_cap=fmodel.Cap(1),
+                    match_max=fmodel.Cap(1),
                     ranges=(fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31)),),
                 )
             ],
@@ -2098,7 +2099,7 @@ class TestMatchCountLimitDateRanges(unittest.TestCase):
         with self.assertRaises(ValueError):
             fmodel.RangeLimit(
                 teams=[a1],
-                match_cap=fmodel.Cap(1, {date(2025, 1, 1): 1}),
+                match_max=fmodel.Cap(1, {date(2025, 1, 1): 1}),
                 ranges=(fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31)),),
             )
 
@@ -2129,7 +2130,7 @@ class TestMatchCountLimitDateRanges(unittest.TestCase):
         self.assertNotIn(date(2024, 12, 31), rng)
 
     def test_max_zero_prunes_candidate_var(self) -> None:
-        """A max_matches: 0 limit makes its candidates a certain zero, so _build_model
+        """A match_max=Cap(0) limit makes its candidates a certain zero, so _build_model
         never creates a decision variable for them -- observable because a
         fixed_fixtures entry pinned onto such a date then fails with the
         descriptive 'not schedulable on that date' error (the fixture is still
@@ -2153,7 +2154,7 @@ class TestMatchCountLimitDateRanges(unittest.TestCase):
             match_count_limits=[
                 fmodel.RangeLimit(
                     teams=[a1, x1],
-                    match_cap=fmodel.Cap(0),
+                    match_max=fmodel.Cap(0),
                     ranges=(fmodel.DateRange(date(2025, 12, 22), date(2026, 1, 4)),),
                 )
             ],
@@ -2169,7 +2170,7 @@ class TestMatchCountLimitDateRanges(unittest.TestCase):
         rng = fmodel.DateRange(date(2025, 12, 22), date(2026, 1, 4))
         away_only = fmodel.RangeLimit(
             teams=[a1],
-            match_cap=fmodel.Cap(0),
+            match_max=fmodel.Cap(0),
             venue_scope=fmodel.VenueScope.AWAY,
             ranges=(rng,),
         )
@@ -2179,8 +2180,176 @@ class TestMatchCountLimitDateRanges(unittest.TestCase):
         # Outside the range: not forbidden.
         self.assertFalse(away_only.forbids(away_fix, date(2026, 1, 5)))
         # A non-zero cap is never an up-front bar.
-        keep = fmodel.RangeLimit(teams=[a1], match_cap=fmodel.Cap(1), ranges=(rng,))
+        keep = fmodel.RangeLimit(teams=[a1], match_max=fmodel.Cap(1), ranges=(rng,))
         self.assertFalse(keep.forbids(away_fix, date(2025, 12, 29)))
+
+
+class TestMatchCountLimitMin(unittest.TestCase):
+    """match_min/playing_teams_min floor a window's count from below, the mirror
+    of match_max/playing_teams_max."""
+
+    def test_min_forces_a_match_into_the_range(self) -> None:
+        """A1's one home leg has an in-range and an out-of-range home date
+        available; match_min=1 over the range forces it onto the in-range one
+        (the opposite pull from TestMatchCountLimitDateRanges's
+        test_max_zero_forces_matches_out_of_the_range)."""
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        x1 = fmodel.Team(division=1, club="X", index=1)
+        params = _params(
+            teams=[a1, x1],
+            home_dates={"A": [date(2025, 1, 7), date(2025, 2, 4)], "X": []},
+            unavailable_away_dates={"A": [], "X": []},
+            min_gap_days=7,
+            excluded_fixtures=[fmodel.Fixture(home_team=x1, away_team=a1)],
+            match_count_limits=[
+                fmodel.RangeLimit(
+                    teams=[a1],
+                    match_min=fmodel.Cap(1),
+                    ranges=(fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31)),),
+                )
+            ],
+        )
+        fixtures = list(fmodel.solve(params).fixtures)
+        self.assertEqual([sf.date for sf in fixtures], [date(2025, 1, 7)])
+
+    def test_min_infeasible_when_nothing_can_fall_in_range(self) -> None:
+        """A1's only home date is outside the range entirely, so match_min=1
+        over the range can never be met -- and it must still be enforced (as an
+        empty-sum >= 1 constraint) rather than silently skipped the way an
+        empty max window is."""
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        x1 = fmodel.Team(division=1, club="X", index=1)
+        params = _params(
+            teams=[a1, x1],
+            home_dates={"A": [date(2025, 2, 4)], "X": []},
+            unavailable_away_dates={"A": [], "X": []},
+            min_gap_days=7,
+            excluded_fixtures=[fmodel.Fixture(home_team=x1, away_team=a1)],
+            match_count_limits=[
+                fmodel.RangeLimit(
+                    teams=[a1],
+                    match_min=fmodel.Cap(1),
+                    ranges=(fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31)),),
+                )
+            ],
+        )
+        with self.assertRaises(ValueError):
+            fmodel.solve(params)
+
+    def test_playing_teams_min_forces_a_match_into_the_window(self) -> None:
+        """Same shape as test_min_forces_a_match_into_the_range, but floors
+        playing_teams instead of matches: still enough to force the leg into the
+        window, since one ordinary match puts exactly one of `teams` on to
+        play."""
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        x1 = fmodel.Team(division=1, club="X", index=1)
+        params = _params(
+            teams=[a1, x1],
+            home_dates={"A": [date(2025, 1, 7), date(2025, 2, 4)], "X": []},
+            unavailable_away_dates={"A": [], "X": []},
+            min_gap_days=7,
+            excluded_fixtures=[fmodel.Fixture(home_team=x1, away_team=a1)],
+            match_count_limits=[
+                fmodel.RangeLimit(
+                    teams=[a1],
+                    playing_teams_min=fmodel.Cap(1),
+                    ranges=(fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31)),),
+                )
+            ],
+        )
+        fixtures = list(fmodel.solve(params).fixtures)
+        self.assertEqual([sf.date for sf in fixtures], [date(2025, 1, 7)])
+
+    def test_min_and_max_together_pin_an_exact_count(self) -> None:
+        """min=max=1 over the range: exactly one of A1/A2's two home legs must
+        land there (two in-range dates and a one-a-night venue would otherwise
+        let both, or neither, land inside)."""
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        a2 = fmodel.Team(division=2, club="A", index=2)
+        x1 = fmodel.Team(division=1, club="X", index=1)
+        x2 = fmodel.Team(division=2, club="X", index=2)
+        params = _params(
+            teams=[a1, a2, x1, x2],
+            home_dates={
+                "A": [date(2025, 1, 7), date(2025, 1, 14), date(2025, 2, 4)],
+                "X": [],
+            },
+            unavailable_away_dates={"A": [], "X": []},
+            min_gap_days=7,
+            max_concurrent_matches={"A": _home_limit(1)},
+            excluded_fixtures=[
+                fmodel.Fixture(home_team=x1, away_team=a1),
+                fmodel.Fixture(home_team=x2, away_team=a2),
+            ],
+            match_count_limits=[
+                fmodel.RangeLimit(
+                    teams=[a1, a2],
+                    match_max=fmodel.Cap(1),
+                    match_min=fmodel.Cap(1),
+                    ranges=(fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31)),),
+                )
+            ],
+        )
+        fixtures = list(fmodel.solve(params).fixtures)
+        in_january = [sf for sf in fixtures if sf.date.month == 1]
+        self.assertEqual(len(in_january), 1)
+
+    def test_rejects_min_exceeding_max(self) -> None:
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        with self.assertRaises(ValueError):
+            fmodel.RollingLimit(
+                teams=[a1], match_max=fmodel.Cap(1), match_min=fmodel.Cap(2)
+            )
+
+    def test_rejects_playing_teams_min_exceeding_max(self) -> None:
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        with self.assertRaises(ValueError):
+            fmodel.RollingLimit(
+                teams=[a1],
+                playing_teams_max=fmodel.Cap(1),
+                playing_teams_min=fmodel.Cap(2),
+            )
+
+    def test_min_alone_is_a_valid_limit(self) -> None:
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        limit = fmodel.RollingLimit(teams=[a1], match_min=fmodel.Cap(1))
+        self.assertIsNone(limit.match_max)
+        self.assertEqual(limit.match_min, fmodel.Cap(1))
+
+    def test_needs_at_least_one_bound(self) -> None:
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        with self.assertRaises(ValueError):
+            fmodel.RollingLimit(teams=[a1])
+
+    def test_rolling_limit_rejects_min_overrides_with_multi_day_window(
+        self,
+    ) -> None:
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        with self.assertRaises(ValueError):
+            fmodel.RollingLimit(
+                teams=[a1],
+                match_min=fmodel.Cap(1, {date(2025, 1, 1): 2}),
+                window_days=7,
+            )
+
+    def test_range_limit_rejects_min_overrides(self) -> None:
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        with self.assertRaises(ValueError):
+            fmodel.RangeLimit(
+                teams=[a1],
+                match_min=fmodel.Cap(1, {date(2025, 1, 1): 2}),
+                ranges=(fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31)),),
+            )
+
+    def test_min_does_not_make_a_candidate_forbidden(self) -> None:
+        """Unlike a max of 0, a min never prunes an individual candidate up
+        front -- it's a floor over a whole window's worth of alternatives, not a
+        per-candidate bar."""
+        a1 = fmodel.Team(division=1, club="A", index=1)
+        x1 = fmodel.Team(division=1, club="X", index=1)
+        fixture = fmodel.Fixture(home_team=a1, away_team=x1)
+        limit = fmodel.RollingLimit(teams=[a1], match_min=fmodel.Cap(5))
+        self.assertFalse(limit.forbids(fixture, date(2025, 1, 1)))
 
 
 class TestPerClubGap(unittest.TestCase):
@@ -2207,7 +2376,7 @@ class TestPerClubGap(unittest.TestCase):
             match_count_limits=[
                 fmodel.RollingLimit(
                     teams=teams_by_club[club],
-                    match_cap=fmodel.Cap(1),
+                    match_max=fmodel.Cap(1),
                     window_days=gap,
                     apply_per=fmodel.ApplyPer.EACH_TEAM,
                 )
@@ -2236,8 +2405,8 @@ class TestPerClubGap(unittest.TestCase):
 
 
 class TestSharedHomeLimitNullAndOverrides(unittest.TestCase):
-    """A shared home-scope MatchCountLimit with max_matches=None imposes no cap; a
-    `max_matches_overrides` entry of None lifts it for that one date, an int replaces it.
+    """A shared home-scope MatchCountLimit with match_max=None imposes no cap; a
+    `match_max`'s overrides entry of None lifts it for that one date, an int replaces it.
     """
 
     def test_finite_default_makes_it_infeasible(self) -> None:
@@ -2309,7 +2478,7 @@ class TestSharedHomeLimitNullAndOverrides(unittest.TestCase):
             match_count_limits=(
                 fmodel.RollingLimit(
                     teams=[a1, a2],
-                    match_cap=fmodel.Cap(1, {date(2025, 1, 1): None}),
+                    match_max=fmodel.Cap(1, {date(2025, 1, 1): None}),
                     venue_scope=fmodel.VenueScope.HOME,
                 ),
             ),
@@ -2350,12 +2519,12 @@ class TestSharedLimitAwayAndAllScopes(unittest.TestCase):
 
     def _any(self, limit: int | None) -> fmodel.RollingLimit:
         return fmodel.RollingLimit(
-            teams=[], match_cap=fmodel.Cap(limit), venue_scope=fmodel.VenueScope.ALL
+            teams=[], match_max=fmodel.Cap(limit), venue_scope=fmodel.VenueScope.ALL
         )
 
     def _away(self, limit: int | None) -> fmodel.RollingLimit:
         return fmodel.RollingLimit(
-            teams=[], match_cap=fmodel.Cap(limit), venue_scope=fmodel.VenueScope.AWAY
+            teams=[], match_max=fmodel.Cap(limit), venue_scope=fmodel.VenueScope.AWAY
         )
 
     def test_any_scope_limit_blocks_two_matches_on_one_date(self) -> None:
@@ -2405,7 +2574,7 @@ class TestInternalMatchAwayScope(unittest.TestCase):
     def test_counts_fixture_skips_internal_derby_under_away_scope(self) -> None:
         away = fmodel.RollingLimit(
             teams=[self.h1, self.h2],
-            match_cap=fmodel.Cap(1),
+            match_max=fmodel.Cap(1),
             venue_scope=fmodel.VenueScope.AWAY,
         )
         self.assertFalse(away.counts_fixture(self.derby))
@@ -2415,7 +2584,7 @@ class TestInternalMatchAwayScope(unittest.TestCase):
     def test_counts_fixture_keeps_internal_derby_under_home_and_all_scope(self) -> None:
         for scope in (fmodel.VenueScope.HOME, fmodel.VenueScope.ALL):
             rule = fmodel.RollingLimit(
-                teams=[self.h1, self.h2], match_cap=fmodel.Cap(1), venue_scope=scope
+                teams=[self.h1, self.h2], match_max=fmodel.Cap(1), venue_scope=scope
             )
             self.assertTrue(rule.counts_fixture(self.derby), scope)
 
@@ -2423,18 +2592,18 @@ class TestInternalMatchAwayScope(unittest.TestCase):
         rng = fmodel.DateRange(date(2025, 1, 1), date(2025, 1, 31))
         away_blackout = fmodel.RangeLimit(
             teams=[self.h1, self.h2],
-            match_cap=fmodel.Cap(0),
+            match_max=fmodel.Cap(0),
             venue_scope=fmodel.VenueScope.AWAY,
             ranges=(rng,),
         )
         self.assertFalse(away_blackout.forbids(self.derby, date(2025, 1, 15)))
         self.assertTrue(away_blackout.forbids(self.away_at_x, date(2025, 1, 15)))
 
-    def test_two_internal_derbies_share_a_night_under_an_away_playing_teams_cap(
+    def test_two_internal_derbies_share_a_night_under_an_away_playing_teams_max(
         self,
     ) -> None:
         """The draft3 case in miniature: two of a club's own derbies are pinned to
-        the same night, and the club has an AWAY-scope max_playing_teams: 2 cap. The
+        the same night, and the club has an AWAY-scope playing_teams_max=Cap(2) cap. The
         derbies play at the club's own venue, so they don't count as away and the
         cap is satisfied. Before internal matches were excluded from AWAY scope each
         derby put 2 of the club's teams "away" (4 > 2) and this was INFEASIBLE.
@@ -2457,7 +2626,7 @@ class TestInternalMatchAwayScope(unittest.TestCase):
             match_count_limits=[
                 fmodel.RollingLimit(
                     teams=[self.h1, self.h2, h3, h4],
-                    playing_teams_cap=fmodel.Cap(2),
+                    playing_teams_max=fmodel.Cap(2),
                     venue_scope=fmodel.VenueScope.AWAY,
                 )
             ],
@@ -2467,10 +2636,10 @@ class TestInternalMatchAwayScope(unittest.TestCase):
         on_night = {sf.date for sf in fixtures if sf.date == night}
         self.assertEqual(on_night, {night})
 
-    def test_away_playing_teams_cap_still_limits_genuine_away_matches(self) -> None:
+    def test_away_playing_teams_max_still_limits_genuine_away_matches(self) -> None:
         """The same cap still bites when the matches really are away: club A's two
         teams (different divisions, so no internal match between them) both have to
-        play their away leg on X's single home date, exceeding max_playing_teams: 1.
+        play their away leg on X's single home date, exceeding playing_teams_max=Cap(1).
         """
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=2, club="A", index=2)
@@ -2483,7 +2652,7 @@ class TestInternalMatchAwayScope(unittest.TestCase):
             match_count_limits=[
                 fmodel.RollingLimit(
                     teams=[a1, a2],
-                    playing_teams_cap=fmodel.Cap(1),
+                    playing_teams_max=fmodel.Cap(1),
                     venue_scope=fmodel.VenueScope.AWAY,
                 )
             ],

--- a/report_test.py
+++ b/report_test.py
@@ -57,7 +57,8 @@ club_constraints:
     match_count_limits:
       - override_key: venue-capacity
         venue_scope: home
-        max_matches: 1
+        matches:
+          max: 1
   albany:
     home_dates: [2025-09-01, 2025-09-29]
   hackney:

--- a/runs/2026-27/draft1/spec.yaml
+++ b/runs/2026-27/draft1/spec.yaml
@@ -265,21 +265,24 @@ club_constraints:
       - override_key: weekly-gap
         apply_per: each_team
         time_window_days: 7
-        max_matches: 1
+        matches:
+          max: 1
       # Spec-wide venue capacity: one home match a night. Clubs with a bigger
       # venue replace this via 'override_key: venue-capacity'.
       - override_key: venue-capacity
         venue_scope: home
-        max_matches: 1
+        matches:
+          max: 1
       # Christmas/New Year: no club schedules any fixture - home or away - in the
       # fortnight from Monday 2026-12-21 through Sunday 2027-01-03, on the
-      # assumption nobody wants to play then. A whole-club max_matches: 0 date_ranges
+      # assumption nobody wants to play then. A whole-club matches: {max: 0} date_ranges
       # default blocks it everywhere, so individual clubs don't repeat it in
       # their own unavailable_away_dates; a club could opt back in by overriding
       # 'no-play-dates'. (Home dates a club lists inside the range just go
       # unused; the weekend dates in the range never carry fixtures anyway.)
       - override_key: no-play-dates
-        max_matches: 0
+        matches:
+          max: 0
         date_ranges:
           - { start_date: "2026-12-21", end_date: "2027-01-03" }
   hendon:
@@ -327,31 +330,37 @@ club_constraints:
       # the spec-wide one-a-night default).
       - override_key: venue-capacity
         venue_scope: home
-        max_matches: 3
+        matches:
+          max: 3
       # Hendon 1 and Hendon 2 (both division 1) draw on the same players, so keep
       # their matches at least a week apart (matches exactly 7 days apart are
       # still allowed).
       - teams: [hendon-1, hendon-2]
         time_window_days: 7
-        max_matches: 1
+        matches:
+          max: 1
       # London Chess Classic (24 Nov - 7 Dec 2026): no Hendon 1 or Hendon 2
       # match, home or away, during the Classic.
       - teams: [hendon-1, hendon-2]
-        max_matches: 0
+        matches:
+          max: 0
         date_ranges:
           - { start_date: "2026-11-24", end_date: "2026-12-07" }
       # Cap Hendon's overall load: no more than 3 matches (home or away, any
       # team) in any 7-consecutive-day period. teams defaults to all of Hendon's
       # teams.
       - time_window_days: 7
-        max_matches: 3
+        matches:
+          max: 3
       # No matches (even away matches) the week we have a seasonal break for Christmas
-      - max_matches: 0
+      - matches:
+          max: 0
         date_ranges:
           - { start_date: "2026-12-14", end_date: "2026-12-20" }
       # Camden school-holiday weeks - Andrew wants Hendon's fixture load kept
       # down across these.
-      - max_matches: 1
+      - matches:
+          max: 1
         date_ranges:
           - { start_date: "2026-10-26", end_date: "2026-11-01" } # Oct half term
           - { start_date: "2027-02-15", end_date: "2027-02-21" } # Feb half term
@@ -360,7 +369,7 @@ club_constraints:
           - { start_date: "2027-04-05", end_date: "2027-04-11" } # Easter
           - { start_date: "2027-05-31", end_date: "2027-06-06" } # May half term
       # Per-date caps on Hendon's total matches (home + away) on a night, layered
-      # on top of the 7-day cap above (max_matches: null = no cap except on the listed
+      # on top of the 7-day cap above (matches: {max: null} = no cap except on the listed
       # dates):
       #
       #  - First Thursday of each month (= 1): the date of Hendon's monthly
@@ -375,23 +384,24 @@ club_constraints:
       #    club (many members still renewing), so we keep the load down then.
       #    Add any further September dates here if the reserve ones are ever
       #    uncommented.
-      - max_matches: null
-        max_matches_overrides:
-          "2026-09-03": 1
-          "2026-09-10": 2
-          "2026-09-17": 2
-          "2026-09-24": 2
-          "2026-10-01": 1
-          "2026-11-05": 1
-          "2026-12-03": 1
-          "2027-01-07": 1
-          "2027-02-04": 1
-          "2027-03-04": 1
-          "2027-04-01": 1
-          "2027-05-06": 1
-          "2027-06-03": 1
-          "2027-07-01": 1
-          "2027-08-05": 1
+      - matches:
+          max: null
+          max_overrides:
+            "2026-09-03": 1
+            "2026-09-10": 2
+            "2026-09-17": 2
+            "2026-09-24": 2
+            "2026-10-01": 1
+            "2026-11-05": 1
+            "2026-12-03": 1
+            "2027-01-07": 1
+            "2027-02-04": 1
+            "2027-03-04": 1
+            "2027-04-01": 1
+            "2027-05-06": 1
+            "2027-06-03": 1
+            "2027-07-01": 1
+            "2027-08-05": 1
   west-london:
     home_dates:
       - "2026-10-07"
@@ -439,7 +449,8 @@ club_constraints:
       # 24 Nov - 7 Dec; the range starts the Monday of that week (2026-11-23)
       # per Andy's "last week of November" ask. The two Wednesdays in the span
       # (2026-11-25, 2026-12-02) are also dropped from home_dates above.
-      - max_matches: 0
+      - matches:
+          max: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2026-11-23", end_date: "2026-12-07" }
@@ -505,7 +516,8 @@ club_constraints:
       # rundown), and w/c 29 Mar + w/c 5 Apr (Easter, and a club-level ask -
       # adjacent weeks, so one range). The Wednesday of each (2027-01-06,
       # 2027-03-31, 2027-04-07) is likewise dropped from home_dates above.
-      - max_matches: 0
+      - matches:
+          max: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2027-01-04", end_date: "2027-01-10" } # w/c 4 Jan
@@ -569,7 +581,8 @@ club_constraints:
       # Mon-Fri of a blocked week (weekends never carry fixtures), with runs of
       # consecutive blocked weeks merged across the weekend between them. This
       # replaces ~95 individually listed weekday dates.
-      - max_matches: 0
+      - matches:
+          max: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2026-09-28", end_date: "2026-10-09" } # w/c 28 Sep + 5 Oct
@@ -611,7 +624,7 @@ club_constraints:
     # here. But the real limit already comes from the match_count_limits entries
     # below: with adjacent teams (1-2, 2-3, 3-4) barred from sharing a date, at
     # most 2 of the 4 can ever coschedule (e.g. 1+3, 1+4 or 2+4), so the
-    # venue-capacity default is simply cancelled (max_matches: null, see
+    # venue-capacity default is simply cancelled (matches: {max: null}, see
     # match_count_limits below) rather than restating that bound as a number
     # that would need to stay in sync with it (and would otherwise need updating
     # if Hammersmith confirms their venue's actual concurrent-match capacity
@@ -937,17 +950,21 @@ club_constraints:
       # top of this club's block).
       - override_key: venue-capacity
         venue_scope: home
-        max_matches: null
+        matches:
+          max: null
       # Adjacent Hammersmith teams (by team index: 1-2, 2-3, 3-4) shouldn't play
       # on the same date, per the club's preference (2026-08-24) - they only asked
       # for same-date avoidance, so time_window_days is left at its default of 1
       # rather than keeping them apart by more than that.
       - teams: [hammersmith-1, hammersmith-2]
-        max_matches: 1
+        matches:
+          max: 1
       - teams: [hammersmith-2, hammersmith-3]
-        max_matches: 1
+        matches:
+          max: 1
       - teams: [hammersmith-3, hammersmith-4]
-        max_matches: 1
+        matches:
+          max: 1
   muswell-hill:
     # Club night is Tuesday. Available for home matches October and
     # November 2026, then January to around mid-May 2027 (2026-08-25
@@ -1018,7 +1035,8 @@ club_constraints:
       # one-home-match-a-night default).
       - override_key: venue-capacity
         venue_scope: home
-        max_matches: 2
+        matches:
+          max: 2
     home_dates:
       - "2026-10-06"
       - "2026-10-13"
@@ -1142,7 +1160,8 @@ club_constraints:
       # No away matches in November 2026 or the first week of December (the
       # home side is handled by home_dates above skipping that span). Was 26
       # individually listed weekday dates.
-      - max_matches: 0
+      - matches:
+          max: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2026-11-02", end_date: "2026-12-07" }
@@ -1160,7 +1179,7 @@ club_constraints:
     #
     # Exceptions: on these dates the venue already has another (non-Middlesex)
     # fixture, so only one Middlesex match can be hosted on each - expressed as
-    # per-date 'max_matches_overrides' of the limit of 2. Leslie Pringle first gave
+    # per-date 'matches.max_overrides' of the limit of 2. Leslie Pringle first gave
     # 2026-09-21, 2026-10-05 and 2026-10-12 (2026-08-28), then supplied the
     # full list in an update as of Sunday evening 2026-08-30, adding
     # 2026-10-26, 2026-11-02, 2027-02-08 and 2027-04-19 ("most of it clear"
@@ -1168,15 +1187,16 @@ club_constraints:
     match_count_limits:
       - override_key: venue-capacity
         venue_scope: home
-        max_matches: 2
-        max_matches_overrides:
-          "2026-09-21": 1
-          "2026-10-05": 1
-          "2026-10-12": 1
-          "2026-10-26": 1
-          "2026-11-02": 1
-          "2027-02-08": 1
-          "2027-04-19": 1
+        matches:
+          max: 2
+          max_overrides:
+            "2026-09-21": 1
+            "2026-10-05": 1
+            "2026-10-12": 1
+            "2026-10-26": 1
+            "2026-11-02": 1
+            "2027-02-08": 1
+            "2027-04-19": 1
     home_dates:
       - "2026-09-14"
       - "2026-09-21"
@@ -1483,12 +1503,14 @@ club_constraints:
       # spec-wide one-home-match-a-night default.
       - override_key: venue-capacity
         venue_scope: home
-        max_matches: 5
+        matches:
+          max: 5
       # Away matches only: keep Harrow 1 and Harrow 2 from playing away on
       # the same date, per Surjit, without constraining their home dates.
       - teams: [harrow-1, harrow-2]
         venue_scope: away
-        max_matches: 1
+        matches:
+          max: 1
   kings-head:
     # Per Colin Mackenzie: Kings Head play home matches on Thursday evenings at
     # the Mind Sports Centre (the same venue as Hammersmith), October to May
@@ -1512,7 +1534,7 @@ club_constraints:
     #     that team did not list as playable (home or away).
     #   - Away availability is handled in match_count_limits: each team may play
     #     away only on the Thursdays it listed or inside the away windows it
-    #     gave Colin, so a 'max_matches: 0' / 'venue_scope: away' / 'date_ranges' entry
+    #     gave Colin, so a 'matches: {max: 0}' / 'venue_scope: away' / 'date_ranges' entry
     #     per team bars every other weekday (same idiom as Metropolitan and West
     #     London). Ranges are Mon-Fri spans with consecutive blocked weeks
     #     merged across the weekend between them, and run through June so the
@@ -1722,14 +1744,16 @@ club_constraints:
       # as it stands.
       - teams: [kings-head-1, kings-head-2]
         time_window_days: 2
-        max_matches: 1
+        matches:
+          max: 1
       # KH2 <-> KH3: at most one match in any 7-day window across the pair (a
       # 7-day cap already forbids same-day / consecutive-day pairings).
       # apply_per defaults to across_teams: the pair shares a single match
       # per window. This one solves comfortably.
       - teams: [kings-head-2, kings-head-3]
         time_window_days: 7
-        max_matches: 1
+        matches:
+          max: 1
       # Per-team away-availability windows (Colin, 2026-08-31). Each team may
       # play away only on the Thursdays it listed or within the away windows
       # it gave; these ranges bar every other weekday. Mon-Fri spans,
@@ -1738,7 +1762,8 @@ club_constraints:
       # 28 Sep) through June (to cover the June away Thursdays if the season
       # overruns).
       - teams: [kings-head-1]
-        max_matches: 0
+        matches:
+          max: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2026-09-01", end_date: "2026-09-25" }
@@ -1763,7 +1788,8 @@ club_constraints:
           - { start_date: "2027-04-13", end_date: "2027-05-07" }
           - { start_date: "2027-06-15", end_date: "2027-06-18" }
       - teams: [kings-head-2]
-        max_matches: 0
+        matches:
+          max: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2026-09-01", end_date: "2026-09-25" }
@@ -1797,7 +1823,8 @@ club_constraints:
           - { start_date: "2027-06-09", end_date: "2027-06-11" }
           - { start_date: "2027-06-15", end_date: "2027-06-18" }
       - teams: [kings-head-3]
-        max_matches: 0
+        matches:
+          max: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2026-09-01", end_date: "2026-09-25" }
@@ -1887,5 +1914,5 @@ fixed_fixtures:
     date: "2026-12-10"
 
 # Christmas/New Year is blocked spec-wide by the 'no-play-dates' entry under
-# club_constraints.defaults.match_count_limits above (a max_matches: 0 date range over
+# club_constraints.defaults.match_count_limits above (a matches: {max: 0} date range over
 # 2026-12-21 to 2027-01-03).

--- a/runs/2026-27/draft2/spec.yaml
+++ b/runs/2026-27/draft2/spec.yaml
@@ -270,21 +270,24 @@ club_constraints:
       - override_key: weekly-gap
         apply_per: each_team
         time_window_days: 7
-        max_matches: 1
+        matches:
+          max: 1
       # Spec-wide venue capacity: one home match a night. Clubs with a bigger
       # venue replace this via 'override_key: venue-capacity'.
       - override_key: venue-capacity
         venue_scope: home
-        max_matches: 1
+        matches:
+          max: 1
       # Christmas/New Year: no club schedules any fixture - home or away - in the
       # fortnight from Monday 2026-12-21 through Sunday 2027-01-03, on the
-      # assumption nobody wants to play then. A whole-club max_matches: 0 date_ranges
+      # assumption nobody wants to play then. A whole-club matches: {max: 0} date_ranges
       # default blocks it everywhere, so individual clubs don't repeat it in
       # their own unavailable_away_dates; a club could opt back in by overriding
       # 'no-play-dates'. (Home dates a club lists inside the range just go
       # unused; the weekend dates in the range never carry fixtures anyway.)
       - override_key: no-play-dates
-        max_matches: 0
+        matches:
+          max: 0
         date_ranges:
           - { start_date: "2026-12-21", end_date: "2027-01-03" }
   hendon:
@@ -332,34 +335,40 @@ club_constraints:
       # the spec-wide one-a-night default).
       - override_key: venue-capacity
         venue_scope: home
-        max_matches: 3
+        matches:
+          max: 3
       # Hendon 1 and Hendon 2 (both division 1) draw on the same players, so keep
       # their matches at least a week apart (matches exactly 7 days apart are
       # still allowed).
       - teams: [hendon-1, hendon-2]
         time_window_days: 7
-        max_matches: 1
+        matches:
+          max: 1
       # London Chess Classic (24 Nov - 7 Dec 2026): no Hendon 1 or Hendon 2
       # match, home or away, during the Classic.
       - teams: [hendon-1, hendon-2]
-        max_matches: 0
+        matches:
+          max: 0
         date_ranges:
           - { start_date: "2026-11-24", end_date: "2026-12-07" }
       # Cap Hendon's overall load: no more than 3 teams playing in any
       # 7-consecutive-day period. 2026-09-10 is exempt: fixed_fixtures pins two
       # pre-season derbies there (Hendon 1 v 2 and Hendon 4 v 5 = 4 teams'-worth),
-      # which that date's own max_matches_overrides entry (2) already covers.
+      # which that date's own matches.max_overrides entry (2) already covers.
       - time_window_days: 7
-        max_playing_teams: 3
+        playing_teams:
+          max: 3
         exclude_dates:
           - "2026-09-10"
       # No matches (even away matches) the week we have a seasonal break for Christmas
-      - max_matches: 0
+      - matches:
+          max: 0
         date_ranges:
           - { start_date: "2026-12-14", end_date: "2026-12-20" }
       # Camden school-holiday weeks - Andrew wants Hendon's fixture load kept
       # down across these.
-      - max_matches: 1
+      - matches:
+          max: 1
         date_ranges:
           - { start_date: "2026-10-26", end_date: "2026-11-01" } # Oct half term
           - { start_date: "2027-02-15", end_date: "2027-02-21" } # Feb half term
@@ -368,7 +377,7 @@ club_constraints:
           - { start_date: "2027-04-05", end_date: "2027-04-11" } # Easter
           - { start_date: "2027-05-31", end_date: "2027-06-06" } # May half term
       # Per-date caps on Hendon's total matches (home + away) on a night, layered
-      # on top of the 7-day cap above (max_matches: null = no cap except on the listed
+      # on top of the 7-day cap above (matches: {max: null} = no cap except on the listed
       # dates):
       #
       #  - First Thursday of each month (= 1): the date of Hendon's monthly
@@ -383,23 +392,24 @@ club_constraints:
       #    club (many members still renewing), so we keep the load down then.
       #    Add any further September dates here if the reserve ones are ever
       #    uncommented.
-      - max_matches: null
-        max_matches_overrides:
-          "2026-09-03": 1
-          "2026-09-10": 2
-          "2026-09-17": 2
-          "2026-09-24": 2
-          "2026-10-01": 1
-          "2026-11-05": 1
-          "2026-12-03": 1
-          "2027-01-07": 1
-          "2027-02-04": 1
-          "2027-03-04": 1
-          "2027-04-01": 1
-          "2027-05-06": 1
-          "2027-06-03": 1
-          "2027-07-01": 1
-          "2027-08-05": 1
+      - matches:
+          max: null
+          max_overrides:
+            "2026-09-03": 1
+            "2026-09-10": 2
+            "2026-09-17": 2
+            "2026-09-24": 2
+            "2026-10-01": 1
+            "2026-11-05": 1
+            "2026-12-03": 1
+            "2027-01-07": 1
+            "2027-02-04": 1
+            "2027-03-04": 1
+            "2027-04-01": 1
+            "2027-05-06": 1
+            "2027-06-03": 1
+            "2027-07-01": 1
+            "2027-08-05": 1
   west-london:
     home_dates:
       - "2026-10-07"
@@ -453,7 +463,8 @@ club_constraints:
       # 24 Nov - 7 Dec; the range starts the Monday of that week (2026-11-23)
       # per Andy's "last week of November" ask. The two Wednesdays in the span
       # (2026-11-25, 2026-12-02) are also dropped from home_dates above.
-      - max_matches: 0
+      - matches:
+          max: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2026-11-23", end_date: "2026-12-07" }
@@ -519,7 +530,8 @@ club_constraints:
       # rundown), and w/c 29 Mar + w/c 5 Apr (Easter, and a club-level ask -
       # adjacent weeks, so one range). The Wednesday of each (2027-01-06,
       # 2027-03-31, 2027-04-07) is likewise dropped from home_dates above.
-      - max_matches: 0
+      - matches:
+          max: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2027-01-04", end_date: "2027-01-10" } # w/c 4 Jan
@@ -590,7 +602,8 @@ club_constraints:
       # Mon-Fri of a blocked week (weekends never carry fixtures), with runs of
       # consecutive blocked weeks merged across the weekend between them. This
       # replaces ~95 individually listed weekday dates.
-      - max_matches: 0
+      - matches:
+          max: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2026-09-28", end_date: "2026-10-09" } # w/c 28 Sep + 5 Oct
@@ -633,7 +646,7 @@ club_constraints:
     # here. But the real limit already comes from the match_count_limits entries
     # below: with adjacent teams (1-2, 2-3, 3-4) barred from sharing a date, at
     # most 2 of the 4 can ever coschedule (e.g. 1+3, 1+4 or 2+4), so the
-    # venue-capacity default is simply cancelled (max_matches: null, see
+    # venue-capacity default is simply cancelled (matches: {max: null}, see
     # match_count_limits below) rather than restating that bound as a number
     # that would need to stay in sync with it (and would otherwise need updating
     # if Hammersmith confirms their venue's actual concurrent-match capacity
@@ -959,17 +972,21 @@ club_constraints:
       # top of this club's block).
       - override_key: venue-capacity
         venue_scope: home
-        max_matches: null
+        matches:
+          max: null
       # Adjacent Hammersmith teams (by team index: 1-2, 2-3, 3-4) shouldn't play
       # on the same date, per the club's preference (2026-08-24) - they only asked
       # for same-date avoidance, so time_window_days is left at its default of 1
       # rather than keeping them apart by more than that.
       - teams: [hammersmith-1, hammersmith-2]
-        max_matches: 1
+        matches:
+          max: 1
       - teams: [hammersmith-2, hammersmith-3]
-        max_matches: 1
+        matches:
+          max: 1
       - teams: [hammersmith-3, hammersmith-4]
-        max_matches: 1
+        matches:
+          max: 1
   muswell-hill:
     # Club night is Tuesday. Available for home matches October and
     # November 2026, then January to around mid-May 2027 (2026-08-25
@@ -1053,7 +1070,8 @@ club_constraints:
       # one-home-match-a-night default).
       - override_key: venue-capacity
         venue_scope: home
-        max_matches: 2
+        matches:
+          max: 2
     home_dates:
       - "2026-10-06"
       - "2026-10-13"
@@ -1180,7 +1198,8 @@ club_constraints:
       # 2026-09-01 - see the note above), nor in November 2026 or the first week
       # of December. The home side of both spans is handled by home_dates above
       # skipping them.
-      - max_matches: 0
+      - matches:
+          max: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2026-09-01", end_date: "2026-09-30" }
@@ -1199,7 +1218,7 @@ club_constraints:
     #
     # Exceptions: on these dates the venue already has another (non-Middlesex)
     # fixture, so only one Middlesex match can be hosted on each - expressed as
-    # per-date 'max_matches_overrides' of the limit of 2. Leslie Pringle first gave
+    # per-date 'matches.max_overrides' of the limit of 2. Leslie Pringle first gave
     # 2026-09-21, 2026-10-05 and 2026-10-12 (2026-08-28), then supplied the
     # full list in an update as of Sunday evening 2026-08-30, adding
     # 2026-10-26, 2026-11-02, 2027-02-08 and 2027-04-19 ("most of it clear"
@@ -1215,18 +1234,20 @@ club_constraints:
     match_count_limits:
       - override_key: venue-capacity
         venue_scope: home
-        max_matches: 2
-        max_matches_overrides:
-          "2026-10-05": 1
-          "2026-10-12": 1
-          "2026-10-26": 1
-          "2026-11-02": 1
-          "2027-02-08": 1
-          "2027-04-19": 1
+        matches:
+          max: 2
+          max_overrides:
+            "2026-10-05": 1
+            "2026-10-12": 1
+            "2026-10-26": 1
+            "2026-11-02": 1
+            "2027-02-08": 1
+            "2027-04-19": 1
       # No away matches before the club's 5th October season start (Leslie
       # Pringle, 2026-09-02). The home side is handled by home_dates below
       # skipping the three preceding Mondays.
-      - max_matches: 0
+      - matches:
+          max: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2026-09-01", end_date: "2026-10-04" }
@@ -1235,7 +1256,8 @@ club_constraints:
       # Dec, 11 Jan or 8 Feb - blocked here (home and away) for Ealing 1
       # only. w/c 11 Jan already contains 2027-01-12, so moving it out of
       # that week is enough; no separate single-date exclusion is needed.
-      - max_matches: 0
+      - matches:
+          max: 0
         teams: [ealing-1]
         date_ranges:
           - { start_date: "2026-11-09", end_date: "2026-11-13" }
@@ -1251,7 +1273,8 @@ club_constraints:
       # her). Both matches should move, avoiding w/c 26 Oct, 9 Nov
       # and the week containing 11 March (w/c 8 Mar, since the 11th is a
       # Thursday) - blocked here (home and away) for Ealing 2 only.
-      - max_matches: 0
+      - matches:
+          max: 0
         teams: [ealing-2]
         date_ranges:
           - { start_date: "2026-10-26", end_date: "2026-10-30" }
@@ -1571,12 +1594,14 @@ club_constraints:
       # spec-wide one-home-match-a-night default.
       - override_key: venue-capacity
         venue_scope: home
-        max_matches: 5
+        matches:
+          max: 5
       # Away matches only: keep Harrow 1 and Harrow 2 from playing away on
       # the same date, per Surjit, without constraining their home dates.
       - teams: [harrow-1, harrow-2]
         venue_scope: away
-        max_matches: 1
+        matches:
+          max: 1
       # Front-load Harrow's fixtures into 2026 (see the club note above). Both
       # teams are held to about the same fraction of their matches in 2027, not
       # the same count: harrow-1 and harrow-2 play a different total (14 vs
@@ -1595,12 +1620,14 @@ club_constraints:
       # cap alone.
       - teams: [harrow-1]
         apply_per: each_team
-        max_matches: 5
+        matches:
+          max: 5
         date_ranges:
           - { start_date: "2027-01-01", end_date: "2027-12-31" }
       - teams: [harrow-2]
         apply_per: each_team
-        max_matches: 4
+        matches:
+          max: 4
         date_ranges:
           - { start_date: "2027-01-01", end_date: "2027-12-31" }
   kings-head:
@@ -1626,7 +1653,7 @@ club_constraints:
     #     that team did not list as playable (home or away).
     #   - Away availability is handled in match_count_limits: each team may play
     #     away only on the Thursdays it listed or inside the away windows it
-    #     gave Colin, so a 'max_matches: 0' / 'venue_scope: away' / 'date_ranges' entry
+    #     gave Colin, so a 'matches: {max: 0}' / 'venue_scope: away' / 'date_ranges' entry
     #     per team bars every other weekday (same idiom as Metropolitan and West
     #     London). Ranges are Mon-Fri spans with consecutive blocked weeks
     #     merged across the weekend between them, and run through June so the
@@ -1836,14 +1863,16 @@ club_constraints:
       # as it stands.
       - teams: [kings-head-1, kings-head-2]
         time_window_days: 2
-        max_matches: 1
+        matches:
+          max: 1
       # KH2 <-> KH3: at most one match in any 7-day window across the pair (a
       # 7-day cap already forbids same-day / consecutive-day pairings).
       # apply_per defaults to across_teams: the pair shares a single match
       # per window. This one solves comfortably.
       - teams: [kings-head-2, kings-head-3]
         time_window_days: 7
-        max_matches: 1
+        matches:
+          max: 1
       # Per-team away-availability windows (Colin, 2026-08-31). Each team may
       # play away only on the Thursdays it listed or within the away windows
       # it gave; these ranges bar every other weekday. Mon-Fri spans,
@@ -1852,7 +1881,8 @@ club_constraints:
       # 28 Sep) through June (to cover the June away Thursdays if the season
       # overruns).
       - teams: [kings-head-1]
-        max_matches: 0
+        matches:
+          max: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2026-09-01", end_date: "2026-09-25" }
@@ -1877,7 +1907,8 @@ club_constraints:
           - { start_date: "2027-04-13", end_date: "2027-05-07" }
           - { start_date: "2027-06-15", end_date: "2027-06-18" }
       - teams: [kings-head-2]
-        max_matches: 0
+        matches:
+          max: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2026-09-01", end_date: "2026-09-25" }
@@ -1911,7 +1942,8 @@ club_constraints:
           - { start_date: "2027-06-09", end_date: "2027-06-11" }
           - { start_date: "2027-06-15", end_date: "2027-06-18" }
       - teams: [kings-head-3]
-        max_matches: 0
+        matches:
+          max: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2026-09-01", end_date: "2026-09-25" }
@@ -2001,5 +2033,5 @@ fixed_fixtures:
     date: "2026-12-10"
 
 # Christmas/New Year is blocked spec-wide by the 'no-play-dates' entry under
-# club_constraints.defaults.match_count_limits above (a max_matches: 0 date range over
+# club_constraints.defaults.match_count_limits above (a matches: {max: 0} date range over
 # 2026-12-21 to 2027-01-03).

--- a/runs/2026-27/draft3/spec.yaml
+++ b/runs/2026-27/draft3/spec.yaml
@@ -268,21 +268,24 @@ club_constraints:
       - override_key: weekly-gap
         apply_per: each_team
         time_window_days: 7
-        max_matches: 1
+        matches:
+          max: 1
       # Spec-wide venue capacity: one home match a night. Clubs with a bigger
       # venue replace this via 'override_key: venue-capacity'.
       - override_key: venue-capacity
         venue_scope: home
-        max_matches: 1
+        matches:
+          max: 1
       # Christmas/New Year: no club schedules any fixture - home or away - in the
       # fortnight from Monday 2026-12-21 through Sunday 2027-01-03, on the
-      # assumption nobody wants to play then. A whole-club max_matches: 0 date_ranges
+      # assumption nobody wants to play then. A whole-club matches: {max: 0} date_ranges
       # default blocks it everywhere, so individual clubs don't repeat it in
       # their own unavailable_away_dates; a club could opt back in by overriding
       # 'no-play-dates'. (Home dates a club lists inside the range just go
       # unused; the weekend dates in the range never carry fixtures anyway.)
       - override_key: no-play-dates
-        max_matches: 0
+        matches:
+          max: 0
         date_ranges:
           - { start_date: "2026-12-21", end_date: "2027-01-03" }
   hendon:
@@ -331,21 +334,25 @@ club_constraints:
       # the spec-wide one-a-night default).
       - override_key: venue-capacity
         venue_scope: home
-        max_matches: 3
+        matches:
+          max: 3
       # Hendon 1 and Hendon 2 (both division 1) draw on the same players, so keep
       # their matches at least a week apart (matches exactly 7 days apart are
       # still allowed).
       - teams: [hendon-1, hendon-2]
         time_window_days: 7
-        max_matches: 1
+        matches:
+          max: 1
       # London Chess Classic (24 Nov - 7 Dec 2026): no Hendon 1 or Hendon 2
       # match, home or away, during the Classic.
       - teams: [hendon-1, hendon-2]
-        max_matches: 0
+        matches:
+          max: 0
         date_ranges:
           - { start_date: "2026-11-23", end_date: "2026-12-07" }
       - teams: [hendon-2]
-        max_matches: 0
+        matches:
+          max: 0
         date_ranges:
           - { start_date: "2026-10-12", end_date: "2026-10-16" }
           - { start_date: "2026-10-19", end_date: "2026-11-02" }
@@ -355,9 +362,10 @@ club_constraints:
       # Cap Hendon's overall load: no more than 3 teams playing in any
       # 7-consecutive-day period. 2026-09-10 is exempt: fixed_fixtures pins two
       # pre-season derbies there (Hendon 1 v 2 and Hendon 4 v 5 = 4 teams'-worth),
-      # which that date's own max_matches_overrides entry (2) already covers.
+      # which that date's own matches.max_overrides entry (2) already covers.
       - time_window_days: 7
-        max_playing_teams: 3
+        playing_teams:
+          max: 3
         exclude_dates:
           - "2026-09-10"
       # No more than 2 Hendon teams playing away on the same night (Andrew).
@@ -369,14 +377,17 @@ club_constraints:
       # at Hendon's own venue), so the two pinned 2026-09-10 derbies don't
       # count against it.
       - venue_scope: away
-        max_playing_teams: 2
+        playing_teams:
+          max: 2
       # No matches (even away matches) the week we have a seasonal break for Christmas
-      - max_matches: 0
+      - matches:
+          max: 0
         date_ranges:
           - { start_date: "2026-12-14", end_date: "2026-12-20" }
       # Camden school-holiday and other potential low-availability weeks -
       # Andrew wants Hendon's fixture load kept down across these.
-      - max_matches: 1
+      - matches:
+          max: 1
         date_ranges:
           - { start_date: "2026-10-26", end_date: "2026-11-01" } # Oct half term
           - { start_date: "2027-01-04", end_date: "2027-01-10" } # First week of New Year
@@ -386,7 +397,7 @@ club_constraints:
           - { start_date: "2027-04-05", end_date: "2027-04-11" } # Easter
           - { start_date: "2027-05-31", end_date: "2027-06-06" } # May half term
       # Per-date caps on Hendon's total matches (home + away) on a night, layered
-      # on top of the 7-day cap above (max_matches: null = no cap except on the listed
+      # on top of the 7-day cap above (matches: {max: null} = no cap except on the listed
       # dates):
       #
       #  - First Thursday of each month (= 1): the date of Hendon's monthly
@@ -401,23 +412,24 @@ club_constraints:
       #    club (many members still renewing), so we keep the load down then.
       #    Add any further September dates here if the reserve ones are ever
       #    uncommented.
-      - max_matches: null
-        max_matches_overrides:
-          "2026-09-03": 1
-          "2026-09-10": 2
-          "2026-09-17": 2
-          "2026-09-24": 2
-          "2026-10-01": 1
-          "2026-11-05": 1
-          "2026-12-03": 1
-          "2027-01-07": 1
-          "2027-02-04": 1
-          "2027-03-04": 1
-          "2027-04-01": 1
-          "2027-05-06": 1
-          "2027-06-03": 1
-          "2027-07-01": 1
-          "2027-08-05": 1
+      - matches:
+          max: null
+          max_overrides:
+            "2026-09-03": 1
+            "2026-09-10": 2
+            "2026-09-17": 2
+            "2026-09-24": 2
+            "2026-10-01": 1
+            "2026-11-05": 1
+            "2026-12-03": 1
+            "2027-01-07": 1
+            "2027-02-04": 1
+            "2027-03-04": 1
+            "2027-04-01": 1
+            "2027-05-06": 1
+            "2027-06-03": 1
+            "2027-07-01": 1
+            "2027-08-05": 1
   west-london:
     # Andy Hayler (draft2 feedback): exclude September entirely for West London.
     # He had assumed an early-October start (not realising matches could begin
@@ -479,7 +491,8 @@ club_constraints:
       # the club note above). West London have no September home_dates, so
       # this blocks the whole month. Replaces the earlier 2026-09-30 avoid in
       # unavailable_away_dates.
-      - max_matches: 0
+      - matches:
+          max: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2026-09-01", end_date: "2026-09-30" }
@@ -488,7 +501,8 @@ club_constraints:
       # 24 Nov - 7 Dec; the range starts the Monday of that week (2026-11-23)
       # per Andy's "last week of November" ask. The two Wednesdays in the span
       # (2026-11-25, 2026-12-02) are also dropped from home_dates above.
-      - max_matches: 0
+      - matches:
+          max: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2026-11-23", end_date: "2026-12-07" }
@@ -554,7 +568,8 @@ club_constraints:
       # rundown), and w/c 29 Mar + w/c 5 Apr (Easter, and a club-level ask -
       # adjacent weeks, so one range). The Wednesday of each (2027-01-06,
       # 2027-03-31, 2027-04-07) is likewise dropped from home_dates above.
-      - max_matches: 0
+      - matches:
+          max: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2027-01-04", end_date: "2027-01-10" } # w/c 4 Jan
@@ -625,7 +640,8 @@ club_constraints:
       # Mon-Fri of a blocked week (weekends never carry fixtures), with runs of
       # consecutive blocked weeks merged across the weekend between them. This
       # replaces ~95 individually listed weekday dates.
-      - max_matches: 0
+      - matches:
+          max: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2026-09-28", end_date: "2026-10-09" } # w/c 28 Sep + 5 Oct
@@ -668,7 +684,7 @@ club_constraints:
     # here. But the real limit already comes from the match_count_limits entries
     # below: with adjacent teams (1-2, 2-3, 3-4) barred from sharing a date, at
     # most 2 of the 4 can ever coschedule (e.g. 1+3, 1+4 or 2+4), so the
-    # venue-capacity default is simply cancelled (max_matches: null, see
+    # venue-capacity default is simply cancelled (matches: {max: null}, see
     # match_count_limits below) rather than restating that bound as a number
     # that would need to stay in sync with it (and would otherwise need updating
     # if Hammersmith confirms their venue's actual concurrent-match capacity
@@ -994,17 +1010,21 @@ club_constraints:
       # top of this club's block).
       - override_key: venue-capacity
         venue_scope: home
-        max_matches: null
+        matches:
+          max: null
       # Adjacent Hammersmith teams (by team index: 1-2, 2-3, 3-4) shouldn't play
       # on the same date, per the club's preference (2026-08-24) - they only asked
       # for same-date avoidance, so time_window_days is left at its default of 1
       # rather than keeping them apart by more than that.
       - teams: [hammersmith-1, hammersmith-2]
-        max_matches: 1
+        matches:
+          max: 1
       - teams: [hammersmith-2, hammersmith-3]
-        max_matches: 1
+        matches:
+          max: 1
       - teams: [hammersmith-3, hammersmith-4]
-        max_matches: 1
+        matches:
+          max: 1
   muswell-hill:
     # Club night is Tuesday. Available for home matches October and
     # November 2026, then January to around mid-May 2027 (2026-08-25
@@ -1088,7 +1108,8 @@ club_constraints:
       # one-home-match-a-night default).
       - override_key: venue-capacity
         venue_scope: home
-        max_matches: 2
+        matches:
+          max: 2
     home_dates:
       - "2026-10-06"
       - "2026-10-13"
@@ -1215,7 +1236,8 @@ club_constraints:
       # 2026-09-01 - see the note above), nor in November 2026 or the first week
       # of December. The home side of both spans is handled by home_dates above
       # skipping them.
-      - max_matches: 0
+      - matches:
+          max: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2026-09-01", end_date: "2026-09-30" }
@@ -1234,7 +1256,7 @@ club_constraints:
     #
     # Exceptions: on these dates the venue already has another (non-Middlesex)
     # fixture, so only one Middlesex match can be hosted on each - expressed as
-    # per-date 'max_matches_overrides' of the limit of 2. Leslie Pringle first gave
+    # per-date 'matches.max_overrides' of the limit of 2. Leslie Pringle first gave
     # 2026-09-21, 2026-10-05 and 2026-10-12 (2026-08-28), then supplied the
     # full list in an update as of Sunday evening 2026-08-30, adding
     # 2026-10-26, 2026-11-02, 2027-02-08 and 2027-04-19 ("most of it clear"
@@ -1250,18 +1272,20 @@ club_constraints:
     match_count_limits:
       - override_key: venue-capacity
         venue_scope: home
-        max_matches: 2
-        max_matches_overrides:
-          "2026-10-05": 1
-          "2026-10-12": 1
-          "2026-10-26": 1
-          "2026-11-02": 1
-          "2027-02-08": 1
-          "2027-04-19": 1
+        matches:
+          max: 2
+          max_overrides:
+            "2026-10-05": 1
+            "2026-10-12": 1
+            "2026-10-26": 1
+            "2026-11-02": 1
+            "2027-02-08": 1
+            "2027-04-19": 1
       # No away matches before the club's 5th October season start (Leslie
       # Pringle, 2026-09-02). The home side is handled by home_dates below
       # skipping the three preceding Mondays.
-      - max_matches: 0
+      - matches:
+          max: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2026-09-01", end_date: "2026-10-04" }
@@ -1270,7 +1294,8 @@ club_constraints:
       # Dec, 11 Jan or 8 Feb - blocked here (home and away) for Ealing 1
       # only. w/c 11 Jan already contains 2027-01-12, so moving it out of
       # that week is enough; no separate single-date exclusion is needed.
-      - max_matches: 0
+      - matches:
+          max: 0
         teams: [ealing-1]
         date_ranges:
           - { start_date: "2026-11-09", end_date: "2026-11-13" }
@@ -1286,7 +1311,8 @@ club_constraints:
       # her). Both matches should move, avoiding w/c 26 Oct, 9 Nov
       # and the week containing 11 March (w/c 8 Mar, since the 11th is a
       # Thursday) - blocked here (home and away) for Ealing 2 only.
-      - max_matches: 0
+      - matches:
+          max: 0
         teams: [ealing-2]
         date_ranges:
           - { start_date: "2026-10-26", end_date: "2026-10-30" }
@@ -1606,12 +1632,14 @@ club_constraints:
       # spec-wide one-home-match-a-night default.
       - override_key: venue-capacity
         venue_scope: home
-        max_matches: 5
+        matches:
+          max: 5
       # Away matches only: keep Harrow 1 and Harrow 2 from playing away on
       # the same date, per Surjit, without constraining their home dates.
       - teams: [harrow-1, harrow-2]
         venue_scope: away
-        max_matches: 1
+        matches:
+          max: 1
       # Front-load Harrow's fixtures into 2026 (see the club note above). Both
       # teams are held to about the same fraction of their matches in 2027, not
       # the same count: harrow-1 and harrow-2 play a different total (14 vs
@@ -1630,12 +1658,14 @@ club_constraints:
       # cap alone.
       - teams: [harrow-1]
         apply_per: each_team
-        max_matches: 5
+        matches:
+          max: 5
         date_ranges:
           - { start_date: "2027-01-01", end_date: "2027-12-31" }
       - teams: [harrow-2]
         apply_per: each_team
-        max_matches: 4
+        matches:
+          max: 4
         date_ranges:
           - { start_date: "2027-01-01", end_date: "2027-12-31" }
   kings-head:
@@ -1661,7 +1691,7 @@ club_constraints:
     #     that team did not list as playable (home or away).
     #   - Away availability is handled in match_count_limits: each team may play
     #     away only on the Thursdays it listed or inside the away windows it
-    #     gave Colin, so a 'max_matches: 0' / 'venue_scope: away' / 'date_ranges' entry
+    #     gave Colin, so a 'matches: {max: 0}' / 'venue_scope: away' / 'date_ranges' entry
     #     per team bars every other weekday (same idiom as Metropolitan and West
     #     London). Ranges are Mon-Fri spans with consecutive blocked weeks
     #     merged across the weekend between them, and run through June so the
@@ -1871,14 +1901,16 @@ club_constraints:
       # as it stands.
       - teams: [kings-head-1, kings-head-2]
         time_window_days: 2
-        max_matches: 1
+        matches:
+          max: 1
       # KH2 <-> KH3: at most one match in any 7-day window across the pair (a
       # 7-day cap already forbids same-day / consecutive-day pairings).
       # apply_per defaults to across_teams: the pair shares a single match
       # per window. This one solves comfortably.
       - teams: [kings-head-2, kings-head-3]
         time_window_days: 7
-        max_matches: 1
+        matches:
+          max: 1
       # Per-team away-availability windows (Colin, 2026-08-31). Each team may
       # play away only on the Thursdays it listed or within the away windows
       # it gave; these ranges bar every other weekday. Mon-Fri spans,
@@ -1887,7 +1919,8 @@ club_constraints:
       # 28 Sep) through June (to cover the June away Thursdays if the season
       # overruns).
       - teams: [kings-head-1]
-        max_matches: 0
+        matches:
+          max: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2026-09-01", end_date: "2026-09-25" }
@@ -1912,7 +1945,8 @@ club_constraints:
           - { start_date: "2027-04-13", end_date: "2027-05-07" }
           - { start_date: "2027-06-15", end_date: "2027-06-18" }
       - teams: [kings-head-2]
-        max_matches: 0
+        matches:
+          max: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2026-09-01", end_date: "2026-09-25" }
@@ -1946,7 +1980,8 @@ club_constraints:
           - { start_date: "2027-06-09", end_date: "2027-06-11" }
           - { start_date: "2027-06-15", end_date: "2027-06-18" }
       - teams: [kings-head-3]
-        max_matches: 0
+        matches:
+          max: 0
         venue_scope: away
         date_ranges:
           - { start_date: "2026-09-01", end_date: "2026-09-25" }
@@ -2036,5 +2071,5 @@ fixed_fixtures:
     date: "2026-12-10"
 
 # Christmas/New Year is blocked spec-wide by the 'no-play-dates' entry under
-# club_constraints.defaults.match_count_limits above (a max_matches: 0 date range over
+# club_constraints.defaults.match_count_limits above (a matches: {max: 0} date range over
 # 2026-12-21 to 2027-01-03).

--- a/runs/example/spec.yaml
+++ b/runs/example/spec.yaml
@@ -197,11 +197,13 @@ club_constraints:
       - override_key: weekly-gap
         apply_per: each_team
         time_window_days: 7
-        max_matches: 1
+        matches:
+          max: 1
       # Each club hosts at most two home matches a night (shared venue).
       - override_key: venue-capacity
         venue_scope: home
-        max_matches: 2
+        matches:
+          max: 2
   albany:
     home_dates:
       - "2025-09-01"
@@ -371,16 +373,18 @@ club_constraints:
       # take a third on 2025-11-13 only.
       - override_key: venue-capacity
         venue_scope: home
-        max_matches: 2
-        max_matches_overrides:
-          "2025-11-13": 3
+        matches:
+          max: 2
+          max_overrides:
+            "2025-11-13": 3
   harrow:
     match_count_limits:
       # Replaces the spec-wide per-team weekly gap
       - override_key: weekly-gap
         apply_per: each_team
         time_window_days: 14
-        max_matches: 1
+        matches:
+          max: 1
     home_dates:
       - "2025-09-11"
       - "2025-09-18"

--- a/solve_test.py
+++ b/solve_test.py
@@ -59,7 +59,8 @@ club_constraints:
     match_count_limits:
       - override_key: venue-capacity
         venue_scope: home
-        max_matches: 1
+        matches:
+          max: 1
   albany:
     home_dates: [2025-09-01, 2025-09-29]
   hackney:

--- a/spec-schema.json
+++ b/spec-schema.json
@@ -191,7 +191,7 @@
         "unavailable_away_dates": {
           "type": "array",
           "default": [],
-          "description": "Dates this club's teams are unavailable to play away. Defaults to empty if omitted. For a contiguous span, or a block that applies to every club, a match_count_limits entry with 'max_matches: 0' and 'date_ranges' is usually tidier.",
+          "description": "Dates this club's teams are unavailable to play away. Defaults to empty if omitted. For a contiguous span, or a block that applies to every club, a match_count_limits entry with 'matches: {max: 0}' and 'date_ranges' is usually tidier.",
           "items": { "$ref": "#/$defs/date" },
           "uniqueItems": true
         },
@@ -224,7 +224,7 @@
         },
         "match_count_limits": {
           "type": "array",
-          "description": "The sole match-count constraint mechanism: each entry caps how many matches involving a set of this club's teams may fall within a rolling window of consecutive days -- or, when the entry sets 'date_ranges', within each of a few explicit calendar ranges. Covers a per-team weekly gap ('apply_per: each_team', 'max_matches: 1', 'time_window_days: 7'), a venue's concurrent-match capacity ('apply_per: across_teams', 'venue_scope: home', typically paired with 'max_playing_teams' to also cap distinct teams playing -- see 'match_count_limit_fields/max_playing_teams'), keeping adjacent-division teams apart ('teams: [...]', 'max_matches: 1'), and holding a club's load down over a named holiday week ('date_ranges: [...]', 'max_matches: 1', or 'max_matches: 0' to bar it entirely). Additive, with as many entries as needed; combined with any inherited from club_constraints.defaults -- an entry with an 'override_key' replaces the like-keyed default for this club instead.",
+          "description": "The sole match-count constraint mechanism: each entry bounds how many matches involving a set of this club's teams may fall within a rolling window of consecutive days -- or, when the entry sets 'date_ranges', within each of a few explicit calendar ranges -- from above ('max'), below ('min'), or both. Covers a per-team weekly gap ('apply_per: each_team', 'matches: {max: 1}', 'time_window_days: 7'), a venue's concurrent-match capacity ('apply_per: across_teams', 'venue_scope: home', typically paired with 'playing_teams' to also cap distinct teams playing -- see 'match_count_limit_fields/playing_teams'), keeping adjacent-division teams apart ('teams: [...]', 'matches: {max: 1}'), a floor on activity ('matches: {min: 1}', e.g. at least one match in a congress fortnight), and holding a club's load down over a named holiday week ('date_ranges: [...]', 'matches: {max: 1}', or 'matches: {max: 0}' to bar it entirely). Additive, with as many entries as needed; combined with any inherited from club_constraints.defaults -- an entry with an 'override_key' replaces the like-keyed default for this club instead.",
           "items": { "$ref": "#/$defs/match_count_limit_entry" }
         }
       }
@@ -248,20 +248,81 @@
       }
     },
     "match_count_limit_fields": {
-      "max_matches": {
+      "bound_max": {
         "oneOf": [{ "type": "integer", "minimum": 0 }, { "type": "null" }],
-        "description": "The most matches (of the kind selected by 'venue_scope') allowed within any window of 'time_window_days' consecutive days (or, with 'date_ranges', within each listed range). At least one of this and 'max_playing_teams' must be given (or another way to supply the cap -- see the entry-level description), so an entry is never accidentally a no-op. Omitted or null means no plain cap -- only useful alongside 'max_matches_overrides' or 'max_playing_teams', or (on a club entry with an 'override_key') to cancel a default. 'max_matches: 1' forbids a second match in a window; a higher value caps density. 'max_matches: 0' is only meaningful together with 'date_ranges' (a full blackout of those ranges); in the rolling-window form use 'max_matches: 1' or higher."
+        "description": "Shared shape of 'matches.max' and 'playing_teams.max': a non-negative ceiling, or null for none."
       },
-      "max_playing_teams": {
-        "type": "integer",
-        "minimum": 0,
-        "description": "A cap on how many teams'-worth of players from 'teams' a window asks for, as opposed to 'max_matches' (a count of matches). Each counted match adds one of 'teams' playing, or two if it's an internal match between two of 'teams' -- e.g. a same-club derby counted by that club's own venue-capacity rule: one match towards 'max_matches', but two teams from the set on to play, both counted towards 'max_playing_teams'. A venue that can physically host 3 simultaneous matches but only has 3 teams' worth of players to field wants both 'max_matches: 3' and 'max_playing_teams: 3' -- otherwise 3 matches, one an internal derby, would need 4 teams' worth of players. Optional; omit for no such cap. Over a wider window (a multi-day 'time_window_days', or 'date_ranges'), the same pair meeting twice counts twice: it's a running tally of teams asked to play, not a count of distinct teams touched. See 'max_playing_teams_overrides' for per-date replacements."
+      "bound_min": {
+        "oneOf": [{ "type": "integer", "minimum": 1 }, { "type": "null" }],
+        "description": "Shared shape of 'matches.min' and 'playing_teams.min': a floor of >= 1, or null for none -- a floor of 0 is never meaningful (it can never bind), so there's no lower value to allow the way 'max' allows 0."
+      },
+      "bound_min_overrides": {
+        "type": "object",
+        "description": "Shared shape of 'matches.min_overrides' and 'playing_teams.min_overrides': per-date replacements, each an integer >= 1, or null to lift the floor that day.",
+        "additionalProperties": {
+          "oneOf": [{ "type": "integer", "minimum": 1 }, { "type": "null" }]
+        }
+      },
+      "bound_max_overrides": {
+        "type": "object",
+        "description": "Shared shape of 'matches.max_overrides' and 'playing_teams.max_overrides': per-date replacements, each an integer >= 0, or null to lift the cap that day -- 0 bars every counted match/team that one date, the single-day equivalent of a 'date_ranges' blackout.",
+        "additionalProperties": {
+          "oneOf": [{ "type": "integer", "minimum": 0 }, { "type": "null" }]
+        }
+      },
+      "matches": {
+        "type": "object",
+        "additionalProperties": false,
+        "minProperties": 1,
+        "description": "Bounds on how many matches (of the kind selected by 'venue_scope') fall within a window of 'time_window_days' consecutive days (or, with 'date_ranges', within each listed range). At least one of this and 'playing_teams' must be given (or another way to supply the bound -- see the entry-level description), so an entry is never accidentally a no-op.",
+        "properties": {
+          "max": {
+            "$ref": "#/$defs/match_count_limit_fields/bound_max",
+            "description": "The most matches allowed within a window. Omitted or null means no ceiling -- only useful alongside 'max_overrides', 'min'/'min_overrides', or (on a club entry with an 'override_key') to cancel a default. 'max: 1' forbids a second match in a window; a higher value caps density. 'max: 0' is only meaningful together with 'date_ranges' (a full blackout of those ranges); in the rolling-window form use 'max: 1' or higher."
+          },
+          "max_overrides": {
+            "$ref": "#/$defs/match_count_limit_fields/bound_max_overrides",
+            "description": "Per-date replacements of 'max', keyed by date; each value an integer >= 0, or null to lift the cap that day (0 bars every counted match that one date -- the single-day equivalent of a 'date_ranges' blackout). Only allowed when 'time_window_days' is 1 (so each window is a single date); not combinable with 'date_ranges'."
+          },
+          "min": {
+            "$ref": "#/$defs/match_count_limit_fields/bound_min",
+            "description": "The fewest matches required within a window. A floor of 0 is never meaningful (it can never bind), so omit 'min' (or leave it null) for no such requirement instead -- there's no 'date_ranges'-shaped exception the way 'max' has one. Combine with 'max' to pin a window's count to a range; when both are given, 'min' may not exceed 'max'."
+          },
+          "min_overrides": {
+            "$ref": "#/$defs/match_count_limit_fields/bound_min_overrides",
+            "description": "Per-date replacements of 'min', keyed by date; each value an integer >= 1, or null to lift the floor that day -- mirroring 'max_overrides'. Only allowed when 'time_window_days' is 1; not combinable with 'date_ranges'."
+          }
+        }
+      },
+      "playing_teams": {
+        "type": "object",
+        "additionalProperties": false,
+        "minProperties": 1,
+        "description": "The same four sub-keys as 'matches' ('max', 'max_overrides', 'min', 'min_overrides'), but bounding how many teams'-worth of players from 'teams' a window asks for, as opposed to 'matches' (a count of matches). Each counted match adds one of 'teams' playing, or two if it's an internal match between two of 'teams' -- e.g. a same-club derby counted by that club's own venue-capacity rule: one match towards 'matches.max', but two teams from the set on to play, both counted here. A venue that can physically host 3 simultaneous matches but only has 3 teams' worth of players to field wants both 'matches: {max: 3}' and 'playing_teams: {max: 3}' -- otherwise 3 matches, one an internal derby, would need 4 teams' worth of players. Over a wider window (a multi-day 'time_window_days', or 'date_ranges'), the same pair meeting twice counts twice: it's a running tally of teams asked to play, not a count of distinct teams touched. Unlike 'matches.max', 'max' here may be 0 regardless of 'date_ranges' -- 'nobody from this set plays' is meaningful either way.",
+        "properties": {
+          "max": {
+            "$ref": "#/$defs/match_count_limit_fields/bound_max",
+            "description": "A cap on how many teams'-worth of players from 'teams' a window asks for. Omitted or null means no such cap. See 'max_overrides' for per-date replacements."
+          },
+          "max_overrides": {
+            "$ref": "#/$defs/match_count_limit_fields/bound_max_overrides",
+            "description": "Per-date replacements of 'max', keyed by date; each value an integer >= 0, or null to lift the cap that day. Only allowed when 'time_window_days' is 1 (so each window is a single date); not combinable with 'date_ranges'. Useful for a one-off exception to a standing venue-capacity rule (e.g. a busy week where two derbies must double up, needing more than the usual number of teams playing at once)."
+          },
+          "min": {
+            "$ref": "#/$defs/match_count_limit_fields/bound_min",
+            "description": "The fewest teams'-worth of players from 'teams' a window must ask for. A floor of 0 is never meaningful, so omit 'min' (or leave it null) for no such requirement. When both 'max' and 'min' are given, 'min' may not exceed 'max'."
+          },
+          "min_overrides": {
+            "$ref": "#/$defs/match_count_limit_fields/bound_min_overrides",
+            "description": "Per-date replacements of 'min', keyed by date; each value an integer >= 1, or null to lift the floor that day. Only allowed when 'time_window_days' is 1; not combinable with 'date_ranges'."
+          }
+        }
       },
       "apply_per": {
         "type": "string",
         "enum": ["across_teams", "each_team"],
         "default": "across_teams",
-        "description": "'across_teams' (the default): the counted teams share one budget of 'max_matches'/'max_playing_teams' per window (a venue capacity, or a keep-apart rule). 'each_team': enforced separately for each team -- typically with 'teams' left as every team of the club and 'max_matches: 1', i.e. a per-team gap."
+        "description": "'across_teams' (the default): the counted teams share one budget per window (a venue capacity, or a keep-apart rule). 'each_team': enforced separately for each team -- typically with 'teams' left as every team of the club and 'matches: {max: 1}', i.e. a per-team gap."
       },
       "time_window_days": {
         "type": "integer",
@@ -275,24 +336,10 @@
         "default": "all",
         "description": "Which of the counted teams' matches the cap counts: 'home' only their home matches, 'away' only their away matches, or 'all' (the default) every match they play. E.g. 'away' counts only away fixtures, still allowing one team to play away on a night another is hosting. An internal match (both teams the same club) is never counted under 'away' scope -- its 'away' team is playing at its own club's venue, so it isn't away for an away-load cap; it still counts under 'home' and 'all'."
       },
-      "max_matches_overrides": {
-        "type": "object",
-        "description": "Per-date replacements of 'max_matches', keyed by date; each value an integer >= 1, or null to lift the cap that day. Only allowed when 'time_window_days' is 1 (so each window is a single date).",
-        "additionalProperties": {
-          "oneOf": [{ "type": "integer", "minimum": 1 }, { "type": "null" }]
-        }
-      },
-      "max_playing_teams_overrides": {
-        "type": "object",
-        "description": "Per-date replacements of 'max_playing_teams', keyed by date; each value an integer >= 0, or null to lift the cap that day -- mirroring 'max_matches_overrides'. Only allowed when 'time_window_days' is 1 (so each window is a single date); not combinable with 'date_ranges'. Useful for a one-off exception to a standing venue-capacity rule (e.g. a busy week where two derbies must double up, needing more than the usual number of teams playing at once).",
-        "additionalProperties": {
-          "oneOf": [{ "type": "integer", "minimum": 0 }, { "type": "null" }]
-        }
-      },
       "date_ranges": {
         "type": "array",
         "minItems": 1,
-        "description": "Restricts this rule to one or more explicit, inclusive calendar ranges instead of every rolling 'time_window_days' window: the caps ('max_matches' and/or 'max_playing_teams') then apply to the counted matches whose date falls within each listed range, each range enforced independently. Use for a limit tied to specific weeks -- a school-holiday week, a congress fortnight -- that a rolling window cannot target. Allowed on club and 'defaults' entries alike; not combinable with 'time_window_days', 'max_matches_overrides' or 'max_playing_teams_overrides' (both tied to a single date), nor (on a club entry) with 'override_key'. With 'date_ranges' set, 'max_matches' must be an integer >= 0 ('max_matches: 0' bars every counted match in the range; a whole-club 'defaults' entry with 'max_matches: 0' is the spec-wide 'nobody plays these dates' block).",
+        "description": "Restricts this rule to one or more explicit, inclusive calendar ranges instead of every rolling 'time_window_days' window: the bounds ('matches' and/or 'playing_teams') then apply to the counted matches whose date falls within each listed range, each range enforced independently. Use for a limit tied to specific weeks -- a school-holiday week, a congress fortnight -- that a rolling window cannot target. Allowed on club and 'defaults' entries alike; not combinable with 'time_window_days' or any '*_overrides' sub-key (all tied to a single date), nor (on a club entry) with 'override_key'. With 'date_ranges' set, 'matches.max' must be an integer >= 0 ('matches: {max: 0}' bars every counted match in the range; a whole-club 'defaults' entry with 'matches: {max: 0}' is the spec-wide 'nobody plays these dates' block).",
         "items": {
           "type": "object",
           "additionalProperties": false,
@@ -312,7 +359,7 @@
       "exclude_dates": {
         "type": "array",
         "minItems": 1,
-        "description": "Dates whose counted matches this rule ignores entirely -- every window is evaluated as if nothing counted falls on them. Use to exempt a date the rule would otherwise make infeasible, typically one whose load is already pinned by fixed_fixtures and governed by a 'max_matches_overrides' entry (e.g. two pre-season derbies on one night, four teams'-worth, under a rolling 'max_playing_teams: 3'). Applies to both 'max_matches' and 'max_playing_teams'; not combinable with 'date_ranges' (list ranges that skip the date instead).",
+        "description": "Dates whose counted matches this rule ignores entirely -- every window is evaluated as if nothing counted falls on them. Use to exempt a date the rule would otherwise make infeasible, typically one whose load is already pinned by fixed_fixtures and governed by a 'max_overrides' entry (e.g. two pre-season derbies on one night, four teams'-worth, under a rolling 'playing_teams: {max: 3}'). Applies to both 'matches' and 'playing_teams'; not combinable with 'date_ranges' (list ranges that skip the date instead).",
         "items": { "$ref": "#/$defs/date" },
         "uniqueItems": true
       },
@@ -324,11 +371,11 @@
     "match_count_limit_entry": {
       "type": "object",
       "additionalProperties": false,
-      "description": "One per-club match_count_limits entry. Needs at least one of 'max_matches' or 'max_playing_teams' -- either alone is fine -- unless 'max_matches_overrides', 'date_ranges', or 'override_key' (cancelling a default) supplies the actual cap instead.",
+      "description": "One per-club match_count_limits entry. Needs a 'matches' and/or 'playing_teams' mapping carrying an actual bound -- either alone is fine -- unless 'date_ranges' or 'override_key' (cancelling a default) is what's meant instead.",
       "properties": {
-        "max_matches": { "$ref": "#/$defs/match_count_limit_fields/max_matches" },
-        "max_playing_teams": {
-          "$ref": "#/$defs/match_count_limit_fields/max_playing_teams"
+        "matches": { "$ref": "#/$defs/match_count_limit_fields/matches" },
+        "playing_teams": {
+          "$ref": "#/$defs/match_count_limit_fields/playing_teams"
         },
         "teams": {
           "type": "array",
@@ -342,12 +389,6 @@
           "$ref": "#/$defs/match_count_limit_fields/time_window_days"
         },
         "venue_scope": { "$ref": "#/$defs/match_count_limit_fields/venue_scope" },
-        "max_matches_overrides": {
-          "$ref": "#/$defs/match_count_limit_fields/max_matches_overrides"
-        },
-        "max_playing_teams_overrides": {
-          "$ref": "#/$defs/match_count_limit_fields/max_playing_teams_overrides"
-        },
         "date_ranges": {
           "$ref": "#/$defs/match_count_limit_fields/date_ranges"
         },
@@ -363,23 +404,17 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["override_key"],
-      "description": "A club_constraints.defaults.match_count_limits entry: like a per-club match_count_limits entry but without 'teams' (defaults apply to every team of every club) and with a required, list-unique 'override_key'. A club's own entry naming that 'override_key' replaces this one for the club wholesale. A 'max_matches: 0' entry with 'date_ranges' is the spec-wide way to say no club plays on those dates (a club can opt back in by overriding the key). Needs at least one of 'max_matches' or 'max_playing_teams' -- either alone is fine -- unless 'max_matches_overrides', 'date_ranges', or a bare cancelling entry (only 'override_key') is what's meant.",
+      "description": "A club_constraints.defaults.match_count_limits entry: like a per-club match_count_limits entry but without 'teams' (defaults apply to every team of every club) and with a required, list-unique 'override_key'. A club's own entry naming that 'override_key' replaces this one for the club wholesale. A 'matches: {max: 0}' entry with 'date_ranges' is the spec-wide way to say no club plays on those dates (a club can opt back in by overriding the key). Needs a 'matches' and/or 'playing_teams' mapping carrying an actual bound -- either alone is fine -- unless 'date_ranges', or a bare cancelling entry (only 'override_key'), is what's meant.",
       "properties": {
-        "max_matches": { "$ref": "#/$defs/match_count_limit_fields/max_matches" },
-        "max_playing_teams": {
-          "$ref": "#/$defs/match_count_limit_fields/max_playing_teams"
+        "matches": { "$ref": "#/$defs/match_count_limit_fields/matches" },
+        "playing_teams": {
+          "$ref": "#/$defs/match_count_limit_fields/playing_teams"
         },
         "apply_per": { "$ref": "#/$defs/match_count_limit_fields/apply_per" },
         "time_window_days": {
           "$ref": "#/$defs/match_count_limit_fields/time_window_days"
         },
         "venue_scope": { "$ref": "#/$defs/match_count_limit_fields/venue_scope" },
-        "max_matches_overrides": {
-          "$ref": "#/$defs/match_count_limit_fields/max_matches_overrides"
-        },
-        "max_playing_teams_overrides": {
-          "$ref": "#/$defs/match_count_limit_fields/max_playing_teams_overrides"
-        },
         "date_ranges": {
           "$ref": "#/$defs/match_count_limit_fields/date_ranges"
         },

--- a/spec_schema_test.py
+++ b/spec_schema_test.py
@@ -81,12 +81,15 @@ club_constraints:
       - override_key: weekly-gap
         apply_per: each_team
         time_window_days: 7
-        max_matches: 1
+        matches:
+          max: 1
       - override_key: venue-capacity
         venue_scope: home
-        max_matches: 2
+        matches:
+          max: 2
       - override_key: no-play-dates
-        max_matches: 0
+        matches:
+          max: 0
         date_ranges:
           - start_date: 2025-12-22
             end_date: 2026-01-04
@@ -99,30 +102,37 @@ club_constraints:
       - override_key: weekly-gap
         apply_per: each_team
         time_window_days: 14
-        max_matches: 1
+        matches:
+          max: 1
       - override_key: venue-capacity
         venue_scope: home
-        max_matches: 3
+        matches:
+          max: 3
 
   hackney:
     home_dates: [2025-09-08, 2025-09-22]
     match_count_limits:
       - override_key: venue-capacity
         venue_scope: home
-        max_matches: 2
-        max_matches_overrides:
-          2025-09-08: 3
-      - max_matches: null
+        matches:
+          max: 2
+          max_overrides:
+            2025-09-08: 3
+      - matches:
+          max: null
+          max_overrides:
+            2025-09-22: 1
         venue_scope: all
-        max_matches_overrides:
-          2025-09-22: 1
       - teams: [hackney-1, hackney-5]
         time_window_days: 7
-        max_matches: 1
+        matches:
+          max: 1
         venue_scope: away
         exclude_dates: [2025-09-08]
       - teams: [hackney-1, hackney-5]
-        max_matches: 1
+        matches:
+          max: 1
+          min: 1
         date_ranges:
           - start_date: 2025-10-20
             end_date: 2025-10-26

--- a/validate_test.py
+++ b/validate_test.py
@@ -139,7 +139,7 @@ class TestCheckSchedule(unittest.TestCase):
             unavailable_away_dates={},
             match_count_limits=[
                 fmodel.RollingLimit(
-                    teams=[_A1, _B1], match_cap=fmodel.Cap(1), window_days=7
+                    teams=[_A1, _B1], match_max=fmodel.Cap(1), window_days=7
                 )
             ],
         )
@@ -230,7 +230,8 @@ club_constraints:
     match_count_limits:
       - override_key: venue-capacity
         venue_scope: home
-        max_matches: 1
+        matches:
+          max: 1
   albany:
     home_dates: [2025-09-01, 2025-09-29]
   hackney:


### PR DESCRIPTION
Replaces the flat max_matches/max_matches_overrides/max_playing_teams/ max_playing_teams_overrides keys with matches/playing_teams mappings, each carrying max, max_overrides, min and min_overrides -- a breaking schema change (no back-compat shim), so all committed spec files are migrated in this same change. Verified the production runs/ specs are semantics-preserving by diffing their resolved match_count_limits against the pre-change parser.

fmodel.MatchCountLimit gains match_min/playing_teams_min alongside the renamed match_max/playing_teams_max, enforced as an added lower-bound constraint per window (never skipped on an empty window, unlike a ceiling, since an unmeetable floor must surface as infeasible).

Also fixes matches.max_overrides to accept 0 (a single-day blackout, matching playing_teams.max_overrides and RangeLimit's max: 0) -- the old >= 1 restriction predated max_playing_teams and had no remaining rationale once playing_teams.max_overrides allowed 0.


Claude-Session: https://claude.ai/code/session_013b52P7W2AXMKHWDVJswhXA