### PR TITLE
Replace spec 'draft' key with 'is_final' (default False)

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,8 +273,10 @@ None of these files are committed: they're all build artifacts, derived from
 
 Venue name (not the address), start time and time limit on each match are
 always the *home* team's club's values. If the spec sets `name`, every HTML
-page shows it in a banner above the page title; if `draft: true` is also set,
-that banner is made prominent and prefixed "DRAFT". (The CSV files carry the
+page shows it in a banner above the page title. Unless the spec sets
+`is_final: true`, that banner is made prominent and prefixed "NOT FINAL" (and
+the page title gets a "(NOT FINAL)" suffix); set `is_final: true` once the
+fixture list is finalised to drop the warning. (The CSV files carry the
 fixture data only, with no such banner.)
 
 ## Development

--- a/fixturespec.py
+++ b/fixturespec.py
@@ -73,7 +73,7 @@ class Spec:
     parameters: fmodel.Parameters
     clubs: Mapping[str, fmodel.Club]
     name: str = ""
-    draft: bool = False
+    is_final: bool = False
     description: str = ""
 
 
@@ -378,7 +378,7 @@ _CLUB_CONSTRAINT_DEFAULTS_KEYS = {"match_count_limits"}
 
 _TOP_LEVEL_KEYS = {
     "name",
-    "draft",
+    "is_final",
     "description",
     "latest_internal_match_date",
     "earliest_match_date",
@@ -1510,12 +1510,12 @@ def load_spec(spec_path: str | Path) -> Spec:
         **kwargs,
     )
     name = _require_str(data.get("name", ""), f"{path}: 'name'")
-    draft = _require_bool(data.get("draft", False), f"{path}: 'draft'")
+    is_final = _require_bool(data.get("is_final", False), f"{path}: 'is_final'")
     description = _require_str(data.get("description", ""), f"{path}: 'description'")
     return Spec(
         parameters=parameters,
         clubs=clubs,
         name=name,
-        draft=draft,
+        is_final=is_final,
         description=description,
     )

--- a/fixturespec_test.py
+++ b/fixturespec_test.py
@@ -248,13 +248,13 @@ class TestLoadSpec(unittest.TestCase):
             )
             self.assertEqual(_cap_base(limit.match_max), 1)
         self.assertEqual(spec.name, "")
-        self.assertFalse(spec.draft)
+        self.assertFalse(spec.is_final)
 
-    def test_run_name_and_draft(self) -> None:
-        path = self._write(_MINIMAL_SPEC + '\nname: "2025-26 Season"\ndraft: true\n')
+    def test_run_name_and_is_final(self) -> None:
+        path = self._write(_MINIMAL_SPEC + '\nname: "2025-26 Season"\nis_final: true\n')
         spec = fixturespec.load_spec(path)
         self.assertEqual(spec.name, "2025-26 Season")
-        self.assertTrue(spec.draft)
+        self.assertTrue(spec.is_final)
 
     def test_description(self) -> None:
         path = self._write(
@@ -272,9 +272,9 @@ class TestLoadSpec(unittest.TestCase):
         spec = fixturespec.load_spec(path)
         self.assertEqual(spec.description, "")
 
-    def test_draft_must_be_a_boolean(self) -> None:
-        path = self._write(_MINIMAL_SPEC + "\ndraft: notabool\n")
-        with self.assertRaisesRegex(fixturespec.SpecError, "draft"):
+    def test_is_final_must_be_a_boolean(self) -> None:
+        path = self._write(_MINIMAL_SPEC + "\nis_final: notabool\n")
+        with self.assertRaisesRegex(fixturespec.SpecError, "is_final"):
             fixturespec.load_spec(path)
 
     def test_name_must_be_a_string(self) -> None:

--- a/htmlreport.py
+++ b/htmlreport.py
@@ -44,10 +44,10 @@ _STYLE = """
     .banner { background: #eee; color: #333; font-weight: 600; text-align: center;
               padding: 0.6rem 1rem; margin-bottom: 1.5rem; font-size: 1.25rem;
               border-radius: 4px; }
-    .banner.draft { background: #b00020; color: #fff; }
+    .banner.not-final { background: #b00020; color: #fff; }
     .banner.compliance-warning { background: #b25f00; color: #fff; font-size: 1rem;
               text-align: left; }
-    .draft-label { font-weight: 800; text-transform: uppercase; letter-spacing: 0.05em;
+    .not-final-label { font-weight: 800; text-transform: uppercase; letter-spacing: 0.05em;
                     margin-right: 0.5rem; }
     .table-scroll { overflow-x: auto; margin-bottom: 2rem; }
     table { border-collapse: collapse; width: 100%; max-width: 80rem; }
@@ -86,14 +86,14 @@ def _fmt_date(d: date) -> str:
     return d.strftime("%a %d %b %Y")
 
 
-def _head_title(title: str, run_name: str, draft: bool, is_run_home: bool) -> str:
+def _head_title(title: str, run_name: str, is_final: bool, is_run_home: bool) -> str:
     """The text for the page's <title> element.
 
     A run's home page gets just the run name; every other page in the run gets
     the run name followed by that page's own title (a club or division name, or
-    "All matches"). A trailing "(DRAFT)" is added whenever the run is a draft.
-    Pages with no run name (e.g. the top-level list of runs) fall back to their
-    own title alone.
+    "All matches"). A trailing "(NOT FINAL)" is added whenever the run is not
+    marked final. Pages with no run name (e.g. the top-level list of runs) fall
+    back to their own title alone.
     """
     if run_name and is_run_home:
         text = run_name
@@ -101,14 +101,14 @@ def _head_title(title: str, run_name: str, draft: bool, is_run_home: bool) -> st
         text = f"{run_name} – {title}"
     else:
         text = title
-    return f"{text} (DRAFT)" if draft else text
+    return text if is_final else f"{text} (NOT FINAL)"
 
 
 def _page(
     title: str,
     body: str,
     run_name: str = "",
-    draft: bool = False,
+    is_final: bool = True,
     description: str = "",
     *,
     is_run_home: bool = False,
@@ -116,13 +116,13 @@ def _page(
     compliance_note: str = "",
 ) -> str:
     banner_html = ""
-    if run_name or draft:
+    if run_name or not is_final:
         parts = []
-        if draft:
-            parts.append('<span class="draft-label">DRAFT</span>')
+        if not is_final:
+            parts.append('<span class="not-final-label">NOT FINAL</span>')
         if run_name:
             parts.append(f'<span class="run-name">{html.escape(run_name)}</span>')
-        classes = "banner draft" if draft else "banner"
+        classes = "banner" if is_final else "banner not-final"
         banner_html = f'<div class="{classes}">{" ".join(parts)}</div>\n'
     back_link_html = ""
     if back_link:
@@ -145,7 +145,7 @@ def _page(
         "<head>\n"
         '<meta charset="utf-8">\n'
         '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
-        f"<title>{html.escape(_head_title(title, run_name, draft, is_run_home))}</title>\n"
+        f"<title>{html.escape(_head_title(title, run_name, is_final, is_run_home))}</title>\n"
         f"<style>{_STYLE}</style>\n"
         "</head>\n"
         "<body>\n"
@@ -482,7 +482,7 @@ def generate_report(
     them, into output_dir.
 
     `spec` supplies everything about the season except the solved dates -- teams,
-    clubs, the run name/draft/description banners, each division's fixture scheme,
+    clubs, the run name/is_final/description banners, each division's fixture scheme,
     and any excluded_fixtures (withheld from scheduling entirely, to be arranged
     in a later run; these are appended to the bottom of every relevant table with
     "TBC" in place of a date). `result` is the solved schedule for that spec,
@@ -509,7 +509,7 @@ def generate_report(
     clubs = spec.clubs
     excluded_fixtures = spec.parameters.excluded_fixtures
     schemes = spec.parameters.division_schemes
-    name, draft, description = spec.name, spec.draft, spec.description
+    name, is_final, description = spec.name, spec.is_final, spec.description
 
     fixtures_by_division: dict[int, list[fmodel.ScheduledFixture]] = defaultdict(list)
     for sf in fixtures:
@@ -549,7 +549,7 @@ def generate_report(
             )
             + _venues_section(all_match_club_ids, clubs),
             name,
-            draft,
+            is_final,
             description,
             back_link=_RUN_INDEX_BACK_LINK,
             compliance_note=compliance_note,
@@ -580,7 +580,7 @@ def generate_report(
                 )
                 + _venues_section(division_club_ids, clubs),
                 name,
-                draft,
+                is_final,
                 description,
                 back_link=_RUN_INDEX_BACK_LINK,
                 compliance_note=compliance_note,
@@ -635,7 +635,7 @@ def generate_report(
                 club_name,
                 body,
                 name,
-                draft,
+                is_final,
                 description,
                 back_link=_RUN_INDEX_BACK_LINK,
                 compliance_note=compliance_note,
@@ -651,7 +651,7 @@ def generate_report(
             _run_index_body(all_matches_links, division_links, club_links)
             + _solver_diagnostics(result.model_stats, result.solve_stats),
             name,
-            draft,
+            is_final,
             description,
             is_run_home=True,
             compliance_note=compliance_note,

--- a/htmlreport_test.py
+++ b/htmlreport_test.py
@@ -39,7 +39,7 @@ def _generate(
     *,
     excluded_fixtures: Collection[fmodel.Fixture] = (),
     name: str = "",
-    draft: bool = False,
+    is_final: bool = True,
     description: str = "",
     division_schemes: Mapping[int, fmodel.FixtureScheme] | None = None,
     compliance_note: str = "",
@@ -57,7 +57,7 @@ def _generate(
         parameters=parameters,
         clubs=clubs,
         name=name,
-        draft=draft,
+        is_final=is_final,
         description=description,
     )
     return htmlreport.generate_report(
@@ -480,11 +480,11 @@ class TestGenerateReport(unittest.TestCase):
         content = (out2 / "club-lonely-fc.html").read_text()
         self.assertIn("No matches", content)
 
-    def test_no_name_or_draft_by_default(self) -> None:
+    def test_no_name_or_not_final_banner_for_final_runs(self) -> None:
         for filename in ["all-matches.html", "division-1.html", "club-harrow.html"]:
             content = (self.output_dir / filename).read_text()
             self.assertNotIn('class="banner"', content)
-            self.assertNotIn('class="draft-label"', content)
+            self.assertNotIn('class="not-final-label"', content)
         self.assertNotIn('class="banner"', self.index_path.read_text())
 
     def test_no_description_by_default(self) -> None:
@@ -493,7 +493,7 @@ class TestGenerateReport(unittest.TestCase):
             self.assertNotIn('class="description"', content)
         self.assertNotIn('class="description"', self.index_path.read_text())
 
-    def test_run_name_and_draft_shown_on_every_page(self) -> None:
+    def test_run_name_and_not_final_banner_shown_on_every_page(self) -> None:
         out2 = Path(self._tmpdir.name) / "out-named"
         index_path = _generate(
             fmodel.SolveResult(self.fixtures),
@@ -501,7 +501,7 @@ class TestGenerateReport(unittest.TestCase):
             self.clubs,
             out2,
             name="2025-26 Season",
-            draft=True,
+            is_final=False,
         )
         for filename in [
             "all-matches.html",
@@ -510,8 +510,8 @@ class TestGenerateReport(unittest.TestCase):
             index_path.name,
         ]:
             content = (out2 / filename).read_text()
-            self.assertIn('<div class="banner draft">', content)
-            self.assertIn('<span class="draft-label">DRAFT</span>', content)
+            self.assertIn('<div class="banner not-final">', content)
+            self.assertIn('<span class="not-final-label">NOT FINAL</span>', content)
             self.assertIn('<span class="run-name">2025-26 Season</span>', content)
 
     def test_description_shown_on_every_page(self) -> None:
@@ -563,7 +563,7 @@ class TestGenerateReport(unittest.TestCase):
             )
 
     def test_head_title_is_bare_page_title_without_a_run_name(self) -> None:
-        # setUp generates with no run name and draft=False.
+        # setUp generates with no run name and is_final=True.
         self.assertIn(
             "<title>All matches</title>",
             (self.output_dir / "all-matches.html").read_text(),
@@ -578,7 +578,7 @@ class TestGenerateReport(unittest.TestCase):
         )
         self.assertIn("<title>Fixtures</title>", self.index_path.read_text())
 
-    def test_head_title_carries_run_name_club_or_division_and_draft(self) -> None:
+    def test_head_title_carries_run_name_club_or_division_and_not_final(self) -> None:
         out2 = Path(self._tmpdir.name) / "out-head-title"
         index_path = _generate(
             fmodel.SolveResult(self.fixtures),
@@ -586,23 +586,25 @@ class TestGenerateReport(unittest.TestCase):
             self.clubs,
             out2,
             name="2025-26 Season",
-            draft=True,
+            is_final=False,
         )
-        self.assertIn("<title>2025-26 Season (DRAFT)</title>", index_path.read_text())
         self.assertIn(
-            "<title>2025-26 Season – All matches (DRAFT)</title>",
+            "<title>2025-26 Season (NOT FINAL)</title>", index_path.read_text()
+        )
+        self.assertIn(
+            "<title>2025-26 Season – All matches (NOT FINAL)</title>",
             (out2 / "all-matches.html").read_text(),
         )
         self.assertIn(
-            "<title>2025-26 Season – Division 1 (DRAFT)</title>",
+            "<title>2025-26 Season – Division 1 (NOT FINAL)</title>",
             (out2 / "division-1.html").read_text(),
         )
         self.assertIn(
-            "<title>2025-26 Season – Harrow (DRAFT)</title>",
+            "<title>2025-26 Season – Harrow (NOT FINAL)</title>",
             (out2 / "club-harrow.html").read_text(),
         )
 
-    def test_head_title_omits_draft_marker_for_non_draft_runs(self) -> None:
+    def test_head_title_omits_not_final_marker_for_final_runs(self) -> None:
         out2 = Path(self._tmpdir.name) / "out-head-title-final"
         index_path = _generate(
             fmodel.SolveResult(self.fixtures),
@@ -610,6 +612,7 @@ class TestGenerateReport(unittest.TestCase):
             self.clubs,
             out2,
             name="2025-26 Season",
+            is_final=True,
         )
         self.assertIn("<title>2025-26 Season</title>", index_path.read_text())
         self.assertIn(
@@ -625,7 +628,7 @@ class TestGenerateReport(unittest.TestCase):
             self.clubs,
             out2,
             name="2025-26 Season",
-            draft=True,
+            is_final=False,
         )
         content = index_path.read_text()
         self.assertIn(">All matches</a>", content)

--- a/runs/2026-27/draft1/spec.yaml
+++ b/runs/2026-27/draft1/spec.yaml
@@ -1,6 +1,5 @@
 # yaml-language-server: $schema=../../../spec-schema.json
 name: "2026-27 Season (attempt 1)"
-draft: true
 
 # Same-club "internal" fixtures (e.g. Hendon 1 v Hendon 2) must be settled by the
 # end of the calendar year, well before the rest of the fixture list.

--- a/runs/2026-27/draft2/spec.yaml
+++ b/runs/2026-27/draft2/spec.yaml
@@ -1,6 +1,5 @@
 # yaml-language-server: $schema=../../../spec-schema.json
 name: "2026-27 Season (attempt 2)"
-draft: true
 
 # Don't schedule matches before this, to make sure all clubs have time to raise teams.
 # Adam Cranston from Hammersmith expressed a preference to have a match on 2026-09-10 if possible

--- a/runs/2026-27/draft3/spec.yaml
+++ b/runs/2026-27/draft3/spec.yaml
@@ -1,6 +1,5 @@
 # yaml-language-server: $schema=../../../spec-schema.json
 name: "2026-27 Season (attempt 3)"
-draft: true
 
 # Don't schedule matches before the Fixtures Meeting.
 earliest_match_date: "2026-09-15"

--- a/runs/example/spec.yaml
+++ b/runs/example/spec.yaml
@@ -1,6 +1,5 @@
 # yaml-language-server: $schema=../../spec-schema.json
 name: "2025-26 Season"
-draft: true
 # This is a static reference example, not a live season, so its whole (long past)
 # season window is exempted from the default (today) earliest_match_date cutoff.
 earliest_match_date: "2025-01-01"

--- a/spec-schema.json
+++ b/spec-schema.json
@@ -12,10 +12,10 @@
       "default": "",
       "description": "Shown as a subtitle banner on every HTML report page (including index.html, which recovers it from one of the other report files). Defaults to no subtitle."
     },
-    "draft": {
+    "is_final": {
       "type": "boolean",
       "default": false,
-      "description": "If true, the name banner (see 'name') is made prominent and prefixed 'DRAFT'."
+      "description": "Set true once this is the finalised fixture list. While false (the default), every HTML report page carries a prominent 'NOT FINAL' banner and a '(NOT FINAL)' suffix in the page title."
     },
     "description": {
       "type": "string",

--- a/spec_schema_test.py
+++ b/spec_schema_test.py
@@ -37,7 +37,7 @@ _SCHEMA_PATH = Path(__file__).parent / "spec-schema.json"
 # drift check that new fields added to one aren't forgotten in the other.
 _FULL_EXAMPLE = """
 name: "2025-26 Season"
-draft: false
+is_final: true
 description: "Final schedule; refer to ECF LMS for authoritative dates."
 latest_internal_match_date: 2025-12-31
 


### PR DESCRIPTION
The old 'draft: true' opt-in became 'is_final: false' (the default): a spec now carries a prominent "NOT FINAL" banner and a "(NOT FINAL)" page title suffix on every HTML report page until it sets 'is_final: true'.

- fixturespec: Spec.draft -> Spec.is_final; top-level key renamed
- htmlreport: banner/title driven by 'not is_final'; .banner.draft ->
  .banner.not-final, .draft-label -> .not-final-label, "DRAFT" -> "NOT FINAL"; _page() defaults is_final=True so the runs index stays unbannered
- spec-schema.json, README: documented under the new key
- runs/*: dropped now-invalid 'draft: true' lines (default covers them)


Claude-Session: https://claude.ai/code/session_01TdvXBEacWngdayKScWwQmr