### PR TITLE
Add zizmor workflow; hash-pin actions and tighten workflow perms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, master]
 
+permissions:
+  contents: read
+
 jobs:
   code-quality:
     runs-on: ubuntu-latest
@@ -14,12 +17,14 @@ jobs:
         python-version: ["3.14"]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Install uv
         # Pinned to an exact version: setup-uv stopped publishing floating
         # major/minor tags (e.g. @v10) from v8 onwards for supply-chain safety.
-        uses: astral-sh/setup-uv@v10.0.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,12 +20,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Install uv
         # Pinned to an exact version: setup-uv stopped publishing floating
         # major/minor tags (e.g. @v10) from v8 onwards for supply-chain safety.
-        uses: astral-sh/setup-uv@v10.0.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           python-version: "3.14"
 
@@ -47,7 +49,7 @@ jobs:
         run: python3 build_schema_docs.py
 
       - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: _site
 
@@ -55,7 +57,7 @@ jobs:
         # A plain, easily downloadable copy of the built site so a reviewer can
         # inspect what a PR would publish before it's merged.
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: _site
           path: _site
@@ -75,4 +77,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,28 @@
+name: Lint GitHub Actions (zizmor)
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+# No workflow-level permissions; each job opts in to exactly what it needs.
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      # Let the action upload its SARIF results to the code-scanning dashboard.
+      security-events: write
+      # Needed to read the workflow files (and, on private repos, the SARIF
+      # upload).
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99 # v0.6.3


### PR DESCRIPTION
Adds .github/workflows/zizmor.yml, which lints the repo's GitHub Actions workflows with the official zizmorcore/zizmor-action on push/PR to main/master.

Fixes every finding zizmor reports on the existing workflows:

- artipacked: set persist-credentials: false on both actions/checkout steps (neither workflow does git writes).
- excessive-permissions: add a top-level permissions: contents: read to ci.yml, matching pages.yml.
- unpinned-uses: pin every action to a full commit SHA, keeping a version comment.

Also bumps actions/upload-artifact 4.6.2 -> 7.0.1 (the only action with a newer release; the v5/v6/v7 runtime bumps don't affect the _site directory upload here). checkout, setup-uv, upload-pages-artifact and deploy-pages are already at their latest release.


Claude-Session: https://claude.ai/code/session_01XpLTn5sQLUVaoX27RDZ7yP