### PR TITLE
Replace latest_match_date/earliest_match_date with match_count_limits (#106)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,13 +191,16 @@ entry is how a club (or, scoped with `teams: [...]`, one of its teams) says it
 can't play away on those dates; the `venue_scope: home` form says a team can't
 host; and a whole-club `matches: {max: 0}` `date_ranges` entry under `defaults`
 is how a spec-wide "nobody plays these dates" block (e.g. Christmas) is
-expressed. Every spec-wide default entry carries a unique `override_key`; a club
-entry repeating one replaces that default for the club, and a club entry with no
-`override_key` is additive.
+expressed. A `date_ranges` entry left open-ended on one side -- `{end_date:
+...}` or `{start_date: ...}` -- with `matches: {max: 0}` is in turn how a
+season start (as a `defaults` block) or a club's early end of season (a per-club
+entry) is set. Every spec-wide default entry carries a unique `override_key`; a
+club entry repeating one replaces that default for the club, and a club entry
+with no `override_key` is additive.
 
 That's only a fraction of what the format supports -- pinned and withheld
-fixtures, per-club match-date cutoffs, and more. For the full field-by-field
-reference, see:
+fixtures, season-boundary and per-club date cutoffs, and more. For the full
+field-by-field reference, see:
 
 - **[spec-schema.json](spec-schema.json)**, the JSON Schema every field is
   defined in (rendered to a browsable reference page at

--- a/build_site_test.py
+++ b/build_site_test.py
@@ -25,7 +25,6 @@ import solve
 
 _SPEC = """
 name: "{name}"
-earliest_match_date: 2025-01-01
 
 clubs:
   albany:
@@ -74,7 +73,8 @@ def _make_run(run_dir: Path, name: str) -> None:
     run_dir.mkdir(parents=True, exist_ok=True)
     spec_path = run_dir / "spec.yaml"
     spec_path.write_text(_SPEC.format(name=name))
-    solve.solve(spec_path, run_dir)
+    # _SPEC's home dates are in the past; these fixtures are reference-only.
+    solve.solve(spec_path, run_dir, allow_past_matches=True)
 
 
 class TestFindRunSpecs(unittest.TestCase):

--- a/fixturespec.py
+++ b/fixturespec.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import dataclasses
 import hashlib
 import itertools
-import logging
 from collections.abc import Mapping
 from datetime import date, datetime
 from pathlib import Path
@@ -32,8 +31,6 @@ from typing import Any
 import yaml
 
 import fmodel
-
-logger = logging.getLogger(__name__)
 
 
 class SpecError(ValueError):
@@ -349,7 +346,6 @@ def _parse_home_dates_used_value(
 _CLUB_CONSTRAINT_FIELD_KEYS = {
     "home_dates",
     "home_dates_used",
-    "latest_match_date",
     "match_count_limits",
 }
 
@@ -371,9 +367,8 @@ _MATCH_COUNT_MEASURE_FIELD_KEYS = {"max", "max_overrides", "min", "min_overrides
 _HOME_DATES_USED_FIELD_KEYS = {"min", "max"}
 
 # match_count_limits is the one constraint type accepted under 'defaults' (a
-# spec-wide list applied to every club). The rest (home_dates, home_dates_used,
-# latest_match_date) are inherently per-club and have no meaningful spec-wide
-# default.
+# spec-wide list applied to every club). The rest (home_dates, home_dates_used)
+# are inherently per-club and have no meaningful spec-wide default.
 _CLUB_CONSTRAINT_DEFAULTS_KEYS = {"match_count_limits"}
 
 _TOP_LEVEL_KEYS = {
@@ -381,7 +376,6 @@ _TOP_LEVEL_KEYS = {
     "is_final",
     "description",
     "latest_internal_match_date",
-    "earliest_match_date",
     "clubs",
     "teams",
     "divisions",
@@ -435,7 +429,6 @@ class _ParsedMatchCountLimit:
 @dataclasses.dataclass(frozen=True)
 class _ClubConstraints:
     home_dates: dict[str, list[date]]
-    club_latest_match_date: dict[str, date]
     home_dates_used: dict[str, fmodel.HomeDatesUsedBounds]
     match_count_limits: list[fmodel.MatchLimit]
 
@@ -446,13 +439,15 @@ def _parse_club_constraints(
     teams: Mapping[str, fmodel.Team],
     path: Path,
 ) -> _ClubConstraints:
-    """Parse the 'club_constraints' section: per-club home_dates, home_dates_used,
-    latest_match_date and match_count_limits, keyed directly by club ID.
+    """Parse the 'club_constraints' section: per-club home_dates, home_dates_used
+    and match_count_limits, keyed directly by club ID.
 
-    A club's optional 'latest_match_date' entry is the last date on which any fixture
-    involving one of that club's teams -- home or away -- may be scheduled (a
-    fixed_fixtures entry involving the club after it is an error). It has no spec-wide
-    default, so it isn't accepted under 'defaults'.
+    A club whose venue or players stop being available partway through the season
+    expresses that as a match_count_limits entry with 'matches: {max: 0}' and an
+    open-ended 'date_ranges' ({start_date: <first unavailable date>}); a spec-wide
+    "no play before the season starts" block is the same shape as a
+    club_constraints.defaults entry ({end_date: <last pre-season date>}), which an
+    individual club can move or cancel via its 'override_key'.
 
     An optional 'defaults' entry (a sibling of the club entries) supplies a spec-wide
     'match_count_limits' list applied to every club. Every defaults entry carries a
@@ -494,7 +489,6 @@ def _parse_club_constraints(
         )
 
     home_dates: dict[str, list[date]] = {}
-    club_latest_match_date: dict[str, date] = {}
     home_dates_used: dict[str, fmodel.HomeDatesUsedBounds] = {}
     club_limits: dict[str, list[_ParsedMatchCountLimit]] = {}
 
@@ -513,12 +507,6 @@ def _parse_club_constraints(
             club_spec.get("home_dates"),
             f"{path}: {section_name}[{club_id!r}].home_dates",
         )
-
-        if "latest_match_date" in club_spec:
-            club_latest_match_date[club_id] = _parse_date(
-                club_spec["latest_match_date"],
-                f"{path}: {section_name}[{club_id!r}].latest_match_date",
-            )
 
         if "home_dates_used" in club_spec:
             home_dates_used[club_id] = _parse_home_dates_used_value(
@@ -539,7 +527,6 @@ def _parse_club_constraints(
 
     return _ClubConstraints(
         home_dates=home_dates,
-        club_latest_match_date=club_latest_match_date,
         home_dates_used=home_dates_used,
         match_count_limits=match_count_limits,
     )
@@ -786,10 +773,14 @@ def _parse_match_count_limits(
         but not both. When given, the rule applies to exactly those ranges
         instead of every rolling 'time_window_days' window. Allowed on both club
         and 'defaults' entries; not combinable with 'time_window_days' or any
-        '*_overrides', nor (on a club entry) with 'override_key'. 'matches.max'
-        must then be a non-negative integer (0 bars every counted match in the
-        range -- a whole-club, all-teams 'defaults' entry with 'matches: {max: 0}'
-        is how a spec-wide "nobody plays these dates" block is expressed).
+        '*_overrides'. May carry an 'override_key' on a club entry -- the club
+        then replaces the like-keyed default with this ranged rule (e.g. a
+        club that starts its season later than the spec-wide 'season-start'
+        block). 'matches.max' must be a non-negative integer (0 bars every
+        counted match in the range -- a whole-club, all-teams 'defaults' entry
+        with 'matches: {max: 0}' is how a spec-wide "nobody plays these dates"
+        block, or an open-ended one a "no play before the season starts" block,
+        is expressed).
       - 'dates' (optional): a non-empty list of individual dates, sugar for a
         'date_ranges' list of one single-day range per date -- the tidy way to
         pin a scattered set of dates rather than a contiguous span (e.g. the
@@ -803,7 +794,10 @@ def _parse_match_count_limits(
         cap. Not combinable with 'date_ranges'/'dates'.
       - 'override_key': required for a 'defaults' entry (and unique within that
         list); optional for a club entry, where it names the default this one
-        replaces for the club wholesale.
+        replaces for the club wholesale. On a club entry it can't be combined
+        with 'teams' (an override replaces a spec-wide, all-teams default), but
+        the replacement may be a 'date_ranges' rule (or a bare 'override_key'
+        with nothing else, which just cancels the default).
     """
     if entries_spec is None:
         return []
@@ -982,13 +976,6 @@ def _parse_match_count_limits(
 
         date_ranges: tuple[fmodel.DateRange, ...] = ()
         if has_date_ranges:
-            if not is_defaults and override_key is not None:
-                raise SpecError(
-                    f"{entry_context}: a club entry can't combine {dr_key!r} "
-                    "with 'override_key' (an override_key names a rolling default "
-                    "to replace wholesale; on a defaults entry it is the entry's "
-                    f"own key and {dr_key!r} is fine)"
-                )
             if "time_window_days" in entry:
                 raise SpecError(
                     f"{entry_context}: {dr_key!r} and 'time_window_days' can't "
@@ -1436,8 +1423,6 @@ def load_spec(spec_path: str | Path) -> Spec:
     home_dates = club_constraints.home_dates
 
     kwargs: dict[str, Any] = {}
-    if club_constraints.club_latest_match_date:
-        kwargs["club_latest_match_date"] = club_constraints.club_latest_match_date
     if club_constraints.home_dates_used:
         kwargs["home_dates_used"] = club_constraints.home_dates_used
     if club_constraints.match_count_limits:
@@ -1476,31 +1461,6 @@ def load_spec(spec_path: str | Path) -> Spec:
                     "latest_internal_match_date"
                 )
         kwargs["latest_internal_match_date"] = latest_internal_match_date
-
-    if "earliest_match_date" in data:
-        earliest_match_date = _parse_date(
-            data["earliest_match_date"], f"{path}: 'earliest_match_date'"
-        )
-    else:
-        earliest_match_date = date.today()
-    if earliest_match_date < date.today():
-        logger.warning(
-            "%s: earliest_match_date %s is in the past",
-            path,
-            earliest_match_date.isoformat(),
-        )
-    kwargs["earliest_match_date"] = earliest_match_date
-
-    for sf in fixed_fixtures:
-        for team in (sf.fixture.home_team, sf.fixture.away_team):
-            cutoff = club_constraints.club_latest_match_date.get(team.club)
-            if cutoff is not None and sf.date > cutoff:
-                raise SpecError(
-                    f"{path}: fixed_fixtures entry {sf.fixture.home_team.name} vs "
-                    f"{sf.fixture.away_team.name} on {sf.date.isoformat()} is after "
-                    f"club_constraints[{team.club!r}].latest_match_date "
-                    f"({cutoff.isoformat()})"
-                )
 
     parameters = fmodel.Parameters(
         teams=list(teams.values()),

--- a/fixturespec_test.py
+++ b/fixturespec_test.py
@@ -63,14 +63,9 @@ def _cap_overrides(cap: fmodel.Cap | None) -> Mapping[date, int | None]:
 # existing one would create a duplicate top-level YAML key, which PyYAML resolves by
 # silently letting the later one clobber the earlier one).
 #
-# Pins earliest_match_date well before every home_dates entry below, so tests that
-# solve() end-to-end aren't affected by the default (today) cutoff excluding these
-# fixed 2025 dates as time passes; tests of earliest_match_date itself override or
-# strip this line instead of appending a second one (a duplicate top-level key, as
-# above).
+# The spec no longer carries any implicit earliest-date cutoff, so the fixed 2025
+# home dates below stay usable however far into the future the tests run.
 _BOILERPLATE = """
-earliest_match_date: 2025-01-01
-
 clubs:
   albany:
     name: Albany
@@ -131,10 +126,7 @@ _MINIMAL_SPEC = (
 
 # A three-team spec (two Albany teams plus Hackney) for exclude_fixtures tests, which
 # need a division where excluding one team/club still leaves other fixtures behind.
-# See _BOILERPLATE above for why earliest_match_date is pinned here too.
 _THREE_TEAM_SPEC = """
-earliest_match_date: 2025-01-01
-
 clubs:
   albany:
     name: Albany
@@ -335,50 +327,12 @@ class TestLoadSpec(unittest.TestCase):
         with self.assertRaisesRegex(fixturespec.SpecError, "not-a-date"):
             fixturespec.load_spec(path)
 
-    def test_earliest_match_date_defaults_to_today(self) -> None:
-        path = self._write(
-            _MINIMAL_SPEC.replace("earliest_match_date: 2025-01-01\n", "")
-        )
-        spec = fixturespec.load_spec(path)
-        self.assertEqual(spec.parameters.earliest_match_date, date.today())
-
-    def test_earliest_match_date_parsed(self) -> None:
-        path = self._write(
-            _MINIMAL_SPEC.replace(
-                "earliest_match_date: 2025-01-01", "earliest_match_date: 2030-01-01"
-            )
-        )
-        spec = fixturespec.load_spec(path)
-        self.assertEqual(spec.parameters.earliest_match_date, date(2030, 1, 1))
-
-    def test_earliest_match_date_invalid(self) -> None:
-        path = self._write(
-            _MINIMAL_SPEC.replace(
-                "earliest_match_date: 2025-01-01", "earliest_match_date: not-a-date"
-            )
-        )
-        with self.assertRaisesRegex(fixturespec.SpecError, "not-a-date"):
-            fixturespec.load_spec(path)
-
-    def test_earliest_match_date_in_the_past_logs_a_warning(self) -> None:
-        path = self._write(
-            _MINIMAL_SPEC.replace(
-                "earliest_match_date: 2025-01-01", "earliest_match_date: 2020-01-01"
-            )
-        )
-        with self.assertLogs(fixturespec.logger, level="WARNING") as cm:
-            fixturespec.load_spec(path)
-        self.assertIn("2020-01-01", cm.output[0])
-        self.assertIn("in the past", cm.output[0])
-
-    def test_earliest_match_date_today_does_not_log_a_warning(self) -> None:
-        path = self._write(
-            _MINIMAL_SPEC.replace(
-                "earliest_match_date: 2025-01-01",
-                f"earliest_match_date: {date.today().isoformat()}",
-            )
-        )
-        with self.assertNoLogs(fixturespec.logger, level="WARNING"):
+    def test_earliest_match_date_key_no_longer_recognised(self) -> None:
+        # earliest_match_date was removed (issue #106): a season-start cutoff is
+        # now a club_constraints.defaults matches: {max: 0} entry with an
+        # open-ended date_range, so the old top-level key is an unknown field.
+        path = self._write(_MINIMAL_SPEC + "earliest_match_date: 2025-01-01\n")
+        with self.assertRaisesRegex(fixturespec.SpecError, "earliest_match_date"):
             fixturespec.load_spec(path)
 
     def test_avoid_dates_key_no_longer_recognised(self) -> None:
@@ -907,24 +861,36 @@ class TestLoadSpec(unittest.TestCase):
         with self.assertRaisesRegex(fixturespec.SpecError, "max_overrides"):
             fixturespec.load_spec(path)
 
-    def test_match_count_limits_date_ranges_reject_override_key(self) -> None:
+    def test_match_count_limits_date_ranges_with_override_key_replaces_default(
+        self,
+    ) -> None:
+        # A club may replace a like-keyed default with its own date_ranges rule --
+        # e.g. a club whose season runs later than the spec-wide 'season-start'
+        # block. The default is dropped for that club; the ranged rule takes over.
         path = self._write(
             _BOILERPLATE + "club_constraints:\n"
             "  defaults:\n"
             "    match_count_limits:\n"
-            "      - override_key: venue-capacity\n"
-            "        venue_scope: home\n"
-            "        matches:\n          max: 1\n"
+            "      - override_key: season-start\n"
+            "        matches:\n          max: 0\n"
+            "        date_ranges:\n"
+            "          - end_date: 2025-08-31\n"
             "  albany:\n"
             "    match_count_limits:\n"
-            "      - override_key: venue-capacity\n"
-            "        matches:\n          max: 1\n"
+            "      - override_key: season-start\n"
+            "        matches:\n          max: 0\n"
             "        date_ranges:\n"
-            "          - start_date: 2025-10-27\n"
-            "            end_date: 2025-11-02\n"
+            "          - end_date: 2025-08-15\n"
         )
-        with self.assertRaisesRegex(fixturespec.SpecError, "date_ranges"):
-            fixturespec.load_spec(path)
+        spec = fixturespec.load_spec(path)
+        by_club: dict[str, list[fmodel.DateRange]] = {}
+        for limit in spec.parameters.match_count_limits:
+            assert isinstance(limit, fmodel.RangeLimit)
+            for team in limit.teams:
+                by_club.setdefault(team.club, []).extend(limit.ranges)
+        # albany's own end_date wins; hackney keeps the default's.
+        self.assertEqual(by_club["albany"], [fmodel.DateRange(end=date(2025, 8, 15))])
+        self.assertEqual(by_club["hackney"], [fmodel.DateRange(end=date(2025, 8, 31))])
 
     def test_match_count_limits_date_ranges_allowed_under_defaults(self) -> None:
         # A defaults entry may carry date_ranges; its own override_key is the
@@ -2207,28 +2173,34 @@ club_constraints:
         ):
             fixturespec.load_spec(path)
 
-    def test_club_latest_match_date_parsed(self) -> None:
-        """A per-club latest_match_date lands in Parameters.club_latest_match_date,
-        keyed by club, and only for the clubs that set one."""
+    def test_club_latest_match_date_key_no_longer_recognised(self) -> None:
+        # A per-club latest_match_date was removed (issue #106): an end-of-season
+        # cutoff is now a match_count_limits entry with matches: {max: 0} over an
+        # open-ended date_range, so the old per-club key is an unknown field.
         path = self._write(
             _MINIMAL_SPEC_NO_CONCURRENCY + "    latest_match_date: 2025-09-20\n"
         )
-        spec = fixturespec.load_spec(path)
-        self.assertEqual(
-            spec.parameters.club_latest_match_date, {"hackney": date(2025, 9, 20)}
-        )
-
-    def test_club_latest_match_date_absent(self) -> None:
-        path = self._write(_MINIMAL_SPEC)
-        spec = fixturespec.load_spec(path)
-        self.assertEqual(spec.parameters.club_latest_match_date, {})
-
-    def test_club_latest_match_date_invalid(self) -> None:
-        path = self._write(
-            _MINIMAL_SPEC_NO_CONCURRENCY + "    latest_match_date: not-a-date\n"
-        )
         with self.assertRaisesRegex(fixturespec.SpecError, "latest_match_date"):
             fixturespec.load_spec(path)
+
+    def test_club_end_of_season_via_open_ended_date_range(self) -> None:
+        """The successor to a per-club latest_match_date: a match_count_limits
+        entry with matches: {max: 0} over a date_range open-ended at the end
+        resolves to a RangeLimit barring every counted match from that date on."""
+        path = self._write(
+            _MINIMAL_SPEC_NO_CONCURRENCY + "    match_count_limits:\n"
+            "      - matches: {max: 0}\n"
+            "        date_ranges:\n"
+            "          - {start_date: 2025-09-20}\n"
+        )
+        spec = fixturespec.load_spec(path)
+        limits = spec.parameters.match_count_limits
+        self.assertEqual(len(limits), 1)
+        (limit,) = limits
+        assert isinstance(limit, fmodel.RangeLimit)
+        self.assertEqual(limit.ranges, (fmodel.DateRange(start=date(2025, 9, 20)),))
+        self.assertEqual(limit.match_max, fmodel.Cap(base=0))
+        self.assertEqual({t.club for t in limit.teams}, {"hackney"})
 
     def test_fixed_fixture(self) -> None:
         path = self._write(
@@ -2249,32 +2221,6 @@ club_constraints:
                 )
             ],
         )
-
-    def test_fixed_fixture_before_earliest_match_date_still_solves(self) -> None:
-        """A fixed_fixtures entry dated before earliest_match_date is not rejected,
-        and the solver still places it there -- the cutoff only excludes candidate
-        dates for newly scheduled fixtures, not fixtures already pinned down. Albany's
-        other home date (2025-09-29) is on/after the cutoff, so its own (unfixed)
-        fixture against Hackney still has somewhere to land."""
-        path = self._write(
-            _MINIMAL_SPEC.replace(
-                "earliest_match_date: 2025-01-01", "earliest_match_date: 2025-09-20"
-            )
-            + "fixed_fixtures:\n"
-            "  - home: hackney-1\n"
-            "    away: albany-1\n"
-            "    date: 2025-09-15\n"
-        )
-        spec = fixturespec.load_spec(path)
-        self.assertEqual(spec.parameters.earliest_match_date, date(2025, 9, 20))
-        hackney_1 = next(t for t in spec.parameters.teams if t.club == "hackney")
-        albany_1 = next(t for t in spec.parameters.teams if t.club == "albany")
-        fixed = fmodel.ScheduledFixture(
-            fixture=fmodel.Fixture(home_team=hackney_1, away_team=albany_1),
-            date=date(2025, 9, 15),
-        )
-        fixtures = list(fmodel.solve(spec.parameters).fixtures)
-        self.assertIn(fixed, fixtures)
 
     def test_fixed_fixtures_absent(self) -> None:
         path = self._write(_MINIMAL_SPEC)
@@ -2903,54 +2849,69 @@ club_constraints:
         for sf in internal:
             self.assertLessEqual(sf.date, date(2025, 10, 15))
 
-    def test_club_latest_match_date_conflicts_with_fixed_fixture_home_team(
+    # The successor to a per-club latest_match_date is a match_count_limits entry
+    # with matches: {max: 0} over a date_range open-ended at the end. Unlike the
+    # old cutoff it does not exempt fixed_fixtures, so a pin past it is caught at
+    # model-build time rather than by load_spec().
+    @staticmethod
+    def _club_end_of_season(start: str) -> str:
+        return (
+            "    match_count_limits:\n"
+            "      - matches: {max: 0}\n"
+            "        date_ranges:\n"
+            f"          - {{start_date: {start}}}\n"
+        )
+
+    def test_fixed_fixture_after_club_end_of_season_blackout_home_team(
         self,
     ) -> None:
         path = self._write(
-            _THREE_TEAM_SPEC + "    latest_match_date: 2026-01-15\n"
-            "fixed_fixtures:\n"
+            _THREE_TEAM_SPEC
+            + self._club_end_of_season("2026-01-16")
+            + "fixed_fixtures:\n"
             "  - home: hackney-1\n"
             "    away: albany-1\n"
             "    date: 2026-02-01\n"
         )
-        with self.assertRaisesRegex(
-            fixturespec.SpecError, r"is after club_constraints\['hackney'\]"
-        ):
-            fixturespec.load_spec(path)
+        spec = fixturespec.load_spec(path)
+        with self.assertRaisesRegex(ValueError, "not schedulable on that date"):
+            fmodel.solve(spec.parameters)
 
-    def test_club_latest_match_date_conflicts_with_fixed_fixture_away_team(
+    def test_fixed_fixture_after_club_end_of_season_blackout_away_team(
         self,
     ) -> None:
-        """The cutoff also rejects a fixed fixture where the club plays away."""
+        """The blackout also bars a fixed fixture where the club plays away."""
+        # hackney gets two home dates before the blackout so its own hosted
+        # fixtures stay schedulable and the solve reaches the fixed-fixtures check.
         path = self._write(
-            _THREE_TEAM_SPEC + "    latest_match_date: 2025-11-15\n"
-            "fixed_fixtures:\n"
+            _THREE_TEAM_SPEC.replace(
+                "home_dates: [2026-01-01, 2026-02-01]",
+                "home_dates: [2025-10-15, 2025-11-08]",
+            )
+            + self._club_end_of_season("2025-11-16")
+            + "fixed_fixtures:\n"
             "  - home: albany-1\n"
             "    away: hackney-1\n"
             "    date: 2025-12-01\n"
         )
-        with self.assertRaisesRegex(
-            fixturespec.SpecError, r"is after club_constraints\['hackney'\]"
-        ):
-            fixturespec.load_spec(path)
+        spec = fixturespec.load_spec(path)
+        with self.assertRaisesRegex(ValueError, "not schedulable on that date"):
+            fmodel.solve(spec.parameters)
 
-    def test_club_latest_match_date_solves_end_to_end(self) -> None:
-        """A cutoff that still leaves hackney a usable home date solves, with every
-        hackney fixture on or before the cutoff."""
+    def test_club_end_of_season_blackout_solves_end_to_end(self) -> None:
+        """A blackout that still leaves hackney a usable home date solves, with
+        every hackney fixture before it."""
         # hackney-1 hosts two required home fixtures (v albany-1 and v albany-2), and
-        # a team may only play once per date, so needs two usable home dates within
-        # the cutoff -- an extra one is added here beyond _THREE_TEAM_SPEC's own.
+        # a team may only play once per date, so needs two usable home dates before
+        # the blackout -- an extra one is added here beyond _THREE_TEAM_SPEC's own.
         path = self._write(
             _THREE_TEAM_SPEC.replace(
                 "home_dates: [2026-01-01, 2026-02-01]",
                 "home_dates: [2025-12-18, 2026-01-01, 2026-02-01]",
             )
-            + "    latest_match_date: 2026-01-15\n"
+            + self._club_end_of_season("2026-01-16")
         )
         spec = fixturespec.load_spec(path)
-        self.assertEqual(
-            spec.parameters.club_latest_match_date, {"hackney": date(2026, 1, 15)}
-        )
         fixtures = list(fmodel.solve(spec.parameters).fixtures)
         hackney_fixtures = [
             sf
@@ -2961,14 +2922,15 @@ club_constraints:
             len(hackney_fixtures), 4
         )  # hackney-1 home and away vs each albany
         for sf in hackney_fixtures:
-            self.assertLessEqual(sf.date, date(2026, 1, 15))
+            self.assertLess(sf.date, date(2026, 1, 16))
 
-    def test_club_latest_match_date_before_all_its_home_dates_is_infeasible(
+    def test_club_end_of_season_blackout_before_all_home_dates_is_infeasible(
         self,
     ) -> None:
-        """A cutoff before every hackney home date leaves the hackney-hosted
-        fixtures with no schedulable date -- required, so solve() raises."""
-        path = self._write(_THREE_TEAM_SPEC + "    latest_match_date: 2025-12-31\n")
+        """A blackout starting before every hackney home date leaves the
+        hackney-hosted fixtures with no schedulable date -- required, so solve()
+        raises."""
+        path = self._write(_THREE_TEAM_SPEC + self._club_end_of_season("2025-12-31"))
         spec = fixturespec.load_spec(path)
         with self.assertRaisesRegex(ValueError, "no schedulable date"):
             fmodel.solve(spec.parameters)

--- a/fmodel.py
+++ b/fmodel.py
@@ -734,23 +734,6 @@ class Parameters:
     fixed_fixtures: Collection[ScheduledFixture] = ()
     excluded_fixtures: Collection[Fixture] = ()
     latest_internal_match_date: date | None = None
-    # Excludes candidate dates before this one from newly scheduled fixtures -- e.g.
-    # so re-running the solver after some home dates have already passed doesn't
-    # place a fixture in the past. Unlike latest_internal_match_date, a fixed_fixtures
-    # entry dated before this cutoff is *not* rejected: fixed_fixtures records matches
-    # that are already committed (possibly already played), so an old date there is
-    # expected, not an error, and must keep solving correctly however far into the
-    # season this is re-run.
-    earliest_match_date: date | None = None
-    # Per-club cutoff: no fixture involving one of a listed club's teams -- home or
-    # away -- may be scheduled after that club's date here. A club with no entry has
-    # no such cutoff. Unlike latest_internal_match_date this covers every match the
-    # club plays, not just same-club derbies; like it (and unlike earliest_match_date)
-    # a fixed_fixtures entry past a club's cutoff is a contradiction, rejected by
-    # fixturespec.load_spec().
-    club_latest_match_date: Mapping[ClubT, date] = dataclasses.field(
-        default_factory=dict
-    )
     # The one match-count / availability mechanism. Dates a club (or one of its
     # teams) can't play away, or a team can't host, are a `match_max=Cap(0)`
     # RangeLimit with the relevant `venue_scope` and `teams` -- see
@@ -804,11 +787,6 @@ class Parameters:
             )
             for number, division_teams in by_number.items()
         )
-
-    def latest_match_date_for(self, team: Team) -> date | None:
-        """The last date `team` may play any match, home or away: its club's
-        club_latest_match_date entry, or None if the club has no such cutoff."""
-        return self.club_latest_match_date.get(team.club)
 
 
 def date_windows(dates: Collection[date], window_days: int) -> list[frozenset[date]]:
@@ -1030,10 +1008,11 @@ def _add_fixed_fixtures_constraints(
                 "(check that the two teams are in the same division, that the date "
                 "is a home date for the home team's club, that no "
                 "match_count_limits entry bars it on that date (a club/team "
-                "away or home blackout, or a spec-wide no-play block), that the "
-                "fixture isn't also in excluded_fixtures, that the date isn't after "
-                "either club's latest_match_date, and -- if the two teams share a "
-                "club -- that the date isn't after latest_internal_match_date)"
+                "away or home blackout, a spec-wide no-play block, or an "
+                "open-ended date_ranges cutoff standing in for a season "
+                "start/end), that the fixture isn't also in excluded_fixtures, "
+                "and -- if the two teams share a club -- that the date isn't "
+                "after latest_internal_match_date)"
             )
         model.add(var == 1)
 
@@ -1045,7 +1024,6 @@ def _build_model(params: Parameters) -> tuple[cp_model.CpModel, _FixtureVars]:
     fixture_vars = _FixtureVars()
 
     excluded = set(params.excluded_fixtures)
-    fixed_fixture_keys = {(sf.fixture, sf.date) for sf in params.fixed_fixtures}
 
     required_fixtures = [
         fixture
@@ -1071,24 +1049,13 @@ def _build_model(params: Parameters) -> tuple[cp_model.CpModel, _FixtureVars]:
                 and match_date > params.latest_internal_match_date
             ):
                 continue
-            home_cutoff = params.latest_match_date_for(home_team)
-            away_cutoff = params.latest_match_date_for(away_team)
-            if home_cutoff is not None and match_date > home_cutoff:
-                continue
-            if away_cutoff is not None and match_date > away_cutoff:
-                continue
-            if (
-                params.earliest_match_date is not None
-                and match_date < params.earliest_match_date
-                and (fixture, match_date) not in fixed_fixture_keys
-            ):
-                continue
             # A match_count_limits entry with an effective cap of 0 over this date
-            # (e.g. a spec-wide "nobody plays these dates" block, or a club/team
-            # away or home blackout) makes the candidate a certain zero -- don't
-            # create a variable for it. Unlike earliest_match_date this is not
-            # waived for fixed_fixtures: a fixture pinned onto a barred date is a
-            # real contradiction, and _add_fixed_fixtures_constraints reports it
+            # (e.g. a spec-wide "nobody plays these dates" block, a club/team
+            # away or home blackout, or an open-ended date_ranges cutoff standing
+            # in for a season start/end) makes the candidate a certain zero --
+            # don't create a variable for it. This is not waived for
+            # fixed_fixtures: a fixture pinned onto a barred date is a real
+            # contradiction, and _add_fixed_fixtures_constraints reports it
             # clearly.
             forbidding = [
                 limit
@@ -1126,10 +1093,10 @@ def _build_model(params: Parameters) -> tuple[cp_model.CpModel, _FixtureVars]:
         raise ValueError(
             f"{len(unschedulable)} required fixture(s) have no schedulable date: "
             f"{shown}. For each, every home date of the home team's club is ruled "
-            "out for that fixture -- by a latest_match_date / "
-            "latest_internal_match_date / earliest_match_date cutoff, or a "
-            "match_count_limits entry barring all play on those dates (a club or "
-            "team away/home blackout, or a spec-wide no-play block). Add a usable "
+            "out for that fixture -- by the latest_internal_match_date cutoff, or "
+            "a match_count_limits entry barring all play on those dates (a club or "
+            "team away/home blackout, a spec-wide no-play block, or an open-ended "
+            "date_ranges cutoff standing in for a season start/end). Add a usable "
             "date, or exclude the fixture."
         )
 

--- a/model_test.py
+++ b/model_test.py
@@ -839,23 +839,38 @@ class TestLatestInternalMatchDate(unittest.TestCase):
         self.assertTrue(internal_dates)
 
 
-class TestClubLatestMatchDate(unittest.TestCase):
-    """Test cases for the per-club club_latest_match_date cutoff.
+class TestClubEndOfSeasonBlackout(unittest.TestCase):
+    """A club's start-late / end-early cutoff is a match_count_limits entry: a
+    match_max=Cap(0) RangeLimit over every one of the club's teams, across a
+    DateRange left open-ended on one side. venue_scope ALL makes it reach every
+    fixture an A team is in -- hosted by A or not -- and, unlike the removed
+    club_latest_match_date / earliest_match_date cutoffs, it does not exempt
+    fixed_fixtures.
 
     Division 1 here has 3 teams (A1, A2, B1). Club A hosts 4 mutually-conflicting
     fixtures (A1 v A2, A2 v A1, A1 v B1, A2 v B1 -- any two share a team), so club
     A's home_dates below has slack (6 dates) beyond that minimum of 4, leaving room
-    for a cutoff to remove some and still solve.
+    for the blackout to remove some and still solve.
     """
+
+    _A_TEAMS = [
+        fmodel.Team(division=1, club="A", index=1),
+        fmodel.Team(division=1, club="A", index=2),
+    ]
+
+    @classmethod
+    def _blackout_from(cls, start: date) -> fmodel.RangeLimit:
+        """A whole-club end-of-season blackout: no A fixture on or after `start`."""
+        return fmodel.RangeLimit(
+            teams=list(cls._A_TEAMS),
+            match_max=fmodel.Cap(0),
+            ranges=(fmodel.DateRange(start=start),),
+        )
 
     def _params(
         self, *, b_home_dates: list[date] | None = None, **kwargs: Any
     ) -> fmodel.Parameters:
-        teams = [
-            fmodel.Team(division=1, club="A", index=1),
-            fmodel.Team(division=1, club="A", index=2),
-            fmodel.Team(division=1, club="B", index=1),
-        ]
+        teams = [*self._A_TEAMS, fmodel.Team(division=1, club="B", index=1)]
         home_dates = {
             "A": [
                 date(2025, 1, 1),
@@ -875,8 +890,8 @@ class TestClubLatestMatchDate(unittest.TestCase):
             **kwargs,
         )
 
-    # B offers both early dates (playable within A's cutoff) and late ones, so the
-    # scenario stays feasible and the tests can check that A's cutoff pulls the
+    # B offers both early dates (playable within A's blackout) and late ones, so the
+    # scenario stays feasible and the tests can check that A's blackout pulls the
     # B-hosted fixtures against A onto the early dates.
     _B_EARLY_AND_LATE = [
         date(2025, 1, 15),
@@ -885,12 +900,12 @@ class TestClubLatestMatchDate(unittest.TestCase):
         date(2025, 6, 1),
     ]
 
-    def test_cutoff_limits_every_fixture_the_club_is_in(self) -> None:
-        """A cutoff on club A keeps every fixture involving an A team -- hosted by
-        A or not -- on or before it."""
+    def test_blackout_limits_every_fixture_the_club_is_in(self) -> None:
+        """A blackout on club A keeps every fixture involving an A team -- hosted by
+        A or not -- before it."""
         params = self._params(
             b_home_dates=self._B_EARLY_AND_LATE,
-            club_latest_match_date={"A": date(2025, 2, 8)},
+            match_count_limits=[self._blackout_from(date(2025, 2, 9))],
         )
         fixtures = list(fmodel.solve(params).fixtures)
         a_involved = [
@@ -900,46 +915,53 @@ class TestClubLatestMatchDate(unittest.TestCase):
         ]
         self.assertEqual(len(a_involved), 6)  # 4 A-hosted + B1 v A1 + B1 v A2
         for sf in a_involved:
-            self.assertLessEqual(sf.date, date(2025, 2, 8))
+            self.assertLess(sf.date, date(2025, 2, 9))
 
-    def test_cutoff_also_blocks_the_club_playing_away(self) -> None:
+    def test_blackout_also_blocks_the_club_playing_away(self) -> None:
         """B1 v A1 and B1 v A2 are hosted by B, which offers May/June dates, but
-        A's cutoff still forces them onto B's early dates."""
+        A's blackout still forces them onto B's early dates."""
         params = self._params(
             b_home_dates=self._B_EARLY_AND_LATE,
-            club_latest_match_date={"A": date(2025, 2, 8)},
+            match_count_limits=[self._blackout_from(date(2025, 2, 9))],
         )
         fixtures = list(fmodel.solve(params).fixtures)
         b_hosted = [sf for sf in fixtures if sf.fixture.home_team.club == "B"]
         self.assertEqual(len(b_hosted), 2)
         for sf in b_hosted:
-            self.assertLessEqual(sf.date, date(2025, 2, 8))
+            self.assertLess(sf.date, date(2025, 2, 9))
 
-    def test_cutoff_after_a_needed_away_date_makes_it_infeasible(self) -> None:
-        """With B hosting only after A's cutoff, B1 v A1 / B1 v A2 have no
+    def test_blackout_after_a_needed_away_date_makes_it_infeasible(self) -> None:
+        """With B hosting only after A's blackout, B1 v A1 / B1 v A2 have no
         schedulable date -- required fixtures, so solve() raises."""
-        params = self._params(club_latest_match_date={"A": date(2025, 2, 8)})
+        params = self._params(
+            match_count_limits=[self._blackout_from(date(2025, 2, 9))]
+        )
         with self.assertRaisesRegex(ValueError, "no schedulable date"):
             fmodel.solve(params)
 
     def test_other_clubs_unaffected(self) -> None:
-        """A cutoff on A doesn't constrain a fixture between two non-A teams."""
-        teams = [
-            fmodel.Team(division=1, club="A", index=1),
-            fmodel.Team(division=1, club="B", index=1),
-            fmodel.Team(division=1, club="C", index=1),
-        ]
+        """A blackout on A doesn't constrain a fixture between two non-A teams."""
         params = _params(
-            teams=teams,
+            teams=[
+                fmodel.Team(division=1, club="A", index=1),
+                fmodel.Team(division=1, club="B", index=1),
+                fmodel.Team(division=1, club="C", index=1),
+            ],
             home_dates={
                 "A": [date(2025, 1, 1), date(2025, 1, 15)],
                 # Early dates keep A's away legs at B/C schedulable within its
-                # cutoff; the late dates carry the B-C fixtures.
+                # blackout; the late dates carry the B-C fixtures.
                 "B": [date(2025, 1, 8), date(2025, 6, 1)],
                 "C": [date(2025, 1, 22), date(2025, 6, 8)],
             },
             min_gap_days=7,
-            club_latest_match_date={"A": date(2025, 2, 1)},
+            match_count_limits=[
+                fmodel.RangeLimit(
+                    teams=[fmodel.Team(division=1, club="A", index=1)],
+                    match_max=fmodel.Cap(0),
+                    ranges=(fmodel.DateRange(start=date(2025, 2, 2)),),
+                )
+            ],
         )
         fixtures = list(fmodel.solve(params).fixtures)
         bc = [
@@ -951,110 +973,44 @@ class TestClubLatestMatchDate(unittest.TestCase):
         for sf in bc:
             self.assertGreater(sf.date, date(2025, 2, 1))
 
-    def test_no_cutoff_by_default(self) -> None:
+    def test_no_blackout_by_default(self) -> None:
         params = self._params()
         fixtures = list(fmodel.solve(params).fixtures)
         self.assertTrue(any(sf.date > date(2025, 4, 1) for sf in fixtures))
 
-    def test_fixed_fixture_after_cutoff_rejected(self) -> None:
+    def test_open_ended_start_blackout_keeps_new_fixtures_after_it(self) -> None:
+        """The mirror case -- a season start: a blackout open-ended at the start
+        (no earliest date) keeps every A fixture on or after its end. Four of A's
+        six dates survive, the minimum needed (see class docstring)."""
+        params = self._params(
+            match_count_limits=[
+                fmodel.RangeLimit(
+                    teams=list(self._A_TEAMS),
+                    match_max=fmodel.Cap(0),
+                    ranges=(fmodel.DateRange(end=date(2025, 1, 31)),),
+                )
+            ],
+        )
+        fixtures = list(fmodel.solve(params).fixtures)
+        self.assertTrue(fixtures)
+        for sf in fixtures:
+            if "A" in (sf.fixture.home_team.club, sf.fixture.away_team.club):
+                self.assertGreater(sf.date, date(2025, 1, 31))
+
+    def test_fixed_fixture_in_blackout_rejected(self) -> None:
+        """Unlike the old cutoffs, a matches: {max: 0} blackout does not exempt a
+        pinned fixture that falls inside it."""
         a1 = fmodel.Team(division=1, club="A", index=1)
         a2 = fmodel.Team(division=1, club="A", index=2)
         fixed = fmodel.ScheduledFixture(
             fixture=fmodel.Fixture(home_team=a1, away_team=a2), date=date(2025, 3, 8)
         )
         params = self._params(
-            fixed_fixtures=[fixed], club_latest_match_date={"A": date(2025, 2, 8)}
+            fixed_fixtures=[fixed],
+            match_count_limits=[self._blackout_from(date(2025, 2, 9))],
         )
         with self.assertRaises(ValueError):
             fmodel.solve(params)
-
-
-class TestEarliestMatchDate(unittest.TestCase):
-    """Test cases for the earliest_match_date constraint.
-
-    Division 1 here has only 3 teams (A1, A2, B1), so every pair of the 4
-    fixtures that club A hosts (A1 v A2, A2 v A1, A1 v B1, A2 v B1) shares a
-    team -- with only 3 teams to draw from, any two of those 4 fixtures must
-    involve at least one of the same two teams. That means all 4 need distinct
-    dates regardless of max_concurrent_matches, so club A's home_dates
-    below deliberately has some slack (6 dates) beyond that minimum of 4, to
-    leave room for a cutoff to remove some of them and still solve.
-    """
-
-    def _params(self, **kwargs: Any) -> fmodel.Parameters:
-        teams = [
-            fmodel.Team(division=1, club="A", index=1),
-            fmodel.Team(division=1, club="A", index=2),
-            fmodel.Team(division=1, club="B", index=1),
-        ]
-        home_dates = {
-            "A": [
-                date(2025, 1, 1),
-                date(2025, 1, 8),
-                date(2025, 2, 1),
-                date(2025, 2, 8),
-                date(2025, 3, 1),
-                date(2025, 3, 8),
-            ],
-            "B": [date(2025, 5, 1), date(2025, 6, 1)],
-        }
-        return _params(
-            teams=teams,
-            home_dates=home_dates,
-            max_concurrent_matches={
-                "A": _home_limit(2),
-                "B": _home_limit(1),
-            },
-            min_gap_days=7,
-            **kwargs,
-        )
-
-    def test_new_fixtures_respect_the_cutoff(self) -> None:
-        """A cutoff that excludes some (but not all) of club A's dates still
-        leaves enough of them (4, the minimum -- see class docstring) to solve."""
-        params = self._params(earliest_match_date=date(2025, 2, 1))
-        fixtures = list(fmodel.solve(params).fixtures)
-        self.assertTrue(fixtures)
-        for sf in fixtures:
-            self.assertGreaterEqual(sf.date, date(2025, 2, 1))
-
-    def test_cutoff_after_all_of_a_clubs_home_dates_makes_the_solve_infeasible(
-        self,
-    ) -> None:
-        """A cutoff after all of club A's home dates makes every A-hosted fixture
-        unschedulable. Those fixtures are still required, so solve() raises rather
-        than returning a schedule that silently omits them -- an already-played
-        match belongs in fixed_fixtures (which bypass earliest_match_date), not
-        inferred from a truncated result."""
-        params = self._params(earliest_match_date=date(2025, 4, 1))
-        with self.assertRaisesRegex(ValueError, "no schedulable date"):
-            fmodel.solve(params)
-
-    def test_fixed_fixture_before_cutoff_still_solves(self) -> None:
-        """Unlike latest_internal_match_date, a fixed fixture dated before the cutoff
-        is not rejected: fixed_fixtures represents matches that are already
-        committed (possibly already played), so an old date there is expected --
-        this is what lets the solver be re-run after some home dates have passed
-        without breaking on fixtures already fixed to those dates.
-        """
-        a1 = fmodel.Team(division=1, club="A", index=1)
-        a2 = fmodel.Team(division=1, club="A", index=2)
-        fixed = fmodel.ScheduledFixture(
-            fixture=fmodel.Fixture(home_team=a1, away_team=a2), date=date(2025, 1, 1)
-        )
-        params = self._params(
-            fixed_fixtures=[fixed], earliest_match_date=date(2025, 2, 1)
-        )
-        fixtures = list(fmodel.solve(params).fixtures)
-        self.assertIn(fixed, fixtures)
-
-    def test_no_cutoff_by_default(self) -> None:
-        """Without earliest_match_date, all 6 fixtures solve as normal (the tight
-        4-distinct-A-dates requirement from the class docstring, with no cutoff
-        trimming club A's 6 candidate dates, is comfortably satisfiable)."""
-        params = self._params()
-        fixtures = list(fmodel.solve(params).fixtures)
-        self.assertEqual(len(fixtures), 6)
 
 
 class TestExcludedFixtures(unittest.TestCase):

--- a/report_test.py
+++ b/report_test.py
@@ -23,7 +23,6 @@ import solve
 
 _SPEC = """
 name: "Test Season"
-earliest_match_date: 2025-01-01
 
 clubs:
   albany:
@@ -75,7 +74,10 @@ class TestReport(unittest.TestCase):
         self.spec_path = self.dir / "spec.yaml"
         self.spec_path.write_text(_SPEC)
         self.output_dir = self.dir / "out"
-        self.solution_path = solve.solve(self.spec_path, self.output_dir)
+        # _SPEC's home dates are in the past; the schedule is for reference only.
+        self.solution_path = solve.solve(
+            self.spec_path, self.output_dir, allow_past_matches=True
+        )
 
     def test_regenerates_report_from_solution_alone(self) -> None:
         index_path = report.report(self.spec_path, self.solution_path, self.output_dir)

--- a/runs/2026-27/draft1/spec.yaml
+++ b/runs/2026-27/draft1/spec.yaml
@@ -12,9 +12,11 @@ latest_internal_match_date: "2026-12-31"
 # cut-off before 14th May, but the League Secretary (Colin Mackenzie) has
 # told Andrew (2026-09) he is fine with dates up to 30th June 2027 for this
 # season. Dates through 30th June are therefore acceptable; we still prefer
-# to schedule as early as reasonable, and any club unwilling to run that
-# late can be given its own latest_match_date (as Hendon has - 2027-06-04).
-# The reserve dates below (Hendon's are commented out) follow that pattern.
+# to schedule as early as reasonable, and any club unwilling to run that late
+# can be given its own end-of-season cut-off -- a match_count_limits entry with
+# matches: {max: 0} over an open-ended date_range (as Hendon has, from
+# 2027-06-05). The reserve dates below (Hendon's are commented out) follow that
+# pattern.
 # Metropolitan's and Kings Head's late-May / June dates are in use because
 # the spec is otherwise infeasible; they now sit inside the Secretary's
 # approved window rather than needing a separate sign-off.
@@ -205,7 +207,7 @@ teams:
 # The eleventh team gives Kings Head 3 a tenth match with no room for it in
 # its Oct-May calendar, so 2027-03-25 (Maundy Thursday) - one of Colin's
 # "possibly" dates - is freed for KH3 to make the season schedulable
-# without moving Hendon's 2027-06-04 latest_match_date; see the
+# without moving Hendon's 2027-06-05 end-of-season cut-off; see the
 # club_constraints.kings-head and kings-head-3 notes.
 #
 # Every division's team list is in alphabetical (team ID) order; for
@@ -285,8 +287,6 @@ club_constraints:
         date_ranges:
           - { start_date: "2026-12-21", end_date: "2027-01-03" }
   hendon:
-    # Hendon league matches must conclude before the start of the Club Championship.
-    latest_match_date: "2027-06-04"
     # Try to condense Hendon fixtures to as few match nights as possible.
     # This limit can be increased in order to make the spec feasible.
     home_dates_used:
@@ -325,6 +325,13 @@ club_constraints:
     # This date may be required for an Albany match
     # - '2027-05-27'
     match_count_limits:
+      # Hendon league matches must conclude before the start of the Club
+      # Championship: no fixture involving a Hendon team, home or away, on or
+      # after 2027-06-05.
+      - matches:
+          max: 0
+        date_ranges:
+          - { start_date: "2027-06-05" }
       # Venue capacity: Hendon can host up to 3 team matches at once (replaces
       # the spec-wide one-a-night default).
       - override_key: venue-capacity
@@ -613,10 +620,9 @@ club_constraints:
     # date regardless since Adam's spreadsheet (2026-08-30) marks all 4 teams
     # unavailable that day for both home and away (see each team's home and away
     # blackouts below) - it's listed here for an accurate record even though
-    # every team's own unavailability already makes it unusable. (Any date this
-    # early is also excluded from new
-    # scheduling by the spec's earliest_match_date cutoff, which defaults to
-    # today when omitted, as it is here.)
+    # every team's own unavailability already makes it unusable. (This draft
+    # carries no spec-wide season-start block, so nothing else rules the date
+    # out.)
     #
     # Hammersmith run 4 teams across divisions 1-3 out of the same venue, and
     # per their availability spreadsheet (see the 'teams' sub-section below)

--- a/runs/2026-27/draft2/spec.yaml
+++ b/runs/2026-27/draft2/spec.yaml
@@ -1,10 +1,12 @@
 # yaml-language-server: $schema=../../../spec-schema.json
 name: "2026-27 Season (attempt 2)"
 
-# Don't schedule matches before this, to make sure all clubs have time to raise teams.
-# Adam Cranston from Hammersmith expressed a preference to have a match on 2026-09-10 if possible
-# but I'd rather that be negotiated bilaterally rather than risk a second draft being rejected.
-earliest_match_date: "2026-09-14"
+# "Don't schedule matches before all clubs have time to raise teams" is now the
+# club_constraints.defaults 'season-start' entry below (a matches: {max: 0}
+# block over every date up to 2026-09-13), which Hendon cancels for its pinned
+# pre-season derbies. Adam Cranston from Hammersmith expressed a preference to
+# have a match on 2026-09-10 if possible, but I'd rather that be negotiated
+# bilaterally rather than risk a second draft being rejected.
 
 # Same-club "internal" fixtures (e.g. Hendon 1 v Hendon 2) must be settled by the
 # end of the calendar year, well before the rest of the fixture list.
@@ -17,9 +19,11 @@ latest_internal_match_date: "2026-12-31"
 # cut-off before 14th May, but the League Secretary (Colin Mackenzie) has
 # told Andrew (2026-09) he is fine with dates up to 30th June 2027 for this
 # season. Dates through 30th June are therefore acceptable; we still prefer
-# to schedule as early as reasonable, and any club unwilling to run that
-# late can be given its own latest_match_date (as Hendon has - 2027-06-04).
-# The reserve dates below (Hendon's are commented out) follow that pattern.
+# to schedule as early as reasonable, and any club unwilling to run that late
+# can be given its own end-of-season cut-off -- a match_count_limits entry with
+# matches: {max: 0} over an open-ended date_range (as Hendon has, from
+# 2027-06-05). The reserve dates below (Hendon's are commented out) follow that
+# pattern.
 # Metropolitan's and Kings Head's late-May / June dates are in use because
 # the spec is otherwise infeasible; they now sit inside the Secretary's
 # approved window rather than needing a separate sign-off.
@@ -210,7 +214,7 @@ teams:
 # The eleventh team gives Kings Head 3 a tenth match with no room for it in
 # its Oct-May calendar, so 2027-03-25 (Maundy Thursday) - one of Colin's
 # "possibly" dates - is freed for KH3 to make the season schedulable
-# without moving Hendon's 2027-06-04 latest_match_date; see the
+# without moving Hendon's 2027-06-05 end-of-season cut-off; see the
 # club_constraints.kings-head and kings-head-3 notes.
 #
 # Every division's team list is in alphabetical (team ID) order; for
@@ -290,9 +294,17 @@ club_constraints:
           max: 0
         date_ranges:
           - { start_date: "2026-12-21", end_date: "2027-01-03" }
+      # Season start: no club schedules a match before all clubs have had time
+      # to raise teams - a whole-club matches: {max: 0} block over every date up
+      # to 2026-09-13. Hendon replaces 'season-start' with an earlier cut-off so
+      # its pinned pre-season derbies (2026-09-10) stand; any other club with a
+      # pre-season fixture would do the same.
+      - override_key: season-start
+        matches:
+          max: 0
+        date_ranges:
+          - { end_date: "2026-09-13" }
   hendon:
-    # Hendon league matches must conclude before the start of the Club Championship.
-    latest_match_date: "2027-06-04"
     # Try to condense Hendon fixtures to as few match nights as possible.
     # This limit can be increased in order to make the spec feasible.
     home_dates_used:
@@ -331,6 +343,22 @@ club_constraints:
     # This date may be required for an Albany match
     # - '2027-05-27'
     match_count_limits:
+      # Season start: Hendon replaces the spec-wide 'season-start' block with an
+      # earlier cut-off, so its pinned pre-season derbies (Hendon 1 v Hendon 2
+      # and Hendon 4 v Hendon 5, both 2026-09-10) stand while every earlier date
+      # stays blocked for Hendon too.
+      - override_key: season-start
+        matches:
+          max: 0
+        date_ranges:
+          - { end_date: "2026-09-09" }
+      # Hendon league matches must conclude before the start of the Club
+      # Championship: no fixture involving a Hendon team, home or away, on or
+      # after 2027-06-05.
+      - matches:
+          max: 0
+        date_ranges:
+          - { start_date: "2027-06-05" }
       # Venue capacity: Hendon can host up to 3 team matches at once (replaces
       # the spec-wide one-a-night default).
       - override_key: venue-capacity
@@ -638,10 +666,10 @@ club_constraints:
     # date regardless since Adam's spreadsheet (2026-08-30) marks all 4 teams
     # unavailable that day for both home and away (see each team's home and away
     # blackouts below) - it's listed here for an accurate record even though
-    # every team's own unavailability already
-    # makes it unusable. (Any date this early is also excluded from new
-    # scheduling by the spec's earliest_match_date cutoff, which defaults to
-    # today when omitted, as it is here.)
+    # every team's own unavailability already makes it unusable. (Any date this
+    # early is also excluded from scheduling by the spec-wide 'season-start'
+    # block in club_constraints.defaults, which bars every match up to
+    # 2026-09-13; Hammersmith, unlike Hendon, does not override it.)
     #
     # Hammersmith run 4 teams across divisions 1-3 out of the same venue, and
     # per their availability spreadsheet (see the 'teams' sub-section below)

--- a/runs/2026-27/draft3/spec.yaml
+++ b/runs/2026-27/draft3/spec.yaml
@@ -7,8 +7,10 @@ description: >
   does not reflect any changes subsequently agreed between clubs. For up-to-date
   match dates, please refer to the ECF League Management System.
 
-# Don't schedule matches before the Fixtures Meeting.
-earliest_match_date: "2026-09-15"
+# "Don't schedule matches before the Fixtures Meeting" is now the
+# club_constraints.defaults 'season-start' entry below (a matches: {max: 0}
+# block over every date up to 2026-09-14), which Hendon moves earlier to admit
+# its pinned pre-season derbies.
 
 # Same-club "internal" fixtures (e.g. Hendon 1 v Hendon 2) must be settled by the
 # end of the calendar year, well before the rest of the fixture list.
@@ -21,9 +23,11 @@ latest_internal_match_date: "2026-12-31"
 # cut-off before 14th May, but the League Secretary (Colin Mackenzie) has
 # told Andrew (2026-09) he is fine with dates up to 30th June 2027 for this
 # season. Dates through 30th June are therefore acceptable; we still prefer
-# to schedule as early as reasonable, and any club unwilling to run that
-# late can be given its own latest_match_date (as Hendon has - 2027-06-04).
-# The reserve dates below (Hendon's are commented out) follow that pattern.
+# to schedule as early as reasonable, and any club unwilling to run that late
+# can be given its own end-of-season cut-off -- a match_count_limits entry with
+# matches: {max: 0} over an open-ended date_range (as Hendon has, from
+# 2027-06-05). The reserve dates below (Hendon's are commented out) follow that
+# pattern.
 # Metropolitan's and Kings Head's late-May / June dates are in use because
 # the spec is otherwise infeasible; they now sit inside the Secretary's
 # approved window rather than needing a separate sign-off.
@@ -214,7 +218,7 @@ teams:
 # The eleventh team gives Kings Head 3 a tenth match with no room for it in
 # its Oct-May calendar, so 2027-03-25 (Maundy Thursday) - one of Colin's
 # "possibly" dates - is freed for KH3 to make the season schedulable
-# without moving Hendon's 2027-06-04 latest_match_date; see the
+# without moving Hendon's 2027-06-05 end-of-season cut-off; see the
 # club_constraints.kings-head and kings-head-3 notes.
 #
 # Every division's team list is in alphabetical (team ID) order; for
@@ -294,9 +298,17 @@ club_constraints:
           max: 0
         date_ranges:
           - { start_date: "2026-12-21", end_date: "2027-01-03" }
+      # Season start: no club schedules a match before the Fixtures Meeting - a
+      # whole-club matches: {max: 0} block over every date up to 2026-09-14 (the
+      # day before the meeting). Hendon replaces 'season-start' with an earlier
+      # cut-off so its pinned pre-season derbies (2026-09-10) stand; any other
+      # club with a pre-season fixture would do the same.
+      - override_key: season-start
+        matches:
+          max: 0
+        date_ranges:
+          - { end_date: "2026-09-14" }
   hendon:
-    # Hendon league matches must conclude before the start of the Club Championship.
-    latest_match_date: "2027-06-04"
     # Try to condense Hendon fixtures to as few match nights as possible.
     # This limit can be increased in order to make the spec feasible.
     home_dates_used:
@@ -336,6 +348,22 @@ club_constraints:
     # This date may be required for an Albany match
     # - '2027-05-27'
     match_count_limits:
+      # Season start: Hendon replaces the spec-wide 'season-start' block with an
+      # earlier cut-off, so its pinned pre-season derbies (Hendon 1 v Hendon 2
+      # and Hendon 4 v Hendon 5, both 2026-09-10) stand while every earlier date
+      # stays blocked for Hendon too.
+      - override_key: season-start
+        matches:
+          max: 0
+        date_ranges:
+          - { end_date: "2026-09-09" }
+      # Hendon league matches must conclude before the start of the Club
+      # Championship: no fixture involving a Hendon team, home or away, on or
+      # after 2027-06-05.
+      - matches:
+          max: 0
+        date_ranges:
+          - { start_date: "2027-06-05" }
       # Venue capacity: Hendon can host up to 3 team matches at once (replaces
       # the spec-wide one-a-night default).
       - override_key: venue-capacity
@@ -680,10 +708,10 @@ club_constraints:
     # date regardless since Adam's spreadsheet (2026-08-30) marks all 4 teams
     # unavailable that day for both home and away (see each team's home and away
     # blackouts below) - it's listed here for an accurate record even though
-    # every team's own unavailability already
-    # makes it unusable. (Any date this early is also excluded from new
-    # scheduling by the spec's earliest_match_date cutoff, which defaults to
-    # today when omitted, as it is here.)
+    # every team's own unavailability already makes it unusable. (Any date this
+    # early is also excluded from scheduling by the spec-wide 'season-start'
+    # block in club_constraints.defaults, which bars every match up to
+    # 2026-09-14; Hammersmith, unlike Hendon, does not override it.)
     #
     # Hammersmith run 4 teams across divisions 1-3 out of the same venue, and
     # per their availability spreadsheet (see the 'teams' sub-section below)

--- a/runs/example/spec.yaml
+++ b/runs/example/spec.yaml
@@ -1,8 +1,8 @@
 # yaml-language-server: $schema=../../spec-schema.json
 name: "2025-26 Season"
-# This is a static reference example, not a live season, so its whole (long past)
-# season window is exempted from the default (today) earliest_match_date cutoff.
-earliest_match_date: "2025-01-01"
+# This is a static reference example, not a live season: it carries no
+# season-start block, so its (long past) home dates schedule freely. Re-solving
+# it needs "solve.py --allow-past-matches", since the schedule lands in the past.
 clubs:
   albany:
     name: Albany

--- a/solve.py
+++ b/solve.py
@@ -15,12 +15,18 @@
 """Solve a YAML fixture specification and write its solution to a solution.yaml file.
 
 Usage:
-    python solve.py <spec.yaml> [output_dir]
+    python solve.py [--allow-past-matches] <spec.yaml> [output_dir]
 
 <output_dir> defaults to the spec file's own directory, so the usual layout keeps
 spec.yaml and solution.yaml side by side in the same run folder (e.g.
 runs/2025-26-season/). Re-running this overwrites the previous solution.yaml in
 place.
+
+By default the solve aborts without writing anything if any match in the solved
+schedule falls before today -- the spec no longer carries an implicit "no play in
+the past" cutoff, so this guards against re-solving a spec whose home dates have
+partly passed. Pass --allow-past-matches to write the solution anyway (e.g.
+re-solving a past season for reference).
 
 report.py can then (re)generate the HTML report from solution.yaml -- without
 needing to re-solve -- any time the report format changes.
@@ -30,6 +36,9 @@ from __future__ import annotations
 
 import argparse
 import logging
+import sys
+from collections.abc import Collection
+from datetime import date
 from pathlib import Path
 
 import fixturesolution
@@ -37,14 +46,54 @@ import fixturespec
 import fmodel
 
 
-def solve(spec_path: Path, output_dir: Path) -> Path:
+class PastMatchError(Exception):
+    """Raised when a solved schedule contains a match before today and
+    --allow-past-matches was not given."""
+
+
+def _reject_past_matches(fixtures: Collection[fmodel.ScheduledFixture]) -> None:
+    """Raise PastMatchError if any scheduled fixture falls before today. Whether a
+    fixture was pinned via fixed_fixtures or newly scheduled makes no difference:
+    a solution.yaml is only ever written for a season still to be played."""
+    today = date.today()
+    past = sorted(
+        (sf for sf in fixtures if sf.date < today),
+        key=lambda sf: (
+            sf.date,
+            sf.fixture.home_team.name,
+            sf.fixture.away_team.name,
+        ),
+    )
+    if not past:
+        return
+    shown = ", ".join(
+        f"{sf.fixture.home_team.name} vs {sf.fixture.away_team.name} on "
+        f"{sf.date.isoformat()}"
+        for sf in past[:12]
+    )
+    if len(past) > 12:
+        shown += f", ... (+{len(past) - 12} more)"
+    raise PastMatchError(
+        f"{len(past)} scheduled match(es) fall before today "
+        f"({today.isoformat()}): {shown}. Re-run with --allow-past-matches to "
+        "write the solution anyway (e.g. re-solving a past season for reference)."
+    )
+
+
+def solve(
+    spec_path: Path, output_dir: Path, *, allow_past_matches: bool = False
+) -> Path:
     """Solve the given spec and write its solution.yaml into output_dir. Returns the
     path to the solution file.
+
+    Raises PastMatchError (before writing anything) if the solved schedule
+    contains a match before today and allow_past_matches is False.
     """
     spec = fixturespec.load_spec(spec_path)
     team_ids = fixturespec.load_team_ids(spec_path)
-    parameters = spec.parameters
-    result = fmodel.solve(parameters)
+    result = fmodel.solve(spec.parameters)
+    if not allow_past_matches:
+        _reject_past_matches(result.fixtures)
     output_dir.mkdir(parents=True, exist_ok=True)
     solution_path = output_dir / "solution.yaml"
     fixturesolution.save_solution(result, team_ids, solution_path)
@@ -62,12 +111,23 @@ def main() -> None:
         nargs="?",
         help="Directory to write solution.yaml into (default: the spec file's own directory)",
     )
+    parser.add_argument(
+        "--allow-past-matches",
+        action="store_true",
+        help="Write the solution even if it schedules a match before today",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
 
     output_dir = args.output_dir if args.output_dir is not None else args.spec.parent
-    solution_path = solve(args.spec, output_dir)
+    try:
+        solution_path = solve(
+            args.spec, output_dir, allow_past_matches=args.allow_past_matches
+        )
+    except PastMatchError as e:
+        print(f"Not writing a solution: {e}", file=sys.stderr)
+        raise SystemExit(1) from e
 
     print(f"Wrote solution to {solution_path}")
 

--- a/solve_test.py
+++ b/solve_test.py
@@ -16,7 +16,7 @@
 
 import tempfile
 import unittest
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 
 import fixturesolution
@@ -24,9 +24,13 @@ import fixturespec
 import fmodel
 import solve
 
-_MINIMAL_SPEC = """
-earliest_match_date: 2025-01-01
+# Home dates comfortably in the future, so the base tests take solve()'s normal
+# path (its past-match guard, tested separately below, never fires).
+_D1 = (date.today() + timedelta(days=400)).isoformat()
+_D2 = (date.today() + timedelta(days=428)).isoformat()
+_D3 = (date.today() + timedelta(days=414)).isoformat()
 
+_MINIMAL_SPEC = f"""
 clubs:
   albany:
     name: Albany
@@ -62,10 +66,20 @@ club_constraints:
         matches:
           max: 1
   albany:
-    home_dates: [2025-09-01, 2025-09-29]
+    home_dates: [{_D1}, {_D2}]
   hackney:
-    home_dates: [2025-09-15]
+    home_dates: [{_D3}]
 """
+
+_TEAM_OBJS = [
+    fmodel.Team(division=1, club="albany", index=1),
+    fmodel.Team(division=1, club="hackney", index=1),
+]
+_TEAM_IDS = {"albany-1": ("albany", 1), "hackney-1": ("hackney", 1)}
+
+
+def _load(solution_path: Path) -> fmodel.SolveResult:
+    return fixturesolution.load_solution(solution_path, _TEAM_OBJS, _TEAM_IDS)
 
 
 class TestSolve(unittest.TestCase):
@@ -84,14 +98,7 @@ class TestSolve(unittest.TestCase):
         self.assertEqual(solution_path, output_dir / "solution.yaml")
         self.assertTrue(solution_path.exists())
 
-        loaded = fixturesolution.load_solution(
-            solution_path,
-            [
-                fmodel.Team(division=1, club="albany", index=1),
-                fmodel.Team(division=1, club="hackney", index=1),
-            ],
-            {"albany-1": ("albany", 1), "hackney-1": ("hackney", 1)},
-        )
+        loaded = _load(solution_path)
         # Albany v Hackney and Hackney v Albany
         self.assertEqual(len(loaded.fixtures), 2)
         self.assertIn("home: albany-1", solution_path.read_text())
@@ -105,14 +112,7 @@ class TestSolve(unittest.TestCase):
         self.assertIn("satisfaction model", contents)
         self.assertIn("CpSolverResponse summary", contents)
 
-        loaded = fixturesolution.load_solution(
-            solution_path,
-            [
-                fmodel.Team(division=1, club="albany", index=1),
-                fmodel.Team(division=1, club="hackney", index=1),
-            ],
-            {"albany-1": ("albany", 1), "hackney-1": ("hackney", 1)},
-        )
+        loaded = _load(solution_path)
         self.assertIn("#Variables", loaded.model_stats)
         self.assertIn("status:", loaded.solve_stats)
 
@@ -124,14 +124,7 @@ class TestSolve(unittest.TestCase):
         self.assertTrue(expected.startswith("sha256:"))
         self.assertIn(f"spec_checksum: {expected}", solution_path.read_text())
 
-        loaded = fixturesolution.load_solution(
-            solution_path,
-            [
-                fmodel.Team(division=1, club="albany", index=1),
-                fmodel.Team(division=1, club="hackney", index=1),
-            ],
-            {"albany-1": ("albany", 1), "hackney-1": ("hackney", 1)},
-        )
+        loaded = _load(solution_path)
         self.assertEqual(loaded.spec_checksum, expected)
 
     def test_creates_output_dir(self) -> None:
@@ -148,26 +141,76 @@ class TestSolve(unittest.TestCase):
 
         self.assertIn("fixtures:", (output_dir / "solution.yaml").read_text())
 
-    def test_earliest_match_date_excludes_earlier_home_dates(self) -> None:
-        """Albany has two candidate home dates (2025-09-01 and 2025-09-29); a cutoff
-        that excludes the earlier one should still solve, using the later one."""
-        self.spec_path.write_text(
-            _MINIMAL_SPEC.replace(
-                "earliest_match_date: 2025-01-01", "earliest_match_date: 2025-09-02"
-            )
+    def test_season_start_blackout_excludes_earlier_home_dates(self) -> None:
+        """A club_constraints.defaults 'season-start' blackout (matches: {max: 0}
+        over an open-ended past date_range) keeps every scheduled match after it,
+        using Albany's later home date rather than the excluded earlier one."""
+        cutoff = date.today() + timedelta(days=410)
+        spec_text = _MINIMAL_SPEC.replace(
+            "      - override_key: venue-capacity\n",
+            "      - override_key: season-start\n"
+            "        matches: {max: 0}\n"
+            "        date_ranges:\n"
+            f"          - {{end_date: {cutoff.isoformat()}}}\n"
+            "      - override_key: venue-capacity\n",
         )
+        self.spec_path.write_text(spec_text)
         output_dir = self.dir / "out"
         solution_path = solve.solve(self.spec_path, output_dir)
-        loaded = fixturesolution.load_solution(
-            solution_path,
-            [
-                fmodel.Team(division=1, club="albany", index=1),
-                fmodel.Team(division=1, club="hackney", index=1),
-            ],
-            {"albany-1": ("albany", 1), "hackney-1": ("hackney", 1)},
-        )
+        loaded = _load(solution_path)
         for sf in loaded.fixtures:
-            self.assertGreaterEqual(sf.date, date(2025, 9, 2))
+            self.assertGreater(sf.date, cutoff)
+
+
+class TestPastMatchGuard(unittest.TestCase):
+    """solve() aborts, before writing anything, if the solved schedule contains
+    any match before today -- unless allow_past_matches is set."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.dir = Path(self._tmpdir.name)
+        self.spec_path = self.dir / "spec.yaml"
+        # Every home date is in the past, so the whole schedule lands before today.
+        past = (
+            _MINIMAL_SPEC.replace(_D1, "2020-01-07")
+            .replace(_D2, "2020-02-04")
+            .replace(_D3, "2020-01-21")
+        )
+        self.spec_path.write_text(past)
+
+    def test_past_matches_raise_and_write_nothing(self) -> None:
+        output_dir = self.dir / "out"
+        with self.assertRaises(solve.PastMatchError):
+            solve.solve(self.spec_path, output_dir)
+        self.assertFalse((output_dir / "solution.yaml").exists())
+
+    def test_allow_past_matches_writes_the_solution(self) -> None:
+        output_dir = self.dir / "out"
+        solution_path = solve.solve(self.spec_path, output_dir, allow_past_matches=True)
+        self.assertEqual(len(_load(solution_path).fixtures), 2)
+
+    def test_pinned_past_fixtures_also_raise(self) -> None:
+        """A past date trips the guard even when it comes straight from
+        fixed_fixtures: the check is purely on the solved ScheduledFixtures."""
+        spec_text = self.spec_path.read_text() + (
+            "fixed_fixtures:\n"
+            "  - home: albany-1\n"
+            "    away: hackney-1\n"
+            "    date: 2020-01-07\n"
+            "  - home: hackney-1\n"
+            "    away: albany-1\n"
+            "    date: 2020-01-21\n"
+        )
+        self.spec_path.write_text(spec_text)
+        output_dir = self.dir / "out"
+        with self.assertRaises(solve.PastMatchError):
+            solve.solve(self.spec_path, output_dir)
+        self.assertFalse((output_dir / "solution.yaml").exists())
+        # ...but the flag still lets it through.
+        solution_path = solve.solve(self.spec_path, output_dir, allow_past_matches=True)
+        self.assertEqual(len(_load(solution_path).fixtures), 2)
 
 
 if __name__ == "__main__":

--- a/spec-schema.json
+++ b/spec-schema.json
@@ -26,10 +26,6 @@
       "$ref": "#/$defs/date",
       "description": "Latest date allowed for a fixture between two teams of the same club (e.g. Hendon 1 v Hendon 2) -- useful for requiring 'derby' matches to be settled earlier in the season than the rest of the fixture list. Has no effect on fixtures between teams from different clubs. If omitted, no such cutoff is applied. Any 'fixed_fixtures' entry between two teams of the same club must not be dated after it."
     },
-    "earliest_match_date": {
-      "$ref": "#/$defs/date",
-      "description": "Excludes candidate dates before this one from newly scheduled fixtures -- e.g. so re-running the solver after some home dates have already passed doesn't place a fixture in the past. If omitted, defaults to today. A 'fixed_fixtures' entry dated before this cutoff is not rejected: fixed_fixtures records matches that are already committed (possibly already played), so an old date there is expected. If this date is in the past, a warning is logged (but solving still proceeds) -- pass a date on or before the spec's earliest home date to disable the cutoff entirely, e.g. for an old spec being re-solved for reference."
-    },
     "clubs": {
       "type": "object",
       "description": "Every club in the season, keyed by club ID (a stable key referenced from teams, club_constraints, fixed_fixtures and exclude_fixtures).",
@@ -72,7 +68,7 @@
     },
     "club_constraints": {
       "type": "object",
-      "description": "Every constraint that can vary by club -- home_dates, home_dates_used, latest_match_date and match_count_limits -- keyed by that club's own ID, alongside an optional 'defaults' entry. Dates a club (or one of its teams) can't play away, and dates a team can't host, are match_count_limits entries: 'matches: {max: 0}' with 'venue_scope: away' (or 'home'), a 'dates' list, and 'teams' where it isn't club-wide.",
+      "description": "Every constraint that can vary by club -- home_dates, home_dates_used and match_count_limits -- keyed by that club's own ID, alongside an optional 'defaults' entry. Dates a club (or one of its teams) can't play away, and dates a team can't host, are match_count_limits entries: 'matches: {max: 0}' with 'venue_scope: away' (or 'home'), a 'dates' list, and 'teams' where it isn't club-wide. A club whose season starts late or ends early uses the same 'matches: {max: 0}' shape with an open-ended 'date_ranges' ({start_date: ...} or {end_date: ...}); the spec-wide 'no play before the season starts' block is that shape as a 'defaults' entry, which a club can move or cancel through its 'override_key'.",
       "additionalProperties": { "$ref": "#/$defs/club_constraints_entry" },
       "properties": {
         "defaults": {
@@ -206,10 +202,6 @@
             }
           }
         },
-        "latest_match_date": {
-          "$ref": "#/$defs/date",
-          "description": "Latest date any fixture involving one of this club's teams -- home or away -- may be scheduled. Useful when a club's venue or players stop being available partway through the common season window (e.g. a hall booking that ends earlier than most). Omit for no cutoff. Distinct from the spec-wide 'latest_internal_match_date', which only limits same-club derby fixtures; this limits every match the club plays. Any 'fixed_fixtures' entry involving the club must not be dated after it."
-        },
         "match_count_limits": {
           "type": "array",
           "description": "The sole match-count constraint mechanism: each entry bounds how many matches involving a set of this club's teams may fall within a rolling window of consecutive days -- or, when the entry sets 'date_ranges' (or its 'dates' sugar), within each of a few explicit calendar ranges -- from above ('max'), below ('min'), or both. Covers a per-team weekly gap ('apply_per: each_team', 'matches: {max: 1}', 'time_window_days: 7'), a venue's concurrent-match capacity ('apply_per: across_teams', 'venue_scope: home', typically paired with 'playing_teams' to also cap distinct teams playing -- see 'match_count_limit_fields/playing_teams'), keeping adjacent-division teams apart ('teams: [...]', 'matches: {max: 1}'), a floor on activity ('matches: {min: 1}', e.g. at least one match in a congress fortnight), holding a club's load down over a named holiday week ('date_ranges: [...]', 'matches: {max: 1}'), and barring play outright on specific dates -- the dates a team can't host ('venue_scope: home', 'matches: {max: 0}', 'dates: [...]') or a club's teams can't travel ('venue_scope: away', 'matches: {max: 0}', 'dates: [...]'). Additive, with as many entries as needed; combined with any inherited from club_constraints.defaults -- an entry with an 'override_key' replaces the like-keyed default for this club instead.",
@@ -309,7 +301,7 @@
       "date_ranges": {
         "type": "array",
         "minItems": 1,
-        "description": "Restricts this rule to one or more explicit, inclusive calendar ranges instead of every rolling 'time_window_days' window: the bounds ('matches' and/or 'playing_teams') then apply to the counted matches whose date falls within each listed range, each range enforced independently. Use for a limit tied to specific weeks -- a school-holiday week, a congress fortnight -- that a rolling window cannot target. Allowed on club and 'defaults' entries alike; not combinable with 'time_window_days' or any '*_overrides' sub-key (all tied to a single date), nor (on a club entry) with 'override_key'. With 'date_ranges' set, 'matches.max' must be an integer >= 0 ('matches: {max: 0}' bars every counted match in the range; a whole-club 'defaults' entry with 'matches: {max: 0}' is the spec-wide 'nobody plays these dates' block).",
+        "description": "Restricts this rule to one or more explicit, inclusive calendar ranges instead of every rolling 'time_window_days' window: the bounds ('matches' and/or 'playing_teams') then apply to the counted matches whose date falls within each listed range, each range enforced independently. Use for a limit tied to specific weeks -- a school-holiday week, a congress fortnight -- that a rolling window cannot target. A range may be open-ended on one side (omit 'start_date' or 'end_date', not both): an open-ended 'matches: {max: 0}' range is how a season start ({end_date: <last pre-season date>}) or a club's early end of season ({start_date: <first unavailable date>}) is expressed. Allowed on club and 'defaults' entries alike; not combinable with 'time_window_days' or any '*_overrides' sub-key (all tied to a single date). A club entry may carry an 'override_key' alongside 'date_ranges' -- the club then replaces the like-keyed default with this ranged rule (e.g. starting its season later than the spec-wide 'season-start' block). With 'date_ranges' set, 'matches.max' must be an integer >= 0 ('matches: {max: 0}' bars every counted match in the range; a whole-club 'defaults' entry with 'matches: {max: 0}' is the spec-wide 'nobody plays these dates' block).",
         "items": {
           "type": "object",
           "additionalProperties": false,
@@ -342,7 +334,7 @@
       },
       "override_key": {
         "type": "string",
-        "description": "Names a club_constraints.defaults.match_count_limits entry (via its own 'override_key'). On a club entry, replaces that default for the club. Required and unique on every defaults entry; on a club entry it can't be combined with 'teams'."
+        "description": "Names a club_constraints.defaults.match_count_limits entry (via its own 'override_key'). On a club entry, replaces that default for the club -- the replacement may be a rolling rule, a 'date_ranges' rule, or (with nothing else on the entry) a bare cancel. Required and unique on every defaults entry; on a club entry it can't be combined with 'teams'."
       }
     },
     "match_count_limit_entry": {
@@ -384,7 +376,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["override_key"],
-      "description": "A club_constraints.defaults.match_count_limits entry: like a per-club match_count_limits entry but without 'teams' (defaults apply to every team of every club) and with a required, list-unique 'override_key'. A club's own entry naming that 'override_key' replaces this one for the club wholesale. A 'matches: {max: 0}' entry with 'date_ranges' (or its 'dates' sugar) is the spec-wide way to say no club plays on those dates (a club can opt back in by overriding the key). Needs a 'matches' and/or 'playing_teams' mapping carrying an actual bound -- either alone is fine -- unless 'date_ranges'/'dates', or a bare cancelling entry (only 'override_key'), is what's meant.",
+      "description": "A club_constraints.defaults.match_count_limits entry: like a per-club match_count_limits entry but without 'teams' (defaults apply to every team of every club) and with a required, list-unique 'override_key'. A club's own entry naming that 'override_key' replaces this one for the club wholesale. A 'matches: {max: 0}' entry with 'date_ranges' (or its 'dates' sugar) is the spec-wide way to say no club plays on those dates (a club can opt back in by overriding the key); an open-ended '{end_date: ...}' range is in turn the spec-wide 'no play before the season starts' block, which a club with pre-season fixed_fixtures moves earlier (or cancels) through its 'override_key'. Needs a 'matches' and/or 'playing_teams' mapping carrying an actual bound -- either alone is fine -- unless 'date_ranges'/'dates', or a bare cancelling entry (only 'override_key'), is what's meant.",
       "properties": {
         "matches": { "$ref": "#/$defs/match_count_limit_fields/matches" },
         "playing_teams": {

--- a/spec_schema_test.py
+++ b/spec_schema_test.py
@@ -96,7 +96,6 @@ club_constraints:
 
   albany:
     home_dates: [2025-09-01, 2025-09-15, 2025-09-29]
-    latest_match_date: 2026-04-30
     match_count_limits:
       - override_key: weekly-gap
         apply_per: each_team
@@ -111,6 +110,11 @@ club_constraints:
         matches:
           max: 0
         dates: [2025-12-25]
+      # End of season: no Albany fixture, home or away, from 2026-05-01 on.
+      - matches:
+          max: 0
+        date_ranges:
+          - start_date: 2026-05-01
 
   hackney:
     home_dates: [2025-09-08, 2025-09-22]

--- a/validate_test.py
+++ b/validate_test.py
@@ -131,8 +131,18 @@ class TestCheckSchedule(unittest.TestCase):
         )
         self.assertEqual(problems, [f"a 1 vs b 1 on 2025-09-01 {_NOT_A_SLOT}"])
 
-    def test_fixture_before_earliest_match_date_is_not_a_slot(self) -> None:
-        params = _params(earliest_match_date=_D2)
+    def test_fixture_before_season_start_blackout_is_not_a_slot(self) -> None:
+        # A season-start block: matches: {max: 0} over a date_range open-ended at
+        # the start, the successor to the old earliest_match_date cutoff.
+        params = _params(
+            match_count_limits=[
+                fmodel.RangeLimit(
+                    teams=[_A1, _B1],
+                    match_max=fmodel.Cap(0),
+                    ranges=(fmodel.DateRange(end=date(2025, 9, 7)),),
+                )
+            ]
+        )
         problems = fmodel.check_schedule(params, _VALID)
         self.assertEqual(problems, [f"a 1 vs b 1 on 2025-09-01 {_NOT_A_SLOT}"])
 
@@ -205,7 +215,6 @@ class TestMatchesExpectation(unittest.TestCase):
 
 _SPEC = """
 name: "Validate Test Season"
-earliest_match_date: 2025-01-01
 
 clubs:
   albany:
@@ -256,7 +265,10 @@ class TestValidateCli(unittest.TestCase):
         self.dir = Path(self._tmpdir.name)
         self.spec_path = self.dir / "spec.yaml"
         self.spec_path.write_text(_SPEC)
-        self.solution_path = solve.solve(self.spec_path, self.dir)
+        # _SPEC's home dates are in the past; the schedule is for reference only.
+        self.solution_path = solve.solve(
+            self.spec_path, self.dir, allow_past_matches=True
+        )
 
     def test_freshly_solved_solution_validates(self) -> None:
         report = validate.validate(self.spec_path, self.solution_path)


### PR DESCRIPTION
Both date-cutoff mechanisms predated match_count_limits and duplicated a strict subset of what a matches: {max: 0} entry over an open-ended date_ranges already expresses (start-open for "earliest", end-open for "latest"). Following the #102 precedent: breaking schema change, no back-compat shim, all four committed specs migrated in place.

Removed
  - top-level earliest_match_date (and its implicit "default to today" behaviour and past-date warning)
  - per-club club_constraints[*].latest_match_date
  - fmodel.Parameters.earliest_match_date / club_latest_match_date / latest_match_date_for(); the two candidate-pruning blocks in _build_model (latest_internal_match_date stays)
  - fixturespec's earliest/latest parsing and the fixed_fixtures-past- cutoff validation loop

solve.py past-match guard
  With no implicit "no play in the past" cutoff, solve() now solves the
  spec and then -- unless --allow-past-matches is passed -- scans the
  solved ScheduledFixtures and aborts (writing nothing, exit 1) if any
  falls before today. The check is purely on the schedule: a pinned
  fixed_fixtures date in the past trips it too, since a solution.yaml is
  only ever written for a season still to be played.

override_key + date_ranges now allowed on a club entry
  #81 banned this on the assumption an override_key only ever retargets a
  rolling default; _resolve_match_count_limits actually resolves such an
  entry to a RangeLimit fine. Lifting it lets a club replace the
  spec-wide "season-start" block with its own earlier cutoff in one
  entry. The override_key + teams ban stays.

Spec migration
  - runs/example: drop earliest_match_date (it only disabled the cutoff); re-solving now needs solve.py --allow-past-matches
  - draft{1,2,3}: Hendon's latest_match_date -> an additive matches: {max: 0} entry from 2027-06-05
  - draft{2,3}: earliest_match_date -> a club_constraints.defaults 'season-start' entry; Hendon replaces it with an earlier cutoff (end_date 2026-09-09) so its pinned 2026-09-10 pre-season derbies stand while every other club keeps the spec-wide block Each run's committed solution.yaml still validates against its migrated spec (the pre-existing spec_checksum note aside).


Claude-Session: https://claude.ai/code/session_01SNFgXkXhJf26HUKWtKk33D